### PR TITLE
chore: add @ireither as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @harpreetTelnyx
+* @harpreetTelnyx @ireither


### PR DESCRIPTION
## Summary
- Adds `@ireither` as a code owner alongside `@harpreetTelnyx` in `.github/CODEOWNERS`

## Test plan
- [ ] Verify `.github/CODEOWNERS` contains `* @harpreetTelnyx @ireither`
- [ ] Confirm `@ireither` appears as a required reviewer on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)