### PR TITLE
Add first 10 code examples across SMS, Voice, AI, SIP, and IoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ cp .env.example .env
 make setup && make run
 ```
 
+> Full API reference at [developers.telnyx.com](https://developers.telnyx.com)
+
 Every example supports three deployment options: **Local** (`make setup && make run`), **Docker** (`make docker-build && make docker-run`), and **Manual** (step-by-step instructions in each README).
 
 ---
 
 ## Voice AI
 
-Build voice applications with Telnyx Call Control — IVR menus, call recording, conferencing, WebRTC, and AI-powered call routing.
+Build voice applications with [Telnyx Voice AI](https://telnyx.com/products/voice-ai-agents) — IVR menus, call recording, conferencing, WebRTC, and AI-powered call routing.
 
 | Example | Language | Description |
 |---------|----------|-------------|
@@ -47,7 +49,7 @@ Build voice applications with Telnyx Call Control — IVR menus, call recording,
 
 ## SMS & MMS
 
-Send and receive text messages, build autoresponders, implement 2FA, and manage bulk messaging campaigns.
+Send and receive text messages with the [Telnyx SMS API](https://telnyx.com/products/sms-api) — build autoresponders, implement 2FA, and manage bulk messaging campaigns.
 
 | Example | Language | Description |
 |---------|----------|-------------|
@@ -66,7 +68,7 @@ Send and receive text messages, build autoresponders, implement 2FA, and manage 
 
 ## AI Assistants
 
-Create, manage, and chat with Telnyx AI Assistants — LLM-powered agents for voice and messaging automation.
+Create, manage, and chat with [Telnyx AI Assistants](https://telnyx.com/ai-assistants) — LLM-powered agents for voice and messaging automation.
 
 | Example | Language | Description |
 |---------|----------|-------------|
@@ -81,7 +83,7 @@ Create, manage, and chat with Telnyx AI Assistants — LLM-powered agents for vo
 
 ## SIP Trunking
 
-Connect your PBX or SBC to Telnyx SIP infrastructure — trunk setup, inbound routing, failover, and codec configuration.
+Connect your PBX or SBC to [Telnyx SIP Trunking](https://telnyx.com/products/sip-trunks) — trunk setup, inbound routing, failover, and codec configuration.
 
 | Example | Language | Description |
 |---------|----------|-------------|
@@ -95,7 +97,7 @@ Connect your PBX or SBC to Telnyx SIP infrastructure — trunk setup, inbound ro
 
 ## IoT & SIM Management
 
-Activate SIM cards, monitor data usage, provision eSIMs, and track device locations with the Telnyx IoT platform.
+Activate SIM cards, monitor data usage, provision eSIMs, and track device locations with the [Telnyx IoT platform](https://telnyx.com/products/iot-sim-card).
 
 | Example | Language | Description |
 |---------|----------|-------------|
@@ -113,11 +115,11 @@ Activate SIM cards, monitor data usage, provision eSIMs, and track device locati
 
 Telnyx is an **AI Communications Infrastructure** platform that provides a single, integrated API for:
 
-- **Voice AI** — Programmable voice with Call Control, IVR, recording, conferencing, and WebRTC.
-- **SMS & MMS** — Send and receive messages globally with delivery receipts and webhook events.
-- **SIP Trunking** — Connect your existing PBX with elastic SIP trunks, failover routing, and codec control.
-- **AI Assistants** — Deploy LLM-powered voice and messaging agents with built-in telephony.
-- **IoT & SIM** — Global IoT connectivity with SIM management, eSIM provisioning, and data monitoring.
+- **[Voice AI](https://telnyx.com/products/voice-ai-agents)** — Programmable voice with Call Control, IVR, recording, conferencing, and WebRTC.
+- **[SMS & MMS](https://telnyx.com/products/sms-api)** — Send and receive messages globally with delivery receipts and webhook events.
+- **[SIP Trunking](https://telnyx.com/products/sip-trunks)** — Connect your existing PBX with elastic SIP trunks, failover routing, and codec control.
+- **[AI Assistants](https://telnyx.com/ai-assistants)** — Deploy LLM-powered voice and messaging agents with built-in telephony.
+- **[IoT & SIM](https://telnyx.com/products/iot-sim-card)** — Global IoT connectivity with SIM management, eSIM provisioning, and data monitoring.
 
 Unlike stitching together multiple vendors into a Frankenstack, Telnyx gives you one platform, one API key, and one bill. Calls and messages traverse the Telnyx-owned private IP network for lower latency and higher reliability.
 

--- a/activate-sim-card-python/.env.example
+++ b/activate-sim-card-python/.env.example
@@ -1,0 +1,3 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here

--- a/activate-sim-card-python/.env.example
+++ b/activate-sim-card-python/.env.example
@@ -1,3 +1,4 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here

--- a/activate-sim-card-python/Dockerfile
+++ b/activate-sim-card-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/activate-sim-card-python/Dockerfile
+++ b/activate-sim-card-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/activate-sim-card-python/Makefile
+++ b/activate-sim-card-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/activate-sim-card-python/README.md
+++ b/activate-sim-card-python/README.md
@@ -1,0 +1,225 @@
+# SIM Activation with Python and Flask
+
+## What Does This Example Do?
+
+Build a production-ready Flask application that activates SIM cards using the Telnyx IoT API. This tutorial demonstrates how to retrieve SIM card details, activate SIMs with proper validation, handle telecom-specific errors, and manage credentials securely. You'll create endpoints to list SIM cards and activate them individually, with comprehensive error handling for production resilience.
+
+## Who Is This For?
+
+- **Python developers** building iot features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- At least one SIM card provisioned in your Telnyx account.
+- pip (Python package manager).
+- curl or Postman for testing HTTP endpoints.
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/activate-sim-card-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/activate-sim-card-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and initialize the Telnyx client using the new pattern. Define helper functions to list and activate SIM cards with proper validation and error handling:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def list_sim_cards() -> list:
+    """Retrieve all SIM cards and return JSON-serializable list."""
+    response = client.sim_cards.list()
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return [
+        {
+            "id": sim.id,
+            "iccid": sim.iccid,
+            "status": sim.status,
+            "sim_card_group_id": sim.sim_card_group_id,
+        }
+        for sim in response.data
+    ]
+
+
+def get_sim_card(sim_card_id: str) -> dict:
+    """Retrieve a single SIM card by ID and return JSON-serializable data."""
+    response = client.sim_cards.retrieve(sim_card_id)
+    
+    # Extract serializable data from the response object
+    return {
+        "id": response.data.id,
+        "iccid": response.data.iccid,
+        "status": response.data.status,
+        "sim_card_group_id": response.data.sim_card_group_id,
+    }
+
+
+def activate_sim_card(sim_card_id: str) -> dict:
+    """Activate a SIM card and return JSON-serializable response data."""
+    if not sim_card_id:
+        raise ValueError("SIM card ID is required")
+    
+    # Call the activate method with the SIM card ID
+    response = client.sim_cards.activate(sim_card_id)
+    
+    # Extract serializable data from the response object
+    return {
+        "id": response.data.id,
+        "iccid": response.data.iccid,
+        "status": response.data.status,
+        "sim_card_group_id": response.data.sim_card_group_id,
+    }
+```
+
+Now add Flask routes with comprehensive error handling:
+
+```python
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+
+@app.route("/sim-cards", methods=["GET"])
+def list_sims():
+    """HTTP endpoint to list all SIM cards."""
+    try:
+        sims = list_sim_cards()
+        return jsonify({"data": sims}), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+@app.route("/sim-cards/<sim_card_id>", methods=["GET"])
+def get_sim(sim_card_id):
+    """HTTP endpoint to retrieve a single SIM card."""
+    try:
+        sim = get_sim_card(sim_card_id)
+        return jsonify(sim), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+@app.route("/sim-cards/<sim_card_id>/activate", methods=["POST"])
+def activate_sim(sim_card_id):
+    """HTTP endpoint to activate a SIM card."""
+    try:
+        result = activate_sim_card(sim_card_id)
+        return jsonify({"message": "SIM card activated successfully", "data": result}), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Flask server. |
+| SIM Card Not Found (404) | You receive a 404 error or "SIM card not found" message when retrieving or activating a SIM. | Confirm the SIM card ID is correct by first running the `/sim-cards` endpoint to list all available SIM cards. Copy the exact `id` value from the response and use it in subsequent requests. Verify the SIM card exists in your Telnyx account via the Portal. |
+| Environment Variable Not Set | The application raises an error about missing `TELNYX_API_KEY` on startup or first request. | Confirm your `.env` file exists in the same directory as `app.py` and contains the variable. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `load_dotenv()` call must execute before `os.getenv()` is called—verify this import order in your code. |
+| Rate Limit Error (429) | The endpoint returns `{"error": "Rate limit exceeded. Please slow down."}` with HTTP 429. | You have exceeded the Telnyx API rate limit. Implement exponential backoff in your client code and retry requests after a delay. Check the [Telnyx documentation](https://developers.telnyx.com) for current rate limits and contact support if you need higher limits. |
+| Network Connection Error (503) | The endpoint returns `{"error": "Network error connecting to Telnyx"}` with HTTP 503. | Verify your internet connection is active and stable. Check that the Telnyx API endpoint is reachable by testing with `curl https://api.telnyx.com/v2/sim_cards` (you may get a 401, which is expected). If the issue persists, the Telnyx service may be temporarily unavailable—check the [Telnyx status page](https://status.telnyx.com). |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this IoT example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Monitor SIM Card Data Usage](/tutorials/iot/python/data-usage-monitoring).
+- [Configure Custom APN Settings](/tutorials/iot/python/apn-configuration).
+- [Handle SIM Status Change Webhooks](/tutorials/iot/python/sim-status-webhook).

--- a/activate-sim-card-python/README.md
+++ b/activate-sim-card-python/README.md
@@ -137,7 +137,7 @@ def list_sims():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -154,7 +154,7 @@ def get_sim(sim_card_id):
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -171,15 +171,15 @@ def activate_sim(sim_card_id):
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "Invalid request"}), 400
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)
 ```
 
 ## Complete Code

--- a/activate-sim-card-python/README.md
+++ b/activate-sim-card-python/README.md
@@ -218,6 +218,14 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [IoT SIM Get Started](https://developers.telnyx.com/docs/iot-sim/get-started)
+- [SIM Card API Reference](https://developers.telnyx.com/api-reference/sim-cards/get-all-sim-cards)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx IoT SIM Cards](https://telnyx.com/products/iot-sim-card)
+- [IoT Data Plans Pricing](https://telnyx.com/pricing/iot-data-plans)
+
 ## Related Examples
 
 - [Monitor SIM Card Data Usage](/tutorials/iot/python/data-usage-monitoring).

--- a/activate-sim-card-python/app.py
+++ b/activate-sim-card-python/app.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Production-ready Flask application for SIM card activation via Telnyx."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def list_sim_cards() -> list:
+    """Retrieve all SIM cards and return JSON-serializable list."""
+    response = client.sim_cards.list()
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return [
+        {
+            "id": sim.id,
+            "iccid": sim.iccid,
+            "status": sim.status,
+            "sim_card_group_id": sim.sim_card_group_id,
+        }
+        for sim in response.data
+    ]
+
+
+def get_sim_card(sim_card_id: str) -> dict:
+    """Retrieve a single SIM card by ID and return JSON-serializable data."""
+    response = client.sim_cards.retrieve(sim_card_id)
+    
+    # Extract serializable data from the response object
+    return {
+        "id": response.data.id,
+        "iccid": response.data.iccid,
+        "status": response.data.status,
+        "sim_card_group_id": response.data.sim_card_group_id,
+    }
+
+
+def activate_sim_card(sim_card_id: str) -> dict:
+    """Activate a SIM card and return JSON-serializable response data."""
+    if not sim_card_id:
+        raise ValueError("SIM card ID is required")
+    
+    # Call the activate method with the SIM card ID
+    response = client.sim_cards.activate(sim_card_id)
+    
+    # Extract serializable data from the response object
+    return {
+        "id": response.data.id,
+        "iccid": response.data.iccid,
+        "status": response.data.status,
+        "sim_card_group_id": response.data.sim_card_group_id,
+    }
+
+
+@app.route("/sim-cards", methods=["GET"])
+def list_sims():
+    """HTTP endpoint to list all SIM cards."""
+    try:
+        sims = list_sim_cards()
+        return jsonify({"data": sims}), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+@app.route("/sim-cards/<sim_card_id>", methods=["GET"])
+def get_sim(sim_card_id):
+    """HTTP endpoint to retrieve a single SIM card."""
+    try:
+        sim = get_sim_card(sim_card_id)
+        return jsonify(sim), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+@app.route("/sim-cards/<sim_card_id>/activate", methods=["POST"])
+def activate_sim(sim_card_id):
+    """HTTP endpoint to activate a SIM card."""
+    try:
+        result = activate_sim_card(sim_card_id)
+        return jsonify({"message": "SIM card activated successfully", "data": result}), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/activate-sim-card-python/app.py
+++ b/activate-sim-card-python/app.py
@@ -72,7 +72,7 @@ def list_sims():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -89,7 +89,7 @@ def get_sim(sim_card_id):
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -106,11 +106,11 @@ def activate_sim(sim_card_id):
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "Invalid request"}), 400
 
 
 if __name__ == "__main__":

--- a/activate-sim-card-python/app.py
+++ b/activate-sim-card-python/app.py
@@ -114,4 +114,4 @@ def activate_sim(sim_card_id):
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/activate-sim-card-python/requirements.txt
+++ b/activate-sim-card-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/create-ai-assistant-python/.env.example
+++ b/create-ai-assistant-python/.env.example
@@ -1,0 +1,3 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here

--- a/create-ai-assistant-python/.env.example
+++ b/create-ai-assistant-python/.env.example
@@ -1,3 +1,4 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here

--- a/create-ai-assistant-python/Dockerfile
+++ b/create-ai-assistant-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/create-ai-assistant-python/Dockerfile
+++ b/create-ai-assistant-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/create-ai-assistant-python/Makefile
+++ b/create-ai-assistant-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/create-ai-assistant-python/README.md
+++ b/create-ai-assistant-python/README.md
@@ -138,6 +138,14 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [AI Assistants Guide](https://developers.telnyx.com/docs/inference/ai-assistants/no-code-voice-assistant)
+- [Assistants API Reference](https://developers.telnyx.com/api-reference/assistants/create-an-assistant)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx AI Assistants](https://telnyx.com/ai-assistants)
+- [Voice AI Agents](https://telnyx.com/products/voice-ai-agents)
+
 ## Related Examples
 
 - [List AI Assistants](/tutorials/ai/python/list-ai-assistants).

--- a/create-ai-assistant-python/README.md
+++ b/create-ai-assistant-python/README.md
@@ -1,0 +1,145 @@
+# Create AI Assistant with Python and Flask
+
+## What Does This Example Do?
+
+Build a production-ready Flask endpoint that creates AI assistants using the Telnyx AI Assistants API. This tutorial demonstrates the client-based initialization pattern, proper error handling for AI services, and secure credential management via environment variables.
+
+## Who Is This For?
+
+- **Python developers** building ai features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- pip (Python package manager).
+- Basic understanding of REST APIs and JSON.
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/create-ai-assistant-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/create-ai-assistant-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and initialize the Telnyx client using the new pattern. Define a helper function to handle assistant creation with proper validation:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def create_ai_assistant(name: str, instructions: str, model: str = "meta-llama/Meta-Llama-3.1-70B-Instruct", enabled_features: list = None) -> dict:
+    """Create AI assistant via Telnyx and return JSON-serializable response data."""
+    if not name or not instructions:
+        raise ValueError("Name and instructions are required")
+    
+    # Default to messaging if no features specified
+    if enabled_features is None:
+        enabled_features = ["messaging"]
+    
+    # Validate enabled features
+    valid_features = ["messaging", "telephony"]
+    for feature in enabled_features:
+        if feature not in valid_features:
+            raise ValueError(f"Invalid feature: {feature}. Must be one of: {valid_features}")
+    
+    # Use client.ai_assistants.create() — NOT client.ai_assistants.create()
+    response = client.ai_assistants.create(
+        name=name,
+        instructions=instructions,
+        model=model,
+        enabled_features=enabled_features,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "id": response.data.id,
+        "name": response.data.name,
+        "model": response.data.model,
+        "instructions": response.data.instructions,
+        "enabled_features": response.data.enabled_features,
+        "created_at": response.data.created_at,
+    }
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Flask server. |
+| Invalid Feature Error | You receive a 400 error stating "Invalid feature" when creating an assistant. | Ensure `enabled_features` contains only valid values: `["messaging"]`, `["telephony"]`, or `["messaging", "telephony"]`. Check your request payload for typos like "voice" instead of "telephony" or "sms" instead of "messaging". |
+| Missing Instructions Error | The API returns an error about missing or empty instructions field. | Verify that the `instructions` field in your request contains meaningful content. Instructions define the assistant's personality and behavior—they cannot be empty or just whitespace. Provide clear guidance like "You are a helpful customer service representative." |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this AI example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [List AI Assistants](/tutorials/ai/python/list-ai-assistants).
+- [Update an AI Assistant](/tutorials/ai/python/update-ai-assistant).
+- [Chat with an AI Assistant](/tutorials/ai/python/chat-with-ai-assistant).

--- a/create-ai-assistant-python/app.py
+++ b/create-ai-assistant-python/app.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Production-ready Flask endpoint for creating AI assistants via Telnyx."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def create_ai_assistant(name: str, instructions: str, model: str = "meta-llama/Meta-Llama-3.1-70B-Instruct", enabled_features: list = None) -> dict:
+    """Create AI assistant via Telnyx and return JSON-serializable response data."""
+    if not name or not instructions:
+        raise ValueError("Name and instructions are required")
+    
+    # Default to messaging if no features specified
+    if enabled_features is None:
+        enabled_features = ["messaging"]
+    
+    # Validate enabled features
+    valid_features = ["messaging", "telephony"]
+    for feature in enabled_features:
+        if feature not in valid_features:
+            raise ValueError(f"Invalid feature: {feature}. Must be one of: {valid_features}")
+    
+    # Use client.ai_assistants.create() — NOT client.ai_assistants.create()
+    response = client.ai_assistants.create(
+        name=name,
+        instructions=instructions,
+        model=model,
+        enabled_features=enabled_features,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "id": response.data.id,
+        "name": response.data.name,
+        "model": response.data.model,
+        "instructions": response.data.instructions,
+        "enabled_features": response.data.enabled_features,
+        "created_at": response.data.created_at,
+    }
+
+
+@app.route("/ai/assistants", methods=["POST"])
+def create_assistant_endpoint():
+    """HTTP endpoint to create AI assistant."""
+    data = request.get_json()
+    
+    if not data:
+        return jsonify({"error": "Request body required"}), 400
+    
+    name = data.get("name")
+    instructions = data.get("instructions")
+    model = data.get("model", "meta-llama/Meta-Llama-3.1-70B-Instruct")
+    enabled_features = data.get("enabled_features", ["messaging"])
+    
+    if not name or not instructions:
+        return jsonify({"error": "Missing required fields: 'name' and 'instructions'"}), 400
+    
+    try:
+        result = create_ai_assistant(name, instructions, model, enabled_features)
+        return jsonify(result), 201
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/create-ai-assistant-python/app.py
+++ b/create-ai-assistant-python/app.py
@@ -73,11 +73,11 @@ def create_assistant_endpoint():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "Invalid request"}), 400
 
 
 if __name__ == "__main__":

--- a/create-ai-assistant-python/app.py
+++ b/create-ai-assistant-python/app.py
@@ -81,4 +81,4 @@ def create_assistant_endpoint():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/create-ai-assistant-python/requirements.txt
+++ b/create-ai-assistant-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/inbound-sip-routing-python/.env.example
+++ b/inbound-sip-routing-python/.env.example
@@ -1,0 +1,3 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here

--- a/inbound-sip-routing-python/.env.example
+++ b/inbound-sip-routing-python/.env.example
@@ -1,3 +1,4 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here

--- a/inbound-sip-routing-python/Dockerfile
+++ b/inbound-sip-routing-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/inbound-sip-routing-python/Dockerfile
+++ b/inbound-sip-routing-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/inbound-sip-routing-python/Makefile
+++ b/inbound-sip-routing-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/inbound-sip-routing-python/README.md
+++ b/inbound-sip-routing-python/README.md
@@ -189,6 +189,14 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [SIP Trunking Get Started](https://developers.telnyx.com/docs/voice/sip-trunking/get-started)
+- [SIP Configuration Guides](https://developers.telnyx.com/docs/voice/sip-trunking/configuration-guides)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx SIP Trunks](https://telnyx.com/products/sip-trunks)
+- [SIP Trunking Pricing](https://telnyx.com/pricing/elastic-sip)
+
 ## Related Examples
 
 - [Configure SIP Authentication Methods](/tutorials/sip/python/sip-authentication).

--- a/inbound-sip-routing-python/README.md
+++ b/inbound-sip-routing-python/README.md
@@ -1,0 +1,196 @@
+# Inbound SIP Routing with Python and Flask
+
+## What Does This Example Do?
+
+Build a Flask application that manages inbound SIP routing configurations using the Telnyx SIP Trunking API. This tutorial demonstrates how to create SIP connections, configure routing rules, and handle inbound calls through your PBX or SIP endpoint with proper error handling and secure credential management.
+
+## Who Is This For?
+
+- **Python developers** building sip features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- A publicly accessible SIP endpoint (PBX, SBC, or softphone) for receiving calls.
+- pip (Python package manager).
+- Basic understanding of SIP protocol concepts.
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/inbound-sip-routing-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/inbound-sip-routing-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and initialize the Telnyx client. Define helper functions to manage SIP connections and routing configurations:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def create_sip_connection(name: str, sip_uri: str, username: str = None, password: str = None) -> dict:
+    """Create a new SIP connection for inbound routing."""
+    connection_params = {
+        "connection_name": name,
+        "transport_protocol": "UDP",
+        "default_on_hold_comfort_noise_enabled": True,
+        "dtmf_type": "RFC 2833",
+        "encode_contact_header_enabled": False,
+        "encrypted_media": "SRTP",
+        "onnet_t38_passthrough_enabled": False,
+        "webhook_event_url": "",
+        "webhook_event_failover_url": "",
+        "webhook_api_version": "1",
+        "webhook_timeout_secs": 25,
+        "rtcp_settings": {
+            "port": "rtp+1"
+        }
+    }
+    
+    # Configure authentication method based on provided credentials
+    if username and password:
+        # Credential-based authentication
+        connection_params.update({
+            "sip_uri": sip_uri,
+            "sip_username": username,
+            "sip_password": password,
+            "auth_username": username
+        })
+    else:
+        # IP-based authentication (no registration required)
+        connection_params.update({
+            "sip_uri": sip_uri,
+            "auth_username": "",
+            "sip_username": "",
+            "sip_password": ""
+        })
+    
+    response = client.sip_connections.create(**connection_params)
+    
+    # Extract serializable data from SDK response
+    return {
+        "id": response.data.id,
+        "name": response.data.connection_name,
+        "sip_uri": response.data.sip_uri,
+        "username": response.data.sip_username,
+        "status": "created",
+        "auth_method": "credential" if username else "ip"
+    }
+
+
+def list_sip_connections() -> list:
+    """Retrieve all SIP connections with routing information."""
+    response = client.sip_connections.list()
+    
+    return [
+        {
+            "id": connection.id,
+            "name": connection.connection_name,
+            "sip_uri": connection.sip_uri,
+            "username": connection.sip_username,
+            "transport": connection.transport_protocol,
+            "encrypted_media": connection.encrypted_media
+        }
+        for connection in response.data
+    ]
+
+
+def get_sip_connection(connection_id: str) -> dict:
+    """Retrieve detailed information about a specific SIP connection."""
+    response = client.sip_connections.retrieve(connection_id)
+    
+    return {
+        "id": response.data.id,
+        "name": response.data.connection_name,
+        "sip_uri": response.data.sip_uri,
+        "username": response.data.sip_username,
+        "transport": response.data.transport_protocol,
+        "encrypted_media": response.data.encrypted_media,
+        "dtmf_type": response.data.dtmf_type,
+        "webhook_url": response.data.webhook_event_url,
+        "rtcp_settings": response.data.rtcp_settings
+    }
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| SIP Connection Creation Fails | The API returns a 422 error when creating a SIP connection, indicating invalid parameters or configuration. | Verify that your SIP URI follows the correct format: `sip:hostname:port` or `sip:ip_address:port`. Ensure the hostname or IP address is publicly accessible from Telnyx servers. Check that the transport protocol (UDP/TCP/TLS) matches your SIP endpoint configuration. If using credential authentication, confirm the username and password are valid for your PBX. |
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` when making API calls to manage SIP connections. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key from the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes around the API key. If the key was recently regenerated, update your environment file and restart the Flask server. Check that the API key has the necessary permissions for SIP connection management. |
+| Inbound Calls Not Routing | SIP connection is created successfully but inbound calls are not reaching your PBX or SIP endpoint. | Confirm your SIP endpoint is publicly accessible and listening on the specified port. Test connectivity using SIP debugging tools like `sipsak` or `sipgrep`. Verify firewall rules allow inbound SIP traffic on UDP port 5060 (or your custom port). Check that your PBX is configured to accept calls from Telnyx IP ranges. Ensure the SIP connection is properly associated with your Telnyx phone numbers through the portal or API. |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this SIP example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Configure SIP Authentication Methods](/tutorials/sip/python/sip-authentication).
+- [Set Up Outbound SIP Calling](/tutorials/sip/python/outbound-sip-call).
+- [Implement SIP Failover Routing](/tutorials/sip/python/failover-routing).

--- a/inbound-sip-routing-python/app.py
+++ b/inbound-sip-routing-python/app.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Flask application for managing inbound SIP routing with Telnyx."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def create_sip_connection(name: str, sip_uri: str, username: str = None, password: str = None) -> dict:
+    """Create a new SIP connection for inbound routing."""
+    connection_params = {
+        "connection_name": name,
+        "transport_protocol": "UDP",
+        "default_on_hold_comfort_noise_enabled": True,
+        "dtmf_type": "RFC 2833",
+        "encode_contact_header_enabled": False,
+        "encrypted_media": "SRTP",
+        "onnet_t38_passthrough_enabled": False,
+        "webhook_event_url": "",
+        "webhook_event_failover_url": "",
+        "webhook_api_version": "1",
+        "webhook_timeout_secs": 25,
+        "rtcp_settings": {
+            "port": "rtp+1"
+        }
+    }
+    
+    # Configure authentication method based on provided credentials
+    if username and password:
+        # Credential-based authentication
+        connection_params.update({
+            "sip_uri": sip_uri,
+            "sip_username": username,
+            "sip_password": password,
+            "auth_username": username
+        })
+    else:
+        # IP-based authentication (no registration required)
+        connection_params.update({
+            "sip_uri": sip_uri,
+            "auth_username": "",
+            "sip_username": "",
+            "sip_password": ""
+        })
+    
+    response = client.sip_connections.create(**connection_params)
+    
+    # Extract serializable data from SDK response
+    return {
+        "id": response.data.id,
+        "name": response.data.connection_name,
+        "sip_uri": response.data.sip_uri,
+        "username": response.data.sip_username,
+        "status": "created",
+        "auth_method": "credential" if username else "ip"
+    }
+
+
+def list_sip_connections() -> list:
+    """Retrieve all SIP connections with routing information."""
+    response = client.sip_connections.list()
+    
+    return [
+        {
+            "id": connection.id,
+            "name": connection.connection_name,
+            "sip_uri": connection.sip_uri,
+            "username": connection.sip_username,
+            "transport": connection.transport_protocol,
+            "encrypted_media": connection.encrypted_media
+        }
+        for connection in response.data
+    ]
+
+
+def get_sip_connection(connection_id: str) -> dict:
+    """Retrieve detailed information about a specific SIP connection."""
+    response = client.sip_connections.retrieve(connection_id)
+    
+    return {
+        "id": response.data.id,
+        "name": response.data.connection_name,
+        "sip_uri": response.data.sip_uri,
+        "username": response.data.sip_username,
+        "transport": response.data.transport_protocol,
+        "encrypted_media": response.data.encrypted_media,
+        "dtmf_type": response.data.dtmf_type,
+        "webhook_url": response.data.webhook_event_url,
+        "rtcp_settings": response.data.rtcp_settings
+    }
+
+
+@app.route("/sip/connections", methods=["GET"])
+def list_connections():
+    """List all SIP connections configured for inbound routing."""
+    try:
+        connections = list_sip_connections()
+        return jsonify({"connections": connections}), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+@app.route("/sip/connections", methods=["POST"])
+def create_connection():
+    """Create a new SIP connection for inbound call routing."""
+    data = request.get_json()
+    
+    if not data:
+        return jsonify({"error": "Request body required"}), 400
+    
+    name = data.get("name")
+    sip_uri = data.get("sip_uri")
+    username = data.get("username")
+    password = data.get("password")
+    
+    if not name or not sip_uri:
+        return jsonify({"error": "Missing required fields: 'name' and 'sip_uri'"}), 400
+    
+    try:
+        connection = create_sip_connection(name, sip_uri, username, password)
+        return jsonify(connection), 201
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+@app.route("/sip/connections/<connection_id>", methods=["GET"])
+def get_connection(connection_id):
+    """Get detailed information about a specific SIP connection."""
+    try:
+        connection = get_sip_connection(connection_id)
+        return jsonify(connection), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/inbound-sip-routing-python/app.py
+++ b/inbound-sip-routing-python/app.py
@@ -110,7 +110,7 @@ def list_connections():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -140,7 +140,7 @@ def create_connection():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -157,7 +157,7 @@ def get_connection(connection_id):
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 

--- a/inbound-sip-routing-python/app.py
+++ b/inbound-sip-routing-python/app.py
@@ -163,4 +163,4 @@ def get_connection(connection_id):
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/inbound-sip-routing-python/requirements.txt
+++ b/inbound-sip-routing-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/list-ai-assistants-python/.env.example
+++ b/list-ai-assistants-python/.env.example
@@ -1,0 +1,3 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here

--- a/list-ai-assistants-python/.env.example
+++ b/list-ai-assistants-python/.env.example
@@ -1,3 +1,4 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here

--- a/list-ai-assistants-python/Dockerfile
+++ b/list-ai-assistants-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/list-ai-assistants-python/Dockerfile
+++ b/list-ai-assistants-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/list-ai-assistants-python/Makefile
+++ b/list-ai-assistants-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/list-ai-assistants-python/README.md
+++ b/list-ai-assistants-python/README.md
@@ -1,0 +1,138 @@
+# List AI Assistants with Python and Flask
+
+## What Does This Example Do?
+
+Build a production-ready Flask endpoint that lists all your AI Assistants using the Telnyx Python SDK. This tutorial covers the client-based initialization pattern, proper serialization of SDK response objects, and comprehensive error handling for a robust API layer over Telnyx AI Assistants.
+
+By the end, you'll have a running Flask server with a `GET /assistants` endpoint that returns a clean JSON array of your AI Assistants — ready to power a dashboard, admin panel, or integration workflow.
+
+## Who Is This For?
+
+- **Python developers** building ai features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- At least one AI Assistant created in the Telnyx Portal (so the list endpoint returns data).
+- pip (Python package manager).
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/list-ai-assistants-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/list-ai-assistants-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and start by initializing the Telnyx client. Define a helper function that calls the API and returns a plain list of dictionaries — SDK response objects are **not** JSON-serializable, so you must extract fields explicitly:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def fetch_assistants() -> list[dict]:
+    """Retrieve all AI Assistants and return JSON-serializable data."""
+    response = client.ai_assistants.list()
+
+    # SDK objects are NOT JSON-serializable — always unpack to plain dicts
+    return [
+        {
+            "id": assistant.id,
+            "name": assistant.name,
+            "model": assistant.model,
+            "instructions": assistant.instructions,
+            "enabled_features": assistant.enabled_features,
+            "created_at": assistant.created_at,
+        }
+        for assistant in response.data
+    ]
+```
+
+Key points about this helper:
+
+- It uses `client.ai_assistants.list()` — note the flat namespace (`ai_assistants`, **not** `ai.assistants`).
+- Each assistant object is unpacked into a plain dictionary so Flask's `jsonify` can serialize it.
+- No exception handling here — errors bubble up to the route handler where they belong.
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces, surrounding quotes, or newline characters. If the key was recently regenerated, update your `.env` file and restart the Flask server. |
+| Empty Array Returned | The endpoint returns `[]` even though you expect assistants to exist. | Confirm that AI Assistants have been created under the same Telnyx account whose API key you are using. Log in to the [Telnyx Portal](https://portal.telnyx.com), navigate to the AI Assistants section, and verify at least one assistant exists. If you have multiple API keys (e.g., test vs. production), ensure you are using the correct one. |
+| Environment Variable Not Loaded | The application crashes with `None` passed as the API key, or you see an `AuthenticationError` immediately on startup. | Confirm your `.env` file exists in the same directory where you run `python app.py` and is named exactly `.env` (not `.env.txt` or `env`). The `load_dotenv()` call must execute before `telnyx.Telnyx()` is instantiated — verify the import and call order at the top of your file. |
+| Connection Error (503) | The endpoint returns `{"error": "Network error connecting to Telnyx"}` with HTTP 503. | Check your internet connection and verify that outbound HTTPS traffic to `api.telnyx.com` is not blocked by a firewall or proxy. If you are behind a corporate network, you may need to configure proxy settings for the Python process. |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this AI example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Get an AI Assistant](/tutorials/ai/python/get-ai-assistant).
+- [Create an AI Assistant](/tutorials/ai/python/create-ai-assistant).
+- [Chat with an AI Assistant](/tutorials/ai/python/chat-with-ai-assistant).

--- a/list-ai-assistants-python/README.md
+++ b/list-ai-assistants-python/README.md
@@ -131,6 +131,14 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [AI Assistants Guide](https://developers.telnyx.com/docs/inference/ai-assistants/no-code-voice-assistant)
+- [Assistants API Reference](https://developers.telnyx.com/api-reference/assistants/create-an-assistant)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx AI Assistants](https://telnyx.com/ai-assistants)
+- [Voice AI Agents](https://telnyx.com/products/voice-ai-agents)
+
 ## Related Examples
 
 - [Get an AI Assistant](/tutorials/ai/python/get-ai-assistant).

--- a/list-ai-assistants-python/app.py
+++ b/list-ai-assistants-python/app.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Production-ready Flask endpoint for listing Telnyx AI Assistants."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, jsonify
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def fetch_assistants() -> list[dict]:
+    """Retrieve all AI Assistants and return JSON-serializable data."""
+    response = client.ai_assistants.list()
+
+    # SDK objects are NOT JSON-serializable — always unpack to plain dicts
+    return [
+        {
+            "id": assistant.id,
+            "name": assistant.name,
+            "model": assistant.model,
+            "instructions": assistant.instructions,
+            "enabled_features": assistant.enabled_features,
+            "created_at": assistant.created_at,
+        }
+        for assistant in response.data
+    ]
+
+
+@app.route("/assistants", methods=["GET"])
+def list_assistants():
+    """Return all AI Assistants as a JSON array."""
+    try:
+        assistants = fetch_assistants()
+        return jsonify(assistants), 200
+
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/list-ai-assistants-python/app.py
+++ b/list-ai-assistants-python/app.py
@@ -44,7 +44,7 @@ def list_assistants():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 

--- a/list-ai-assistants-python/app.py
+++ b/list-ai-assistants-python/app.py
@@ -50,4 +50,4 @@ def list_assistants():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/list-ai-assistants-python/requirements.txt
+++ b/list-ai-assistants-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/route-phone-calls-to-ai-agent-python/.env.example
+++ b/route-phone-calls-to-ai-agent-python/.env.example
@@ -1,0 +1,3 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here

--- a/route-phone-calls-to-ai-agent-python/.env.example
+++ b/route-phone-calls-to-ai-agent-python/.env.example
@@ -1,3 +1,4 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here

--- a/route-phone-calls-to-ai-agent-python/Dockerfile
+++ b/route-phone-calls-to-ai-agent-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/route-phone-calls-to-ai-agent-python/Dockerfile
+++ b/route-phone-calls-to-ai-agent-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/route-phone-calls-to-ai-agent-python/Makefile
+++ b/route-phone-calls-to-ai-agent-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/route-phone-calls-to-ai-agent-python/README.md
+++ b/route-phone-calls-to-ai-agent-python/README.md
@@ -144,6 +144,16 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [Voice API Overview](https://developers.telnyx.com/docs/voice)
+- [Voice API Commands](https://developers.telnyx.com/docs/voice/programmable-voice/voice-api-commands-and-resources)
+- [AI Assistant Start](https://developers.telnyx.com/docs/voice/programmable-voice/ai-assistant-start)
+- [Call Control API Reference](https://developers.telnyx.com/api-reference/call-commands/dial)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx Voice API](https://telnyx.com/products/voice-api)
+- [Voice AI Agents](https://telnyx.com/products/voice-ai-agents)
+
 ## Related Examples
 
 - [Make an Outbound Call with Python](/tutorials/voice/python/outbound-call).

--- a/route-phone-calls-to-ai-agent-python/README.md
+++ b/route-phone-calls-to-ai-agent-python/README.md
@@ -1,0 +1,151 @@
+# Inbound Call Webhook with Python and Flask
+
+## What Does This Example Do?
+
+Build a production-ready Flask webhook endpoint that receives and processes inbound calls from the Telnyx Voice API. This tutorial demonstrates how to handle call control events, answer incoming calls, and respond with text-to-speech using the Telnyx Python SDK and webhook event handling.
+
+## Who Is This For?
+
+- **Python developers** building voice features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- A Telnyx phone number enabled for inbound calls.
+- A Call Control Application configured in the Telnyx Portal with your webhook URL.
+- A publicly accessible URL (use ngrok for local development).
+- pip (Python package manager).
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/route-phone-calls-to-ai-agent-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/route-phone-calls-to-ai-agent-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and initialize the Telnyx client. Define helper functions to handle call control actions:
+
+```python
+import os
+import json
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def answer_call(call_control_id: str) -> dict:
+    """Answer an inbound call."""
+    response = client.calls.actions.answer(call_control_id)
+    return {
+        "call_control_id": response.data.call_control_id,
+        "status": "answered",
+    }
+
+
+def speak_to_call(call_control_id: str, message: str) -> dict:
+    """Play text-to-speech message to the call."""
+    response = client.calls.actions.speak(
+        call_control_id,
+        payload=message,
+        voice="female",
+        language_code="en-US",
+    )
+    return {
+        "call_control_id": response.data.call_control_id,
+        "message": message,
+    }
+
+
+def hangup_call(call_control_id: str) -> dict:
+    """Terminate the call."""
+    response = client.calls.actions.hangup(call_control_id)
+    return {
+        "call_control_id": response.data.call_control_id,
+        "status": "hangup_initiated",
+    }
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| Webhook not receiving events | The Flask endpoint is running but Telnyx is not sending webhook payloads. | Verify that your ngrok URL is correctly configured in the Telnyx Portal under your Call Control Application settings. Ensure the webhook URL is exactly `https://your-ngrok-url.ngrok.io/webhooks/call` with no trailing slashes. Check that ngrok is still running and the tunnel is active. Restart ngrok if the URL changes. |
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` when processing webhook events. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. Restart the Flask server after updating the `.env` file. |
+| Call not being answered | Inbound calls ring but are not answered by the webhook. | Confirm that the `call.initiated` event is being received by checking Flask logs. Verify that `answer_call()` is being invoked without exceptions. Check that your Call Control Application is properly linked to your Telnyx phone number in the Portal. Ensure the phone number is in E.164 format in your configuration. |
+| Missing call_control_id in payload | The webhook receives events but `call_control_id` is None or missing. | Verify that the webhook payload structure matches Telnyx's event format. Check the Telnyx documentation for the exact payload structure of `call.initiated` events. Log the entire payload to debug: add `print(json.dumps(payload, indent=2))` in the webhook handler. |
+| TTS message not playing | The call is answered but no audio is heard. | Verify that the `speak_to_call()` function is being called after `answer_call()`. Check that the message text is not empty. Ensure the voice and language_code parameters are valid (e.g., `voice="female"`, `language_code="en-US"`). Review Flask logs for any API errors returned by the Telnyx SDK. |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this Voice example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Make an Outbound Call with Python](/tutorials/voice/python/outbound-call).
+- [Record Inbound Calls with Python](/tutorials/voice/python/call-recording).
+- [Build an IVR Menu with Python](/tutorials/voice/python/ivr-menu).

--- a/route-phone-calls-to-ai-agent-python/app.py
+++ b/route-phone-calls-to-ai-agent-python/app.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Production-ready Flask webhook for handling inbound calls via Telnyx Voice API."""
+
+import os
+import json
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def answer_call(call_control_id: str) -> dict:
+    """Answer an inbound call."""
+    response = client.calls.actions.answer(call_control_id)
+    return {
+        "call_control_id": response.data.call_control_id,
+        "status": "answered",
+    }
+
+
+def speak_to_call(call_control_id: str, message: str) -> dict:
+    """Play text-to-speech message to the call."""
+    response = client.calls.actions.speak(
+        call_control_id,
+        payload=message,
+        voice="female",
+        language_code="en-US",
+    )
+    return {
+        "call_control_id": response.data.call_control_id,
+        "message": message,
+    }
+
+
+def hangup_call(call_control_id: str) -> dict:
+    """Terminate the call."""
+    response = client.calls.actions.hangup(call_control_id)
+    return {
+        "call_control_id": response.data.call_control_id,
+        "status": "hangup_initiated",
+    }
+
+
+@app.route("/webhooks/call", methods=["POST"])
+def handle_call_webhook():
+    """Webhook endpoint to handle inbound call events."""
+    try:
+        payload = request.get_json()
+        
+        if not payload:
+            return jsonify({"error": "No payload received"}), 400
+        
+        # Extract event type and call control ID from webhook payload
+        event_type = payload.get("data", {}).get("event_type")
+        call_control_id = payload.get("data", {}).get("call_control_id")
+        
+        if not event_type or not call_control_id:
+            return jsonify({"error": "Missing event_type or call_control_id"}), 400
+        
+        # Handle call.initiated event — inbound call received
+        if event_type == "call.initiated":
+            from_number = payload.get("data", {}).get("from", {}).get("phone_number")
+            to_number = payload.get("data", {}).get("to", {}).get("phone_number")
+            
+            # Answer the call
+            answer_call(call_control_id)
+            
+            # Play greeting message
+            speak_to_call(
+                call_control_id,
+                "Thank you for calling. Your call is important to us. Goodbye."
+            )
+            
+            return jsonify({
+                "status": "call_answered",
+                "call_control_id": call_control_id,
+                "from": from_number,
+                "to": to_number,
+            }), 200
+        
+        # Handle call.answered event — call was answered
+        elif event_type == "call.answered":
+            return jsonify({
+                "status": "call_answered",
+                "call_control_id": call_control_id,
+            }), 200
+        
+        # Handle call.hangup event — call ended
+        elif event_type == "call.hangup":
+            hangup_reason = payload.get("data", {}).get("hangup_reason")
+            return jsonify({
+                "status": "call_ended",
+                "call_control_id": call_control_id,
+                "hangup_reason": hangup_reason,
+            }), 200
+        
+        # Handle call.speak.ended event — TTS playback finished
+        elif event_type == "call.speak.ended":
+            # Hangup after message finishes
+            hangup_call(call_control_id)
+            return jsonify({
+                "status": "message_finished",
+                "call_control_id": call_control_id,
+            }), 200
+        
+        # Acknowledge other events without processing
+        else:
+            return jsonify({
+                "status": "event_received",
+                "event_type": event_type,
+            }), 200
+    
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded"}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except Exception as e:
+        return jsonify({"error": f"Unexpected error: {str(e)}"}), 500
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/route-phone-calls-to-ai-agent-python/app.py
+++ b/route-phone-calls-to-ai-agent-python/app.py
@@ -129,4 +129,4 @@ def handle_call_webhook():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/route-phone-calls-to-ai-agent-python/app.py
+++ b/route-phone-calls-to-ai-agent-python/app.py
@@ -121,11 +121,11 @@ def handle_call_webhook():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded"}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except Exception as e:
-        return jsonify({"error": f"Unexpected error: {str(e)}"}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 if __name__ == "__main__":

--- a/route-phone-calls-to-ai-agent-python/requirements.txt
+++ b/route-phone-calls-to-ai-agent-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -80,6 +80,69 @@ PRODUCT_LABELS = {
     "iot": "IoT",
 }
 
+PRODUCT_LINKS = {
+    "sms": {
+        "docs": [
+            ("Messaging Overview", "https://developers.telnyx.com/docs/messaging"),
+            ("Send an SMS — Quickstart", "https://developers.telnyx.com/docs/messaging/messages/send-message"),
+            ("Messaging API Reference", "https://developers.telnyx.com/api-reference/messages/send-a-message"),
+        ],
+        "dotcom": [
+            ("Telnyx SMS API", "https://telnyx.com/products/sms-api"),
+            ("Messaging Pricing", "https://telnyx.com/pricing/messaging"),
+        ],
+    },
+    "voice": {
+        "docs": [
+            ("Voice API Overview", "https://developers.telnyx.com/docs/voice"),
+            ("Voice API Commands", "https://developers.telnyx.com/docs/voice/programmable-voice/voice-api-commands-and-resources"),
+            ("AI Assistant Start", "https://developers.telnyx.com/docs/voice/programmable-voice/ai-assistant-start"),
+            ("Call Control API Reference", "https://developers.telnyx.com/api-reference/call-commands/dial"),
+        ],
+        "dotcom": [
+            ("Telnyx Voice API", "https://telnyx.com/products/voice-api"),
+            ("Voice AI Agents", "https://telnyx.com/products/voice-ai-agents"),
+        ],
+    },
+    "ai": {
+        "docs": [
+            ("AI Assistants Guide", "https://developers.telnyx.com/docs/inference/ai-assistants/no-code-voice-assistant"),
+            ("Assistants API Reference", "https://developers.telnyx.com/api-reference/assistants/create-an-assistant"),
+        ],
+        "dotcom": [
+            ("Telnyx AI Assistants", "https://telnyx.com/ai-assistants"),
+            ("Voice AI Agents", "https://telnyx.com/products/voice-ai-agents"),
+        ],
+    },
+    "sip": {
+        "docs": [
+            ("SIP Trunking Get Started", "https://developers.telnyx.com/docs/voice/sip-trunking/get-started"),
+            ("SIP Configuration Guides", "https://developers.telnyx.com/docs/voice/sip-trunking/configuration-guides"),
+        ],
+        "dotcom": [
+            ("Telnyx SIP Trunks", "https://telnyx.com/products/sip-trunks"),
+            ("SIP Trunking Pricing", "https://telnyx.com/pricing/elastic-sip"),
+        ],
+    },
+    "iot": {
+        "docs": [
+            ("IoT SIM Get Started", "https://developers.telnyx.com/docs/iot-sim/get-started"),
+            ("SIM Card API Reference", "https://developers.telnyx.com/api-reference/sim-cards/get-all-sim-cards"),
+        ],
+        "dotcom": [
+            ("Telnyx IoT SIM Cards", "https://telnyx.com/products/iot-sim-card"),
+            ("IoT Data Plans Pricing", "https://telnyx.com/pricing/iot-data-plans"),
+        ],
+    },
+}
+
+LANG_SDK_URL = {
+    "python": ("Python SDK", "https://developers.telnyx.com/development/sdk/python"),
+    "nodejs": ("Node.js SDK", "https://developers.telnyx.com/development/sdk/node"),
+    "ruby":   ("Ruby SDK", "https://developers.telnyx.com/development/sdk/ruby"),
+    "go":     ("Go SDK", "https://developers.telnyx.com/development/sdk/go"),
+}
+
 # Code block language tags for extraction
 LANG_CODE_TAGS = {
     "python": ["python"],
@@ -632,6 +695,23 @@ def _get_version_answer(language: str) -> str:
     return versions.get(language, "See the Prerequisites section.")
 
 
+def build_resources(product: str, language: str) -> str:
+    """Generate a Resources section with links to Dev Docs, SDK, and product pages."""
+    links = PRODUCT_LINKS.get(product, {})
+    sdk = LANG_SDK_URL.get(language)
+    items = []
+    for label, url in links.get("docs", []):
+        items.append(f"- [{label}]({url})")
+    if sdk:
+        items.append(f"- [{sdk[0]}]({sdk[1]})")
+    for label, url in links.get("dotcom", []):
+        items.append(f"- [{label}]({url})")
+    lines = ["## Resources", ""]
+    lines.extend(items)
+    lines.append("")
+    return "\n".join(lines)
+
+
 def build_related_examples(sections: dict, product: str, language: str) -> str:
     """Build the Related Examples section from TF Next Steps."""
     next_steps = sections.get("next steps", "")
@@ -687,6 +767,7 @@ def restructure_readme(
         troubleshooting,
         "",
         build_faq(title, product, language, framework),
+        build_resources(product, language),
         build_related_examples(sections, product, language),
     ]
 

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -602,9 +602,9 @@ def build_why_telnyx() -> str:
     """Generate the standard 'Why Telnyx?' section."""
     return """## Why Telnyx?
 
-Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for [voice](https://telnyx.com/products/voice-ai-agents), [messaging](https://telnyx.com/products/sms-api), [SIP](https://telnyx.com/products/sip-trunks), [AI](https://telnyx.com/ai-assistants), and [IoT](https://telnyx.com/products/iot-sim-card) — no Frankenstack required.
 
-- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Integrated platform** — [Voice](https://telnyx.com/products/voice-ai-agents), [SMS](https://telnyx.com/products/sms-api), [SIP trunking](https://telnyx.com/products/sip-trunks), [AI assistants](https://telnyx.com/ai-assistants), and [IoT SIM management](https://telnyx.com/products/iot-sim-card) under one roof. No stitching together multiple vendors.
 - **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
 - **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
 - **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -657,6 +657,7 @@ def restructure_readme(
     overview = sections.get("overview", "")
     prerequisites = sections.get("prerequisites", "")
     implementation = sections.get("step 3: implementation", sections.get("step 3", ""))
+    implementation = sanitize_code(implementation, language)
     troubleshooting = sections.get("troubleshooting", "")
 
     parts = [

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -192,6 +192,16 @@ def extract_complete_code(sections: dict, language: str) -> str:
     return all_blocks[0].strip() if all_blocks else ""
 
 
+def sanitize_code(code: str, language: str) -> str:
+    """Apply security post-processing to extracted code."""
+    if language == "python":
+        code = code.replace(
+            "app.run(debug=True, port=5000)",
+            'app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)',
+        )
+    return code
+
+
 def extract_env_vars(code: str, language: str) -> list[str]:
     """Extract environment variable names from code."""
     env_vars = set()
@@ -341,6 +351,9 @@ RUN pip install --no-cache-dir -r {dep_file}
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE {port}
 
 CMD ["python", "{code_file}"]
@@ -354,6 +367,8 @@ COPY package.json .
 RUN npm install --production
 
 COPY . .
+
+USER node
 
 EXPOSE {port}
 
@@ -374,6 +389,9 @@ FROM alpine:3.19
 WORKDIR /app
 COPY --from=builder /app/server .
 
+RUN adduser -D appuser
+USER appuser
+
 EXPOSE {port}
 
 CMD ["./server"]
@@ -388,6 +406,9 @@ RUN bundle install
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE {port}
 
 CMD ["ruby", "{code_file}"]
@@ -396,6 +417,8 @@ CMD ["ruby", "{code_file}"]
         return f"""FROM python:3.12-slim
 WORKDIR /app
 COPY . .
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
 EXPOSE {port}
 CMD ["python", "{code_file}"]
 """
@@ -686,6 +709,7 @@ def transform(
 
     # 1. Extract and write code file
     code = extract_complete_code(sections, language)
+    code = sanitize_code(code, language)
     if code:
         (folder_path / code_file).write_text(code + "\n")
     else:

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -195,9 +195,36 @@ def extract_complete_code(sections: dict, language: str) -> str:
 def sanitize_code(code: str, language: str) -> str:
     """Apply security post-processing to extracted code."""
     if language == "python":
+        # Fix debug=True
         code = code.replace(
             "app.run(debug=True, port=5000)",
             'app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)',
+        )
+        # Fix exception info exposure — don't leak str(e) in HTTP responses.
+        # Pattern: jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        code = code.replace(
+            'return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code',
+            'return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code',
+        )
+        # Pattern: jsonify({"error": str(e)}), e.status_code
+        code = code.replace(
+            'return jsonify({"error": str(e)}), e.status_code',
+            'return jsonify({"error": "API request failed"}), e.status_code',
+        )
+        # Pattern: jsonify({"error": str(e)}), 400
+        code = code.replace(
+            'return jsonify({"error": str(e)}), 400',
+            'return jsonify({"error": "Invalid request"}), 400',
+        )
+        # Pattern: jsonify({"error": f"Unexpected error: {str(e)}"}), 500
+        code = code.replace(
+            'return jsonify({"error": f"Unexpected error: {str(e)}"}), 500',
+            'return jsonify({"error": "Internal server error"}), 500',
+        )
+        # Pattern: jsonify({"error": str(e)}), 500
+        code = code.replace(
+            'return jsonify({"error": str(e)}), 500',
+            'return jsonify({"error": "Internal server error"}), 500',
         )
     return code
 

--- a/send-sms-nodejs/.env.example
+++ b/send-sms-nodejs/.env.example
@@ -1,0 +1,5 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+PORT=5000
+TELNYX_PHONE_NUMBER=+15551234567

--- a/send-sms-nodejs/Dockerfile
+++ b/send-sms-nodejs/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY package.json .
+RUN npm install --production
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/send-sms-nodejs/Dockerfile
+++ b/send-sms-nodejs/Dockerfile
@@ -7,6 +7,8 @@ RUN npm install --production
 
 COPY . .
 
+USER node
+
 EXPOSE 3000
 
 CMD ["node", "server.js"]

--- a/send-sms-nodejs/Makefile
+++ b/send-sms-nodejs/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	npm install
+
+run:
+	node server.js
+
+test:
+	node --check server.js
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 3000:3000 $$(basename $$(pwd))

--- a/send-sms-nodejs/README.md
+++ b/send-sms-nodejs/README.md
@@ -57,7 +57,7 @@ See the [Implementation Details](#implementation-details) section below for step
 
 ## Implementation Details
 
-Create `app.js` and initialize the Telnyx client using the new pattern. Define a helper function to handle message creation with proper validation:
+Create `server.js` and initialize the Telnyx client using the new pattern. Define a helper function to handle message creation with proper validation:
 
 ```javascript
 const Telnyx = require("telnyx");
@@ -112,7 +112,7 @@ See [`server.js`](./server.js) for the full implementation.
 |-------|---------|----------|
 | Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Express server. |
 | Invalid Phone Number Format | You receive a 400 error stating "Phone number must be in E.164 format" or a Telnyx API error about invalid destination. | Ensure all phone numbers use E.164 format: start with `+`, followed by country code and number without spaces or dashes. Example: `+15551234567` (US) or `+447700900123` (UK). Update your test curl command to use properly formatted numbers. |
-| Environment Variable Not Set | The application raises an error about `TELNYX_PHONE_NUMBER` or `TELNYX_API_KEY` not being set. | Confirm your `.env` file exists in the same directory as `app.js` and contains both variables. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `require("dotenv").config()` call must execute before `process.env` is accessed—verify this import order at the top of your code. |
+| Environment Variable Not Set | The application raises an error about `TELNYX_PHONE_NUMBER` or `TELNYX_API_KEY` not being set. | Confirm your `.env` file exists in the same directory as `server.js` and contains both variables. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `require("dotenv").config()` call must execute before `process.env` is accessed—verify this import order at the top of your code. |
 
 ## FAQ
 

--- a/send-sms-nodejs/README.md
+++ b/send-sms-nodejs/README.md
@@ -1,0 +1,143 @@
+# Send Single SMS with Node.js and Express
+
+## What Does This Example Do?
+
+Build a production-ready Express endpoint that sends SMS messages using the Telnyx Node.js SDK. This tutorial demonstrates the new client-based initialization pattern, proper error handling for telecom APIs, and secure credential management via environment variables.
+
+## Who Is This For?
+
+- **Node.js developers** building sms features with Express.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Node.js 14 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- A Telnyx phone number enabled for outbound SMS.
+- npm (Node Package Manager).
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/send-sms-nodejs
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/send-sms-nodejs
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.js` and initialize the Telnyx client using the new pattern. Define a helper function to handle message creation with proper validation:
+
+```javascript
+const Telnyx = require("telnyx");
+require("dotenv").config();
+
+// Initialize client with the new SDK pattern
+const client = new Telnyx({ apiKey: process.env.TELNYX_API_KEY });
+
+async function sendSms(toNumber, message) {
+  /**
+   * Send SMS via Telnyx and return JSON-serializable response data.
+   * Throws errors for invalid input or API failures.
+   */
+  const fromNumber = process.env.TELNYX_PHONE_NUMBER;
+  if (!fromNumber) {
+    throw new Error("TELNYX_PHONE_NUMBER environment variable not set");
+  }
+
+  // Validate E.164 format to prevent API errors
+  if (!toNumber.startsWith("+")) {
+    throw new Error(
+      "Phone number must be in E.164 format (e.g., +15551234567)"
+    );
+  }
+
+  // Use client.messages.create() to send the SMS
+  const response = await client.messages.create({
+    from_: fromNumber,
+    to: toNumber,
+    text: message,
+  });
+
+  // Extract serializable data — SDK objects are NOT JSON-serializable
+  return {
+    message_id: response.data.id,
+    status: response.data.to && response.data.to[0] ? response.data.to[0].status : "unknown",
+    from: fromNumber,
+    to: toNumber,
+  };
+}
+
+module.exports = { sendSms, client };
+```
+
+## Complete Code
+
+See [`server.js`](./server.js) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Express server. |
+| Invalid Phone Number Format | You receive a 400 error stating "Phone number must be in E.164 format" or a Telnyx API error about invalid destination. | Ensure all phone numbers use E.164 format: start with `+`, followed by country code and number without spaces or dashes. Example: `+15551234567` (US) or `+447700900123` (UK). Update your test curl command to use properly formatted numbers. |
+| Environment Variable Not Set | The application raises an error about `TELNYX_PHONE_NUMBER` or `TELNYX_API_KEY` not being set. | Confirm your `.env` file exists in the same directory as `app.js` and contains both variables. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `require("dotenv").config()` call must execute before `process.env` is accessed—verify this import order at the top of your code. |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this SMS example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Node.js version do I need?**
+
+Node.js 18 or higher. Node.js 20 LTS is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Receive SMS Webhooks with Node.js](/tutorials/sms/nodejs/receive-sms-webhook).
+- [Send Bulk SMS Messages](/tutorials/sms/nodejs/send-bulk-sms).
+- [Implement Two-Factor Authentication with SMS](/tutorials/sms/nodejs/otp-2fa).

--- a/send-sms-nodejs/README.md
+++ b/send-sms-nodejs/README.md
@@ -57,7 +57,7 @@ See the [Implementation Details](#implementation-details) section below for step
 
 ## Implementation Details
 
-Create `server.js` and initialize the Telnyx client using the new pattern. Define a helper function to handle message creation with proper validation:
+Create `app.js` and initialize the Telnyx client using the new pattern. Define a helper function to handle message creation with proper validation:
 
 ```javascript
 const Telnyx = require("telnyx");
@@ -112,7 +112,7 @@ See [`server.js`](./server.js) for the full implementation.
 |-------|---------|----------|
 | Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Express server. |
 | Invalid Phone Number Format | You receive a 400 error stating "Phone number must be in E.164 format" or a Telnyx API error about invalid destination. | Ensure all phone numbers use E.164 format: start with `+`, followed by country code and number without spaces or dashes. Example: `+15551234567` (US) or `+447700900123` (UK). Update your test curl command to use properly formatted numbers. |
-| Environment Variable Not Set | The application raises an error about `TELNYX_PHONE_NUMBER` or `TELNYX_API_KEY` not being set. | Confirm your `.env` file exists in the same directory as `server.js` and contains both variables. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `require("dotenv").config()` call must execute before `process.env` is accessed—verify this import order at the top of your code. |
+| Environment Variable Not Set | The application raises an error about `TELNYX_PHONE_NUMBER` or `TELNYX_API_KEY` not being set. | Confirm your `.env` file exists in the same directory as `app.js` and contains both variables. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `require("dotenv").config()` call must execute before `process.env` is accessed—verify this import order at the top of your code. |
 
 ## FAQ
 
@@ -135,6 +135,15 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 **Q: Where do I get a Telnyx phone number?**
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Resources
+
+- [Messaging Overview](https://developers.telnyx.com/docs/messaging)
+- [Send an SMS — Quickstart](https://developers.telnyx.com/docs/messaging/messages/send-message)
+- [Messaging API Reference](https://developers.telnyx.com/api-reference/messages/send-a-message)
+- [Node.js SDK](https://developers.telnyx.com/development/sdk/node)
+- [Telnyx SMS API](https://telnyx.com/products/sms-api)
+- [Messaging Pricing](https://telnyx.com/pricing/messaging)
 
 ## Related Examples
 

--- a/send-sms-nodejs/package.json
+++ b/send-sms-nodejs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "telnyx-example",
+  "version": "1.0.0",
+  "description": "Telnyx API example",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --check server.js"
+  },
+  "dependencies": {
+    "telnyx": "latest",
+    "express": "latest",
+    "dotenv": "latest"
+  }
+}

--- a/send-sms-nodejs/server.js
+++ b/send-sms-nodejs/server.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Production-ready Express endpoint for sending SMS via Telnyx.
+ * Usage: node app.js
+ */
+
+const express = require("express");
+const Telnyx = require("telnyx");
+require("dotenv").config();
+
+// Initialize client with the new SDK pattern
+const client = new Telnyx({ apiKey: process.env.TELNYX_API_KEY });
+
+async function sendSms(toNumber, message) {
+  /**
+   * Send SMS via Telnyx and return JSON-serializable response data.
+   * Throws errors for invalid input or API failures.
+   */
+  const fromNumber = process.env.TELNYX_PHONE_NUMBER;
+  if (!fromNumber) {
+    throw new Error("TELNYX_PHONE_NUMBER environment variable not set");
+  }
+
+  // Validate E.164 format to prevent API errors
+  if (!toNumber.startsWith("+")) {
+    throw new Error(
+      "Phone number must be in E.164 format (e.g., +15551234567)"
+    );
+  }
+
+  // Use client.messages.create() to send the SMS
+  const response = await client.messages.create({
+    from_: fromNumber,
+    to: toNumber,
+    text: message,
+  });
+
+  // Extract serializable data — SDK objects are NOT JSON-serializable
+  return {
+    message_id: response.data.id,
+    status: response.data.to && response.data.to[0] ? response.data.to[0].status : "unknown",
+    from: fromNumber,
+    to: toNumber,
+  };
+}
+
+const app = express();
+app.use(express.json());
+
+app.post("/sms/send", async (req, res) => {
+  /**
+   * HTTP endpoint to send single SMS.
+   * Expects JSON body with 'to' and 'message' fields.
+   */
+  const { to, message } = req.body;
+
+  // Validate required fields
+  if (!to || !message) {
+    return res
+      .status(400)
+      .json({ error: "Missing required fields: 'to' and 'message'" });
+  }
+
+  try {
+    const result = await sendSms(to, message);
+    return res.status(200).json(result);
+  } catch (error) {
+    // Handle Telnyx-specific errors with appropriate HTTP status codes
+    if (error instanceof Telnyx.AuthenticationError) {
+      return res.status(401).json({ error: "Invalid API key" });
+    }
+    if (error instanceof Telnyx.RateLimitError) {
+      return res
+        .status(429)
+        .json({ error: "Rate limit exceeded. Please slow down." });
+    }
+    if (error instanceof Telnyx.APIStatusError) {
+      return res
+        .status(error.status_code || 500)
+        .json({ error: error.message, status_code: error.status_code });
+    }
+    if (error instanceof Telnyx.APIConnectionError) {
+      return res
+        .status(503)
+        .json({ error: "Network error connecting to Telnyx" });
+    }
+    // Handle validation errors (from sendSms helper)
+    if (error.message.includes("E.164") || error.message.includes("environment")) {
+      return res.status(400).json({ error: error.message });
+    }
+    // Catch-all for unexpected errors
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`SMS server running on http://localhost:${PORT}`);
+});

--- a/send-sms-python/.env.example
+++ b/send-sms-python/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+TELNYX_PHONE_NUMBER=+15551234567

--- a/send-sms-python/.env.example
+++ b/send-sms-python/.env.example
@@ -1,4 +1,5 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here
 TELNYX_PHONE_NUMBER=+15551234567

--- a/send-sms-python/Dockerfile
+++ b/send-sms-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/send-sms-python/Dockerfile
+++ b/send-sms-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/send-sms-python/Makefile
+++ b/send-sms-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/send-sms-python/README.md
+++ b/send-sms-python/README.md
@@ -1,0 +1,137 @@
+# Send Single SMS with Python and Flask
+
+## What Does This Example Do?
+
+Build a production-ready Flask endpoint that sends SMS messages using the Telnyx Python SDK. This tutorial demonstrates the new client-based initialization pattern, proper error handling for telecom APIs, and secure credential management via environment variables.
+
+## Who Is This For?
+
+- **Python developers** building sms features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher.
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com).
+- A Telnyx phone number enabled for outbound SMS.
+- pip (Python package manager).
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/send-sms-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/send-sms-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and initialize the Telnyx client using the new pattern. Define a helper function to handle message creation with proper validation:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def send_sms(to_number: str, message: str) -> dict:
+    """Send SMS via Telnyx and return JSON-serializable response data."""
+    from_number = os.getenv("TELNYX_PHONE_NUMBER")
+    if not from_number:
+        raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
+    
+    # Validate E.164 format to prevent API errors
+    if not to_number.startswith("+"):
+        raise ValueError("Phone number must be in E.164 format (e.g., +15551234567)")
+    
+    # Use client.messages.create() with proper parameters
+    response = client.messages.create(
+        from_=from_number,
+        to=to_number,
+        text=message,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "message_id": response.data.id,
+        "status": response.data.to[0].status if response.data.to else "unknown",
+        "from": from_number,
+        "to": to_number,
+    }
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+| Issue | Problem | Solution |
+|-------|---------|----------|
+| Authentication Error (401) | The endpoint returns `{"error": "Invalid API key"}` with HTTP 401. | Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Flask server. |
+| Invalid Phone Number Format | You receive a 400 error stating "Phone number must be in E.164 format" or a Telnyx API error about invalid destination. | Ensure all phone numbers use E.164 format: start with `+`, followed by country code and number without spaces or dashes. Example: `+15551234567` (US) or `+447700900123` (UK). Update your test curl command to use properly formatted numbers. |
+| Environment Variable Not Set | The application raises `ValueError: TELNYX_PHONE_NUMBER environment variable not set` on startup or first request. | Confirm your `.env` file exists in the same directory as `app.py` and contains the variable. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `load_dotenv()` call must execute before `os.getenv()` is called—verify this import order in your code. |
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this SMS example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Receive SMS Webhooks with Python](/tutorials/sms/python/receive-sms-webhook).
+- [Send Bulk SMS Messages](/tutorials/sms/python/send-bulk-sms).
+- [Implement Two-Factor Authentication with SMS](/tutorials/sms/python/otp-2fa).

--- a/send-sms-python/README.md
+++ b/send-sms-python/README.md
@@ -130,6 +130,15 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [Messaging Overview](https://developers.telnyx.com/docs/messaging)
+- [Send an SMS — Quickstart](https://developers.telnyx.com/docs/messaging/messages/send-message)
+- [Messaging API Reference](https://developers.telnyx.com/api-reference/messages/send-a-message)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx SMS API](https://telnyx.com/products/sms-api)
+- [Messaging Pricing](https://telnyx.com/pricing/messaging)
+
 ## Related Examples
 
 - [Receive SMS Webhooks with Python](/tutorials/sms/python/receive-sms-webhook).

--- a/send-sms-python/app.py
+++ b/send-sms-python/app.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Production-ready Flask endpoint for sending SMS via Telnyx."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def send_sms(to_number: str, message: str) -> dict:
+    """Send SMS via Telnyx and return JSON-serializable response data."""
+    from_number = os.getenv("TELNYX_PHONE_NUMBER")
+    if not from_number:
+        raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
+    
+    # Validate E.164 format to prevent API errors
+    if not to_number.startswith("+"):
+        raise ValueError("Phone number must be in E.164 format (e.g., +15551234567)")
+    
+    # Use client.messages.create() with proper parameters
+    response = client.messages.create(
+        from_=from_number,
+        to=to_number,
+        text=message,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "message_id": response.data.id,
+        "status": response.data.to[0].status if response.data.to else "unknown",
+        "from": from_number,
+        "to": to_number,
+    }
+
+
+@app.route("/sms/send", methods=["POST"])
+def send_sms_endpoint():
+    """HTTP endpoint to send single SMS."""
+    data = request.get_json()
+    
+    if not data:
+        return jsonify({"error": "Request body required"}), 400
+    
+    to_number = data.get("to")
+    message = data.get("message")
+    
+    if not to_number or not message:
+        return jsonify({"error": "Missing required fields: 'to' and 'message'"}), 400
+    
+    try:
+        result = send_sms(to_number, message)
+        return jsonify(result), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/send-sms-python/app.py
+++ b/send-sms-python/app.py
@@ -63,11 +63,11 @@ def send_sms_endpoint():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "Invalid request"}), 400
 
 
 if __name__ == "__main__":

--- a/send-sms-python/app.py
+++ b/send-sms-python/app.py
@@ -71,4 +71,4 @@ def send_sms_endpoint():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/send-sms-python/requirements.txt
+++ b/send-sms-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/send-sms-ruby/.env.example
+++ b/send-sms-ruby/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+TELNYX_PHONE_NUMBER=+15551234567

--- a/send-sms-ruby/Dockerfile
+++ b/send-sms-ruby/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:3.3-slim
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock* ./
+RUN bundle install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["ruby", "app.rb"]

--- a/send-sms-ruby/Dockerfile
+++ b/send-sms-ruby/Dockerfile
@@ -7,6 +7,9 @@ RUN bundle install
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 3000
 
 CMD ["ruby", "app.rb"]

--- a/send-sms-ruby/Gemfile
+++ b/send-sms-ruby/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "telnyx"
+gem "dotenv"
+gem "rails"

--- a/send-sms-ruby/Makefile
+++ b/send-sms-ruby/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	bundle install
+
+run:
+	ruby app.rb
+
+test:
+	ruby -c app.rb
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 3000:3000 $$(basename $$(pwd))

--- a/send-sms-ruby/README.md
+++ b/send-sms-ruby/README.md
@@ -173,6 +173,15 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [Messaging Overview](https://developers.telnyx.com/docs/messaging)
+- [Send an SMS — Quickstart](https://developers.telnyx.com/docs/messaging/messages/send-message)
+- [Messaging API Reference](https://developers.telnyx.com/api-reference/messages/send-a-message)
+- [Ruby SDK](https://developers.telnyx.com/development/sdk/ruby)
+- [Telnyx SMS API](https://telnyx.com/products/sms-api)
+- [Messaging Pricing](https://telnyx.com/pricing/messaging)
+
 ## Related Examples
 
 - [Receive SMS Webhooks with Ruby](/tutorials/sms/ruby/receive-sms-webhook)

--- a/send-sms-ruby/README.md
+++ b/send-sms-ruby/README.md
@@ -1,0 +1,180 @@
+# Send a Single SMS with Ruby on Rails
+
+## What Does This Example Do?
+
+Build a production-ready Rails API endpoint that sends SMS messages using the Telnyx Ruby SDK. This tutorial demonstrates the new client-based initialization pattern, proper error handling for telecom APIs, and secure credential management via environment variables.
+
+## Who Is This For?
+
+- **Ruby developers** building sms features with Rails.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Ruby 3.0 or higher
+- Rails 7.0 or higher
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com)
+- A Telnyx phone number enabled for outbound SMS
+- Bundler (Ruby package manager)
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/send-sms-ruby
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/send-sms-ruby
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Generate a controller to handle SMS operations:
+
+```bash
+rails generate controller Sms send_sms --skip-assets --skip-helper
+```
+
+Open `app/controllers/sms_controller.rb` and implement the endpoint with proper validation and error handling:
+
+```ruby
+class SmsController < ApplicationController
+  # Initialize client per request to ensure fresh connection
+  before_action :initialize_client
+
+  def send_sms
+    to_number = params[:to]
+    message = params[:message]
+
+    # Validate presence of required fields
+    unless to_number.present? && message.present?
+      return render json: { error: "Missing required fields: 'to' and 'message'" }, status: :bad_request
+    end
+
+    # Validate E.164 format to prevent API errors
+    unless to_number.start_with?("+")
+      return render json: { error: "Phone number must be in E.164 format (e.g., +15551234567)" }, status: :bad_request
+    end
+
+    from_number = ENV["TELNYX_PHONE_NUMBER"]
+    unless from_number
+      return render json: { error: "TELNYX_PHONE_NUMBER environment variable not set" }, status: :internal_server_error
+    end
+
+    begin
+      # Use client.messages.create() — NOT Telnyx::Message.create()
+      response = @client.messages.create(
+        from_: from_number,
+        to: to_number,
+        text: message
+      )
+
+      # Extract serializable data — do not return raw response object
+      render json: {
+        message_id: response.data.id,
+        status: response.data.to.first&.status || "unknown",
+        from: from_number,
+        to: to_number
+      }, status: :ok
+
+    rescue Telnyx::AuthenticationError
+      render json: { error: "Invalid API key" }, status: :unauthorized
+    rescue Telnyx::RateLimitError
+      render json: { error: "Rate limit exceeded. Please slow down." }, status: :too_many_requests
+    rescue Telnyx::APIStatusError => e
+      # e.status_code contains the HTTP status from Telnyx
+      render json: { error: e.message, status_code: e.status_code }, status: e.status_code
+    rescue Telnyx::APIConnectionError
+      render json: { error: "Network error connecting to Telnyx" }, status: :service_unavailable
+    end
+  end
+
+  private
+
+  def initialize_client
+    # Initialize client using new pattern — NOT Telnyx.api_key = ...
+    @client = Telnyx::Client.new(api_key: ENV["TELNYX_API_KEY"])
+  end
+end
+```
+
+## Complete Code
+
+See [`app.rb`](./app.rb) for the full implementation.
+
+## Troubleshooting
+
+### Issue 1: Authentication Error (401)
+
+**Problem:** The endpoint returns `{"error": "Invalid API key"}` with HTTP 401.
+
+**Solution:** Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. Restart the Rails server after updating environment variables, as they are loaded at boot time.
+
+### Issue 2: Invalid Phone Number Format
+
+**Problem:** You receive a 400 error stating "Phone number must be in E.164 format" or a Telnyx API error about invalid destination.
+
+**Solution:** Ensure all phone numbers use E.164 format: start with `+`, followed by country code and number without spaces or dashes. Example: `+15551234567` (US) or `+447700900123` (UK). Update your test curl command to use properly formatted numbers.
+
+### Issue 3: uninitialized constant Telnyx::Client
+
+**Problem:** Rails raises `NameError: uninitialized constant Telnyx::Client` when processing a request.
+
+**Solution:** Ensure the `telnyx` gem is included in your `Gemfile` and you have run `bundle install`. If the error persists, verify the gem is not restricted to a specific group (like `:production`) that your current environment doesn't match. Restart the Rails server after modifying the Gemfile.
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this SMS example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Ruby version do I need?**
+
+Ruby 3.1 or higher. Ruby 3.3 is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Receive SMS Webhooks with Ruby](/tutorials/sms/ruby/receive-sms-webhook)
+- [Send Bulk SMS with Ruby](/tutorials/sms/ruby/send-bulk-sms)
+- [Implement Two-Factor Authentication with Ruby](/tutorials/sms/ruby/otp-2fa)

--- a/send-sms-ruby/app.rb
+++ b/send-sms-ruby/app.rb
@@ -1,0 +1,59 @@
+# app/controllers/sms_controller.rb
+class SmsController < ApplicationController
+  # Initialize client per request to ensure fresh connection
+  before_action :initialize_client
+
+  def send_sms
+    to_number = params[:to]
+    message = params[:message]
+
+    # Validate presence of required fields
+    unless to_number.present? && message.present?
+      return render json: { error: "Missing required fields: 'to' and 'message'" }, status: :bad_request
+    end
+
+    # Validate E.164 format to prevent API errors
+    unless to_number.start_with?("+")
+      return render json: { error: "Phone number must be in E.164 format (e.g., +15551234567)" }, status: :bad_request
+    end
+
+    from_number = ENV["TELNYX_PHONE_NUMBER"]
+    unless from_number
+      return render json: { error: "TELNYX_PHONE_NUMBER environment variable not set" }, status: :internal_server_error
+    end
+
+    begin
+      # Use client.messages.create() — NOT Telnyx::Message.create()
+      response = @client.messages.create(
+        from_: from_number,
+        to: to_number,
+        text: message
+      )
+
+      # Extract serializable data — do not return raw response object
+      render json: {
+        message_id: response.data.id,
+        status: response.data.to.first&.status || "unknown",
+        from: from_number,
+        to: to_number
+      }, status: :ok
+
+    rescue Telnyx::AuthenticationError
+      render json: { error: "Invalid API key" }, status: :unauthorized
+    rescue Telnyx::RateLimitError
+      render json: { error: "Rate limit exceeded. Please slow down." }, status: :too_many_requests
+    rescue Telnyx::APIStatusError => e
+      # e.status_code contains the HTTP status from Telnyx
+      render json: { error: e.message, status_code: e.status_code }, status: e.status_code
+    rescue Telnyx::APIConnectionError
+      render json: { error: "Network error connecting to Telnyx" }, status: :service_unavailable
+    end
+  end
+
+  private
+
+  def initialize_client
+    # Initialize client using new pattern — NOT Telnyx.api_key = ...
+    @client = Telnyx::Client.new(api_key: ENV["TELNYX_API_KEY"])
+  end
+end

--- a/setup-sip-trunk-python/.env.example
+++ b/setup-sip-trunk-python/.env.example
@@ -1,0 +1,3 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here

--- a/setup-sip-trunk-python/.env.example
+++ b/setup-sip-trunk-python/.env.example
@@ -1,3 +1,4 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here

--- a/setup-sip-trunk-python/Dockerfile
+++ b/setup-sip-trunk-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/setup-sip-trunk-python/Dockerfile
+++ b/setup-sip-trunk-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/setup-sip-trunk-python/Makefile
+++ b/setup-sip-trunk-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/setup-sip-trunk-python/README.md
+++ b/setup-sip-trunk-python/README.md
@@ -1,0 +1,144 @@
+# Set Up SIP Trunking with Python and Flask
+
+## What Does This Example Do?
+
+Build a production-ready Flask endpoint that sets up SIP trunking using the Telnyx Python SDK. This tutorial demonstrates the new client-based initialization pattern, proper error handling for telecom APIs, and secure credential management via environment variables.
+
+## Who Is This For?
+
+- **Python developers** building sip features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com)
+- A Telnyx phone number enabled for outbound voice
+- pip (Python package manager)
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/setup-sip-trunk-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/setup-sip-trunk-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` and initialize the Telnyx client using the new pattern. Define a helper function to handle SIP connection creation with proper validation:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def create_sip_connection(name: str, username: str, password: str) -> dict:
+    """Create SIP connection via Telnyx and return JSON-serializable response data."""
+    # Validate input to prevent API errors
+    if not name or not username or not password:
+        raise ValueError("Name, username, and password are required")
+    
+    # Use client.sip_connections.create() — NOT client.sip_connections.create()
+    response = client.sip_connections.create(
+        name=name,
+        username=username,
+        password=password,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "id": response.data.id,
+        "name": response.data.name,
+        "username": response.data.username,
+    }
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+### Issue 1: Authentication Error (401)
+
+**Problem:** The endpoint returns `{"error": "Invalid API key"}` with HTTP 401.
+
+**Solution:** Verify your `TELNYX_API_KEY` in the `.env` file matches the key shown in the [Telnyx Portal](https://portal.telnyx.com). Ensure there are no trailing spaces or quotes. If the key was regenerated recently, update your environment file and restart the Flask server.
+
+### Issue 2: Invalid Input
+
+**Problem:** You receive a 400 error stating "Missing required fields: 'name', 'username', and 'password'" or "Name, username, and password are required".
+
+**Solution:** Ensure your request body contains all required fields (`name`, `username`, and `password`) and that they are not empty. Update your test curl command to include valid input.
+
+### Issue 3: Environment Variable Not Set
+
+**Problem:** The application raises `ValueError: TELNYX_API_KEY environment variable not set` on startup or first request.
+
+**Solution:** Confirm your `.env` file exists in the same directory as `app.py` and contains the variable. Ensure the file is named exactly `.env` (not `.env.txt` or `env`). The `load_dotenv()` call must execute before `os.getenv()` is called—verify this import order in your code.
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this SIP example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Configure Outbound SIP Calls](/tutorials/sip/python/outbound-sip-call)
+- [Implement Inbound SIP Routing](/tutorials/sip/python/inbound-sip-routing)
+- [Set Up SIP Authentication](/tutorials/sip/python/sip-authentication)

--- a/setup-sip-trunk-python/README.md
+++ b/setup-sip-trunk-python/README.md
@@ -137,6 +137,14 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [SIP Trunking Get Started](https://developers.telnyx.com/docs/voice/sip-trunking/get-started)
+- [SIP Configuration Guides](https://developers.telnyx.com/docs/voice/sip-trunking/configuration-guides)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx SIP Trunks](https://telnyx.com/products/sip-trunks)
+- [SIP Trunking Pricing](https://telnyx.com/pricing/elastic-sip)
+
 ## Related Examples
 
 - [Configure Outbound SIP Calls](/tutorials/sip/python/outbound-sip-call)

--- a/setup-sip-trunk-python/app.py
+++ b/setup-sip-trunk-python/app.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Production-ready Flask endpoint for setting up SIP trunking via Telnyx."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def create_sip_connection(name: str, username: str, password: str) -> dict:
+    """Create SIP connection via Telnyx and return JSON-serializable response data."""
+    # Validate input to prevent API errors
+    if not name or not username or not password:
+        raise ValueError("Name, username, and password are required")
+    
+    # Use client.sip_connections.create() — NOT client.sip_connections.create()
+    response = client.sip_connections.create(
+        name=name,
+        username=username,
+        password=password,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "id": response.data.id,
+        "name": response.data.name,
+        "username": response.data.username,
+    }
+
+
+@app.route("/sip/setup", methods=["POST"])
+def setup_sip_endpoint():
+    """HTTP endpoint to set up SIP trunking."""
+    data = request.get_json()
+    
+    if not data:
+        return jsonify({"error": "Request body required"}), 400
+    
+    name = data.get("name")
+    username = data.get("username")
+    password = data.get("password")
+    
+    if not name or not username or not password:
+        return jsonify({"error": "Missing required fields: 'name', 'username', and 'password'"}), 400
+    
+    try:
+        result = create_sip_connection(name, username, password)
+        return jsonify(result), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/setup-sip-trunk-python/app.py
+++ b/setup-sip-trunk-python/app.py
@@ -67,4 +67,4 @@ def setup_sip_endpoint():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/setup-sip-trunk-python/app.py
+++ b/setup-sip-trunk-python/app.py
@@ -59,11 +59,11 @@ def setup_sip_endpoint():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e), "status_code": e.status_code}), e.status_code
+        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "Invalid request"}), 400
 
 
 if __name__ == "__main__":

--- a/setup-sip-trunk-python/requirements.txt
+++ b/setup-sip-trunk-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx

--- a/sms-auto-reply-bot-python/.env.example
+++ b/sms-auto-reply-bot-python/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API credentials — get yours at https://portal.telnyx.com
+
+TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+TELNYX_PHONE_NUMBER=+15551234567

--- a/sms-auto-reply-bot-python/.env.example
+++ b/sms-auto-reply-bot-python/.env.example
@@ -1,4 +1,5 @@
 # Telnyx API credentials — get yours at https://portal.telnyx.com
 
 TELNYX_API_KEY=KEY_your_telnyx_api_key_here
+FLASK_DEBUG=your_flask_debug_here
 TELNYX_PHONE_NUMBER=+15551234567

--- a/sms-auto-reply-bot-python/Dockerfile
+++ b/sms-auto-reply-bot-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/sms-auto-reply-bot-python/Dockerfile
+++ b/sms-auto-reply-bot-python/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -r appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/sms-auto-reply-bot-python/Makefile
+++ b/sms-auto-reply-bot-python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup run test docker-build docker-run
+
+setup:
+	pip install -r requirements.txt
+
+run:
+	python app.py
+
+test:
+	python -m py_compile app.py
+
+docker-build:
+	docker build -t $$(basename $$(pwd)) .
+
+docker-run:
+	docker run --env-file .env -p 5000:5000 $$(basename $$(pwd))

--- a/sms-auto-reply-bot-python/README.md
+++ b/sms-auto-reply-bot-python/README.md
@@ -182,6 +182,15 @@ Telnyx is an AI Communications Infrastructure platform with a private global net
 
 Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
 
+## Resources
+
+- [Messaging Overview](https://developers.telnyx.com/docs/messaging)
+- [Send an SMS — Quickstart](https://developers.telnyx.com/docs/messaging/messages/send-message)
+- [Messaging API Reference](https://developers.telnyx.com/api-reference/messages/send-a-message)
+- [Python SDK](https://developers.telnyx.com/development/sdk/python)
+- [Telnyx SMS API](https://telnyx.com/products/sms-api)
+- [Messaging Pricing](https://telnyx.com/pricing/messaging)
+
 ## Related Examples
 
 - [Receive SMS Webhooks with Python](/tutorials/sms/python/receive-sms-webhook)

--- a/sms-auto-reply-bot-python/README.md
+++ b/sms-auto-reply-bot-python/README.md
@@ -1,0 +1,189 @@
+# Build an SMS Autoresponder with Python and Flask
+
+## What Does This Example Do?
+
+Create a production-ready SMS autoresponder that automatically replies to incoming messages using Telnyx webhooks and the Python SDK. This tutorial demonstrates webhook handling, message processing, and intelligent response generation with proper error handling and security practices.
+
+## Who Is This For?
+
+- **Python developers** building sms features with Flask.
+- **Backend engineers** integrating telephony or messaging into existing applications.
+- **DevOps teams** looking for containerized, production-ready telecom examples.
+- **Startups and enterprises** replacing legacy telecom providers with a modern API-first platform.
+
+## Why Telnyx?
+
+Telnyx is an **AI Communications Infrastructure** platform that gives developers a single API for voice, messaging, SIP, AI, and IoT — no Frankenstack required.
+
+- **Integrated platform** — Voice, SMS, SIP trunking, AI assistants, and IoT SIM management under one roof. No stitching together multiple vendors.
+- **Global private network** — Calls and messages traverse the Telnyx-owned IP network for lower latency and higher reliability than the public internet.
+- **Developer-first** — SDKs for Python, Node.js, Go, Ruby, Java, and PHP. Comprehensive webhook event model. Sandbox environment for testing.
+- **Competitive pricing** — Pay-as-you-go with no minimums, contracts, or per-seat fees.
+
+## Prerequisites
+
+- Python 3.8 or higher
+- A Telnyx account with an active API key from the [Telnyx Portal](https://portal.telnyx.com)
+- A Telnyx phone number enabled for SMS
+- A publicly accessible URL for webhooks (use ngrok for local development)
+- pip (Python package manager)
+
+## Quick Start
+
+### Option 1: Local (recommended)
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/sms-auto-reply-bot-python
+cp .env.example .env
+# Edit .env with your Telnyx API key and phone number
+make setup
+make run
+```
+
+### Option 2: Docker
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/sms-auto-reply-bot-python
+cp .env.example .env
+# Edit .env with your credentials
+make docker-build
+make docker-run
+```
+
+### Option 3: Manual
+
+See the [Implementation Details](#implementation-details) section below for step-by-step instructions.
+
+## Implementation Details
+
+Create `app.py` with the autoresponder logic. The system will analyze incoming messages and generate contextual responses:
+
+```python
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify
+import re
+from datetime import datetime
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def generate_response(incoming_message: str, sender_number: str) -> str:
+    """Generate contextual response based on incoming message content."""
+    message_lower = incoming_message.lower().strip()
+    
+    # Business hours check
+    current_hour = datetime.now().hour
+    is_business_hours = 9 <= current_hour <= 17
+    
+    # Keyword-based responses
+    if any(word in message_lower for word in ['help', 'support', 'assistance']):
+        if is_business_hours:
+            return "Hi! Our support team is available now. Please call (555) 123-4567 or visit our website for immediate assistance."
+        else:
+            return "Thanks for reaching out! Our support hours are 9 AM - 5 PM. We'll respond first thing tomorrow morning."
+    
+    elif any(word in message_lower for word in ['hours', 'open', 'closed']):
+        return "We're open Monday-Friday 9 AM to 5 PM EST. Weekend hours: Saturday 10 AM - 2 PM. Closed Sundays."
+    
+    elif any(word in message_lower for word in ['price', 'cost', 'pricing', 'quote']):
+        return "Thanks for your interest in our pricing! Please visit our website or call (555) 123-4567 to speak with our sales team for a custom quote."
+    
+    elif any(word in message_lower for word in ['location', 'address', 'where']):
+        return "We're located at 123 Main Street, Anytown, ST 12345. Free parking available. Need directions? Check our website!"
+    
+    elif message_lower in ['stop', 'unsubscribe', 'opt out']:
+        return "You've been unsubscribed from our messages. Reply START to opt back in. Thanks!"
+    
+    elif message_lower in ['start', 'subscribe', 'opt in']:
+        return "Welcome! You're now subscribed to our updates. Reply STOP anytime to unsubscribe."
+    
+    else:
+        # Default response for unrecognized messages
+        if is_business_hours:
+            return "Thanks for your message! A team member will respond shortly. For immediate help, call (555) 123-4567."
+        else:
+            return "Thanks for contacting us! We'll respond during business hours (9 AM - 5 PM EST). For urgent matters, visit our website."
+
+
+def send_auto_reply(to_number: str, message: str) -> dict:
+    """Send automated SMS reply and return JSON-serializable response data."""
+    from_number = os.getenv("TELNYX_PHONE_NUMBER")
+    if not from_number:
+        raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
+    
+    response = client.messages.create(
+        from_=from_number,
+        to=to_number,
+        text=message,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "message_id": response.data.id,
+        "status": response.data.to[0].status if response.data.to else "unknown",
+        "from": from_number,
+        "to": to_number,
+        "text": message,
+    }
+```
+
+## Complete Code
+
+See [`app.py`](./app.py) for the full implementation.
+
+## Troubleshooting
+
+### Issue 1: Webhooks Not Received
+
+**Problem:** The Flask server is running but no webhook events are being received when SMS messages are sent to your Telnyx number.
+
+**Solution:** Verify your Messaging Profile configuration in the Telnyx Portal. Ensure the webhook URL matches your ngrok HTTPS URL exactly (including `/webhooks/sms` path). Check that the `message.received` event is enabled and your phone number is assigned to the correct profile. Test the webhook URL directly with curl to confirm it's accessible.
+
+### Issue 2: Duplicate Responses Sent
+
+**Problem:** The autoresponder sends multiple replies to the same incoming message, creating a loop or spam situation.
+
+**Solution:** Add message deduplication logic by storing processed message IDs in memory or a database. Check the webhook payload for the `message_id` field and skip processing if already handled. Also verify your Messaging Profile doesn't have multiple webhook URLs configured that could trigger duplicate events.
+
+### Issue 3: Response Generation Fails
+
+**Problem:** The `generate_response()` function raises exceptions or returns empty responses, causing the webhook to fail.
+
+**Solution:** Add input validation to handle edge cases like empty messages, non-text content, or special characters. Implement fallback responses for when keyword matching fails. Consider adding logging to track which messages trigger which response paths. Ensure the datetime module is properly imported for business hours logic.
+
+## FAQ
+
+**Q: Do I need a Telnyx account to run this example?**
+
+Yes. Sign up at [portal.telnyx.com](https://portal.telnyx.com) to get an API key. Telnyx offers free trial credit for testing.
+
+**Q: Can I use this SMS example in production?**
+
+Yes. This example includes error handling, environment-based configuration, and a Dockerfile for containerized deployment. Review the security and scaling sections before deploying to production.
+
+**Q: What Python version do I need?**
+
+Python 3.8 or higher. Python 3.12+ is recommended.
+
+**Q: How is Telnyx different from Twilio?**
+
+Telnyx is an AI Communications Infrastructure platform with a private global network, integrated voice + messaging + AI + SIP + IoT under one API, and significantly lower pricing. No need to stitch together multiple vendors.
+
+**Q: Where do I get a Telnyx phone number?**
+
+Log into the [Telnyx Portal](https://portal.telnyx.com), navigate to Numbers > Search & Buy, and purchase a number with the capabilities you need (SMS, voice, or both).
+
+## Related Examples
+
+- [Receive SMS Webhooks with Python](/tutorials/sms/python/receive-sms-webhook)
+- [Build Two-Way SMS Conversations](/tutorials/sms/python/two-way-sms)
+- [Implement SMS-Based Surveys](/tutorials/sms/python/sms-survey)

--- a/sms-auto-reply-bot-python/app.py
+++ b/sms-auto-reply-bot-python/app.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Production-ready SMS autoresponder using Telnyx webhooks."""
+
+import os
+import telnyx
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify
+import re
+from datetime import datetime
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# Initialize client with the new SDK pattern
+client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
+
+
+def generate_response(incoming_message: str, sender_number: str) -> str:
+    """Generate contextual response based on incoming message content."""
+    message_lower = incoming_message.lower().strip()
+    
+    # Business hours check
+    current_hour = datetime.now().hour
+    is_business_hours = 9 <= current_hour <= 17
+    
+    # Keyword-based responses
+    if any(word in message_lower for word in ['help', 'support', 'assistance']):
+        if is_business_hours:
+            return "Hi! Our support team is available now. Please call (555) 123-4567 or visit our website for immediate assistance."
+        else:
+            return "Thanks for reaching out! Our support hours are 9 AM - 5 PM. We'll respond first thing tomorrow morning."
+    
+    elif any(word in message_lower for word in ['hours', 'open', 'closed']):
+        return "We're open Monday-Friday 9 AM to 5 PM EST. Weekend hours: Saturday 10 AM - 2 PM. Closed Sundays."
+    
+    elif any(word in message_lower for word in ['price', 'cost', 'pricing', 'quote']):
+        return "Thanks for your interest in our pricing! Please visit our website or call (555) 123-4567 to speak with our sales team for a custom quote."
+    
+    elif any(word in message_lower for word in ['location', 'address', 'where']):
+        return "We're located at 123 Main Street, Anytown, ST 12345. Free parking available. Need directions? Check our website!"
+    
+    elif message_lower in ['stop', 'unsubscribe', 'opt out']:
+        return "You've been unsubscribed from our messages. Reply START to opt back in. Thanks!"
+    
+    elif message_lower in ['start', 'subscribe', 'opt in']:
+        return "Welcome! You're now subscribed to our updates. Reply STOP anytime to unsubscribe."
+    
+    else:
+        # Default response for unrecognized messages
+        if is_business_hours:
+            return "Thanks for your message! A team member will respond shortly. For immediate help, call (555) 123-4567."
+        else:
+            return "Thanks for contacting us! We'll respond during business hours (9 AM - 5 PM EST). For urgent matters, visit our website."
+
+
+def send_auto_reply(to_number: str, message: str) -> dict:
+    """Send automated SMS reply and return JSON-serializable response data."""
+    from_number = os.getenv("TELNYX_PHONE_NUMBER")
+    if not from_number:
+        raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
+    
+    response = client.messages.create(
+        from_=from_number,
+        to=to_number,
+        text=message,
+    )
+    
+    # Extract serializable data — SDK objects are NOT JSON-serializable
+    return {
+        "message_id": response.data.id,
+        "status": response.data.to[0].status if response.data.to else "unknown",
+        "from": from_number,
+        "to": to_number,
+        "text": message,
+    }
+
+
+@app.route("/webhooks/sms", methods=["POST"])
+def handle_sms_webhook():
+    """Process incoming SMS webhooks and send automated replies."""
+    try:
+        webhook_data = request.get_json()
+        
+        if not webhook_data:
+            return jsonify({"error": "No webhook data received"}), 400
+        
+        # Extract event data
+        event_type = webhook_data.get("data", {}).get("event_type")
+        
+        # Only process incoming messages
+        if event_type != "message.received":
+            return jsonify({"message": "Event ignored"}), 200
+        
+        payload = webhook_data.get("data", {}).get("payload", {})
+        
+        # Extract message details
+        from_number = payload.get("from", {}).get("phone_number")
+        to_number = payload.get("to", [{}])[0].get("phone_number")
+        message_text = payload.get("text", "")
+        
+        if not from_number or not message_text:
+            return jsonify({"error": "Missing required message data"}), 400
+        
+        # Generate and send automated response
+        response_text = generate_response(message_text, from_number)
+        reply_result = send_auto_reply(from_number, response_text)
+        
+        return jsonify({
+            "status": "success",
+            "original_message": message_text,
+            "response_sent": response_text,
+            "reply_id": reply_result["message_id"]
+        }), 200
+        
+    except telnyx.AuthenticationError:
+        return jsonify({"error": "Invalid API key"}), 401
+    except telnyx.RateLimitError:
+        return jsonify({"error": "Rate limit exceeded"}), 429
+    except telnyx.APIStatusError as e:
+        return jsonify({"error": str(e)}), e.status_code
+    except telnyx.APIConnectionError:
+        return jsonify({"error": "Network error connecting to Telnyx"}), 503
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/health", methods=["GET"])
+def health_check():
+    """Health check endpoint for monitoring."""
+    return jsonify({"status": "healthy", "service": "sms-autoresponder"}), 200
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/sms-auto-reply-bot-python/app.py
+++ b/sms-auto-reply-bot-python/app.py
@@ -132,4 +132,4 @@ def health_check():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true", port=5000)

--- a/sms-auto-reply-bot-python/app.py
+++ b/sms-auto-reply-bot-python/app.py
@@ -118,11 +118,11 @@ def handle_sms_webhook():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded"}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": str(e)}), e.status_code
+        return jsonify({"error": "API request failed"}), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route("/health", methods=["GET"])

--- a/sms-auto-reply-bot-python/requirements.txt
+++ b/sms-auto-reply-bot-python/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+telnyx


### PR DESCRIPTION
## Summary
- Adds 10 deployable code examples covering all 5 product categories (SMS, Voice, AI, SIP, IoT) and 3 languages (Python, Node.js, Ruby)
- Each example includes README.md, application code, dependency file, Dockerfile, Makefile, and .env.example
- 7 examples generated from cached tutorials, 3 newly generated via tutorial-factory pipeline

## Examples included
| Folder | Product | Language |
|--------|---------|----------|
| `send-sms-python` | SMS | Python |
| `sms-auto-reply-bot-python` | SMS | Python |
| `send-sms-ruby` | SMS | Ruby |
| `send-sms-nodejs` | SMS | Node.js |
| `create-ai-assistant-python` | AI | Python |
| `list-ai-assistants-python` | AI | Python |
| `setup-sip-trunk-python` | SIP | Python |
| `inbound-sip-routing-python` | SIP | Python |
| `route-phone-calls-to-ai-agent-python` | Voice | Python |
| `activate-sim-card-python` | IoT | Python |

## Test plan
- [x] `verify.py --verbose` passes for all 10 folders (6 files each)
- [x] No `.env` or `__pycache__` files committed
- [ ] Spot-check README content and code for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)