### PR TITLE
fix: add 19 new Python examples from #10, hardened to standard (supersedes #10's new work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ Build voice applications with [Telnyx Voice AI](https://telnyx.com/products/voic
 | [call-whisper-monitoring-python](./call-whisper-monitoring-python/) | Python | Monitor calls with whisper prompts for agents. |
 | [call-forwarding-python](./call-forwarding-python/) | Python | Forward incoming calls to another destination. |
 | [webrtc-browser-calling-python](./webrtc-browser-calling-python/) | Python | Enable browser-based calling with WebRTC. |
+| [edge-compliance-monitor-python](./edge-compliance-monitor-python/) | Python | ---. |
+| [edge-fraud-firewall-python](./edge-fraud-firewall-python/) | Python | ---. |
+| [edge-geo-smart-router-python](./edge-geo-smart-router-python/) | Python | ---. |
+| [edge-ivr-ab-tester-python](./edge-ivr-ab-tester-python/) | Python | ---. |
+| [edge-merge-ai-receptionist-python](./edge-merge-ai-receptionist-python/) | Python | ---. |
+| [edge-merge-reference-checker-python](./edge-merge-reference-checker-python/) | Python | ---. |
+| [edge-merge-shift-coverage-python](./edge-merge-shift-coverage-python/) | Python | ---. |
+| [edge-number-masking-python](./edge-number-masking-python/) | Python | ---. |
+| [edge-voicemail-to-action-python](./edge-voicemail-to-action-python/) | Python | ---. |
+| [edge-webhook-aggregator-python](./edge-webhook-aggregator-python/) | Python | ---. |
+| [merge-deal-desk-alerts-python](./merge-deal-desk-alerts-python/) | Python | ---. |
+| [merge-employee-hotline-python](./merge-employee-hotline-python/) | Python | ---. |
+| [merge-expense-by-phone-python](./merge-expense-by-phone-python/) | Python | ---. |
+| [merge-interview-pipeline-python](./merge-interview-pipeline-python/) | Python | ---. |
+| [merge-invoice-collector-python](./merge-invoice-collector-python/) | Python | ---. |
+| [merge-pipeline-briefing-python](./merge-pipeline-briefing-python/) | Python | ---. |
+| [merge-recruitment-hotline-python](./merge-recruitment-hotline-python/) | Python | ---. |
+| [merge-ticket-escalation-python](./merge-ticket-escalation-python/) | Python | ---. |
 | [route-phone-calls-to-ai-agent-nodejs](./route-phone-calls-to-ai-agent-nodejs/) | Node.js | Handle inbound calls with webhook-driven AI routing. |
 | [make-outbound-phone-call-nodejs](./make-outbound-phone-call-nodejs/) | Node.js | Initiate outbound calls via the Call Control API. |
 | [make-outbound-phone-call-java](./make-outbound-phone-call-java/) | Java | Initiate outbound calls via the Call Control API. |
@@ -97,6 +115,7 @@ Send and receive text messages with the [Telnyx SMS API](https://telnyx.com/prod
 | [sms-two-factor-auth-python](./sms-two-factor-auth-python/) | Python | Implement SMS-based two-factor authentication. |
 | [send-mms-picture-message-python](./send-mms-picture-message-python/) | Python | Send MMS messages with media attachments. |
 | [sms-auto-reply-bot-python](./sms-auto-reply-bot-python/) | Python | Build an SMS autoresponder bot. |
+| [merge-employee-onboarding-python](./merge-employee-onboarding-python/) | Python | ---. |
 | [send-sms-nodejs](./send-sms-nodejs/) | Node.js | Send a single SMS message via the Telnyx API. |
 | [receive-sms-webhook-nodejs](./receive-sms-webhook-nodejs/) | Node.js | Receive inbound SMS via webhook. |
 | [receive-sms-webhook-csharp](./receive-sms-webhook-csharp/) | C# | Receive inbound SMS via webhook (Ed25519-verified). |

--- a/edge-compliance-monitor-python/.env.example
+++ b/edge-compliance-monitor-python/.env.example
@@ -1,0 +1,5 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-compliance-monitor-python/API.md
+++ b/edge-compliance-monitor-python/API.md
@@ -1,0 +1,103 @@
+# API Reference -- Edge Compliance Monitor
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/violations` | Violations |
+| `GET` | `/calls` | Calls |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /violations`
+
+Violations.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/violations
+```
+
+---
+
+## `GET /calls`
+
+Calls.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/calls
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-compliance-monitor-python/GUIDE.md
+++ b/edge-compliance-monitor-python/GUIDE.md
@@ -1,0 +1,171 @@
+# Build a Edge Compliance Monitor
+
+Real-time compliance checking for regulated call centers at the edge. AI monitors call transcriptions against TCPA, HIPAA, and PCI rules. Whispers warnings to agents before violations occur.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-compliance-monitor-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (150 lines). Here is what each piece does.
+
+
+**`check_compliance()`** -- Check Compliance.
+
+```python
+def check_compliance(utterance, context):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=10, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": SYSTEM_PROMPT},
+                         {"role": "user", "content": f"Call context: {context}\nAgent utterance: {utterance}"}],
+            "response_format": {"type": "json_object"}
+        })
+        if resp.ok:
+            content = resp.json()["choices"][0]["message"]["content"]
+            return json.loads(content)
+    except Exception as e:
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+```
+
+**`get_violations()`** -- Get Violations.
+
+```python
+def get_violations():
+    limit = request.args.get("limit", 50, type=int)
+    return jsonify({"violations": violations_log[-limit:], "total": len(violations_log)})
+```
+
+**`active_calls()`** -- Active Calls.
+
+```python
+def active_calls():
+    return jsonify({"active": len(call_sessions),
+                    "calls": {k: {"utterances": v.get("utterance_count", 0),
+                                   "violations": len(v.get("violations", []))}
+                              for k, v in call_sessions.items()}})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/violations` | Violations |
+| `GET` | `/calls` | Calls |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-compliance-monitor"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-compliance-monitor-python/README.md
+++ b/edge-compliance-monitor-python/README.md
@@ -1,0 +1,170 @@
+---
+name: edge-compliance-monitor
+title: "Edge Compliance Monitor"
+description: "Real-time compliance checking for regulated call centers at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, AI Inference]
+channel: [voice]
+---
+
+# Edge Compliance Monitor
+
+> Also known as: TCPA compliance, HIPAA monitoring, call center compliance, real-time compliance, PCI DSS.
+
+Real-time compliance checking for regulated call centers at the edge. AI monitors call transcriptions against TCPA, HIPAA, and PCI rules. Whispers warnings to agents before violations occur.
+
+## Why Telnyx
+
+Telnyx is the AI Communications Infrastructure that runs voice, messaging, and AI inference on one private global network -- so live call audio, on-the-fly transcription, and compliance scoring happen close to the caller without bouncing across third-party clouds. This example pairs Call Control with the Telnyx AI Inference API to evaluate each agent utterance and whisper warnings back into the same call, all behind a single API key.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-compliance-monitor-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /violations`
+
+Violations.
+
+```bash
+curl http://localhost:5000/violations
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-compliance-monitor"}
+```
+
+### `GET /calls`
+
+Calls.
+
+```bash
+curl http://localhost:5000/calls
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-compliance-monitor"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-compliance-monitor"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/violations` | Violations |
+| `GET` | `/calls` | Calls |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `401 invalid signature` on `/webhooks/voice` | Set `TELNYX_PUBLIC_KEY` to your application's public key from the [Portal](https://portal.telnyx.com/call-control/applications). Verification requires the raw request body and the `telnyx-signature-ed25519` / `telnyx-timestamp` headers; a proxy that rewrites the body or strips headers will break it. Requests older than 300s are rejected as replays -- check your server clock. |
+| Webhooks never arrive | Your local server isn't reachable. Restart `ngrok http 5000` and update the Call Control Application Webhook URL to the current `https://<id>.ngrok.io/webhooks/voice`. |
+| Calls connect but no compliance whispers | The AI Inference call is failing. Confirm `TELNYX_API_KEY` is set and that `AI_MODEL` is a valid model id; check the server logs for `Compliance check failed`. The compliance check fails open (no violation) so the call still continues. |
+| `500` / missing env var on startup | Ensure `.env` exists with at least `TELNYX_API_KEY`. Run `cp .env.example .env` and fill in values, then restart `python app.py`. |
+
+## Related Examples
+
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- route inbound calls to an AI voice agent with Call Control
+- [call-whisper-monitoring-python](../call-whisper-monitoring-python/) -- whisper coaching to agents during live calls
+- [edge-fraud-firewall-python](../edge-fraud-firewall-python/) -- real-time fraud screening at the edge
+- [compliance-call-recorder-ai-auditor-python](../compliance-call-recorder-ai-auditor-python/) -- record calls and AI-audit them for compliance
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-compliance-monitor-python/app.py
+++ b/edge-compliance-monitor-python/app.py
@@ -1,0 +1,176 @@
+"""Edge Compliance Monitor — real-time compliance checking for regulated call centers.
+Processes media streams via WebSocket, AI checks utterances against TCPA/HIPAA rules,
+whispers warnings to agent before they finish the sentence."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+
+COMPLIANCE_RULES = os.getenv("COMPLIANCE_RULES", "TCPA,HIPAA")
+SYSTEM_PROMPT = f"""You are a real-time compliance monitor for phone calls.
+Rules to check: {COMPLIANCE_RULES}
+TCPA violations: threatening language, calling outside allowed hours, failure to identify, refusing to honor do-not-call.
+HIPAA violations: sharing PHI without authorization, naming patients to unauthorized parties, discussing diagnoses on unencrypted channels.
+Analyze each utterance. Respond with JSON: {{"violation": true/false, "rule": "TCPA|HIPAA|null", "severity": "warning|critical|null", "message": "brief warning to whisper to agent"}}"""
+
+call_sessions = {}
+violations_log = []
+MAX_ENTRIES = 10000
+
+
+def verify_telnyx_signature(body: bytes, headers: dict, tolerance: int = 300) -> bool:
+    """Verify the Telnyx Ed25519 signature over "<telnyx-timestamp>|<raw body>".
+    No Telnyx SDK here, so verify directly with the Portal public key. Rejects
+    timestamps older than `tolerance` seconds (replay protection)."""
+    sig_b64 = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not (sig_b64 and timestamp and TELNYX_PUBLIC_KEY):
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > tolerance:  # replay protection
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        public_key.verify(base64.b64decode(sig_b64), f"{timestamp}|".encode() + body)
+        return True
+    except (InvalidSignature, ValueError, Exception):
+        return False
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try: return json.loads(base64.b64decode(b64).decode())
+    except: return {}
+
+def check_compliance(utterance, context):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=10, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": SYSTEM_PROMPT},
+                         {"role": "user", "content": f"Call context: {context}\nAgent utterance: {utterance}"}],
+            "response_format": {"type": "json_object"}
+        })
+        if resp.ok:
+            content = resp.json()["choices"][0]["message"]["content"]
+            return json.loads(content)
+    except Exception as e:
+        app.logger.error("Compliance check failed: %s", e)
+    return {"violation": False}
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature over the RAW body before trusting anything.
+    raw_body = request.get_data()
+    # request.headers is case-insensitive (Werkzeug); dict() would Title-case keys
+    # and break the lowercase header lookups in verify_telnyx_signature.
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                      headers=HEADERS, timeout=10,
+                      json={"client_state": encode_state({"step": "monitor", "utterances": []})})
+        call_sessions[cc_id] = {"start": time.time(), "violations": [], "utterance_count": 0, "ts": time.time()}
+        ttl_cleanup(call_sessions)
+
+    elif event_type == "call.answered":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "This call is being monitored for quality and compliance.",
+                            "voice": "female", "language": "en-US",
+                            "input_type": "speech", "timeout_secs": 60,
+                            "client_state": encode_state({"step": "listening"})})
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        state = decode_state(ep.get("client_state", ""))
+        if speech:
+            session = call_sessions.get(cc_id, {})
+            session["utterance_count"] = session.get("utterance_count", 0) + 1
+            result = check_compliance(speech, f"Utterance #{session['utterance_count']} in call")
+            if result.get("violation"):
+                violation_record = {
+                    "call_control_id": cc_id, "utterance": speech,
+                    "rule": result.get("rule"), "severity": result.get("severity"),
+                    "message": result.get("message"), "ts": time.time()
+                }
+                session.setdefault("violations", []).append(violation_record)
+                violations_log.append(violation_record)
+                if len(violations_log) > MAX_ENTRIES:
+                    violations_log[:] = violations_log[-MAX_ENTRIES:]
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": f"Compliance alert: {result.get('message', 'Please review your statement.')}",
+                                    "voice": "female", "language": "en-US",
+                                    "client_state": encode_state({"step": "whisper_sent"})})
+                return jsonify({"status": "violation_detected"})
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "", "voice": "female", "language": "en-US",
+                            "input_type": "speech", "timeout_secs": 60,
+                            "client_state": encode_state({"step": "listening"})})
+
+    elif event_type == "call.speak.ended":
+        state = decode_state(ep.get("client_state", ""))
+        if state.get("step") == "whisper_sent":
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "", "voice": "female", "language": "en-US",
+                                "input_type": "speech", "timeout_secs": 60,
+                                "client_state": encode_state({"step": "listening"})})
+
+    elif event_type == "call.hangup":
+        session = call_sessions.pop(cc_id, None)
+        if session:
+            app.logger.info("Call ended. Utterances: %s, Violations: %s",
+                           session.get("utterance_count", 0), len(session.get("violations", [])))
+
+    return jsonify({"status": "ok"})
+
+@app.route("/violations", methods=["GET"])
+def get_violations():
+    limit = request.args.get("limit", 50, type=int)
+    return jsonify({"violations": violations_log[-limit:], "total": len(violations_log)})
+
+@app.route("/calls", methods=["GET"])
+def active_calls():
+    return jsonify({"active": len(call_sessions),
+                    "calls": {k: {"utterances": v.get("utterance_count", 0),
+                                   "violations": len(v.get("violations", []))}
+                              for k, v in call_sessions.items()}})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-compliance-monitor",
+                    "active_calls": len(call_sessions), "total_violations": len(violations_log)})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-compliance-monitor-python/requirements.txt
+++ b/edge-compliance-monitor-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=41.0

--- a/edge-fraud-firewall-python/.env.example
+++ b/edge-fraud-firewall-python/.env.example
@@ -1,0 +1,8 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Call Control app — https://portal.telnyx.com/call-control/applications
+TELNYX_CONNECTION_ID=
+FORWARD_NUMBER=+1xxxxxxxxxx
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-fraud-firewall-python/API.md
+++ b/edge-fraud-firewall-python/API.md
@@ -1,0 +1,129 @@
+# API Reference -- Edge Fraud Firewall
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/blocklist` | Blocklist |
+| `POST` | `/blocklist` | Blocklist |
+| `GET` | `/stats` | Stats |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /blocklist`
+
+Blocklist.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/blocklist
+```
+
+---
+
+## `POST /blocklist`
+
+Blocklist.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/blocklist \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `GET /stats`
+
+Stats.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/stats
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-fraud-firewall-python/GUIDE.md
+++ b/edge-fraud-firewall-python/GUIDE.md
@@ -1,0 +1,203 @@
+# Build a Edge Fraud Firewall
+
+Screen every inbound call at the edge. Runs number lookup, velocity checks, AI classification, and blocklist matching before your app sees the call. Legitimate calls pass through; fraud gets rejected with cause code.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Number Lookup** -- real-time caller identity and fraud signals
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Reject**: `POST /v2/calls/{id}/actions/reject` -- [API reference](https://developers.telnyx.com/api/call-control/reject-call)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Number Lookup**: `GET /v2/number_lookup/{phone}` -- [API reference](https://developers.telnyx.com/api/number-lookup/lookup-number)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-fraud-firewall-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (168 lines). Here is what each piece does.
+
+
+**`lookup_number()`** -- Lookup Number.
+
+```python
+def lookup_number(phone):
+    """Check number reputation via Telnyx Number Lookup."""
+    try:
+        resp = requests.get(
+            f"https://api.telnyx.com/v2/number_lookup/{phone}",
+            headers=HEADERS, timeout=10
+        )
+        if resp.ok:
+            return resp.json().get("data", {})
+    except Exception as e:
+        app.logger.error("Number lookup failed: %s", e)
+    return {}
+```
+
+**`classify_caller()`** -- Classify Caller.
+
+```python
+def classify_caller(phone, lookup_data):
+    """Use AI to classify caller risk based on lookup data."""
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": "You are a fraud detection system. Analyze caller data and respond with ONLY one word: CLEAN, SUSPICIOUS, or BLOCK."},
+                         {"role": "user", "content": f"Caller: {phone}\nCarrier: {lookup_data.get('carrier', {}).get('name', 'unknown')}\nType: {lookup_data.get('carrier', {}).get('type', 'unknown')}\nCountry: {lookup_data.get('country_code', 'unknown')}"}]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"].strip().upper()
+    except Exception as e:
+        app.logger.error("Classification failed: %s", e)
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    call_control_id = event.get("payload", {}).get("call_control_id")
+    if not call_control_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated":
+        direction = event.get("payload", {}).get("direction")
+```
+
+**`get_blocklist()`** -- Get Blocklist.
+
+```python
+def get_blocklist():
+    return jsonify({"blocklist": sorted(blocklist), "count": len(blocklist)})
+```
+
+**`add_to_blocklist()`** -- Add To Blocklist.
+
+```python
+def add_to_blocklist():
+    data = request.get_json() or {}
+    phone = data.get("phone")
+    if not phone:
+        return jsonify({"error": "phone required"}), 400
+    blocklist.add(phone)
+    return jsonify({"status": "added", "phone": phone})
+```
+
+**`stats()`** -- Stats.
+
+```python
+def stats():
+    return jsonify({
+        "active_screenings": len(call_screening),
+        "blocklist_size": len(blocklist)
+    })
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/blocklist` | Blocklist |
+| `POST` | `/blocklist` | Blocklist |
+| `GET` | `/stats` | Stats |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-fraud-firewall"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-fraud-firewall-python/README.md
+++ b/edge-fraud-firewall-python/README.md
@@ -1,0 +1,188 @@
+---
+name: edge-fraud-firewall
+title: "Edge Fraud Firewall"
+description: "Screen every inbound call at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Number Lookup, Voice, AI Inference]
+channel: [voice]
+---
+
+# Edge Fraud Firewall
+
+> Also known as: call screening, fraud detection, spam filter, robocall blocker, call firewall, STIR/SHAKEN verification.
+
+Screen every inbound call at the edge. Runs number lookup, velocity checks, AI classification, and blocklist matching before your app sees the call. Legitimate calls pass through; fraud gets rejected with cause code.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, number intelligence, and AI inference run on one private global network instead of stitched-together third parties. This firewall screens callers with Number Lookup and an AI classifier and rejects or transfers the call -- all from the same platform that carries the call, so screening happens before fraud ever touches your application. Low-latency Call Control and inference on a single backbone keep the screen-then-route decision fast enough to sit inline on every inbound call.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Reject**: `POST /v2/calls/{id}/actions/reject` -- [API reference](https://developers.telnyx.com/api/call-control/reject-call)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Number Lookup**: `GET /v2/number_lookup/{phone}` -- [API reference](https://developers.telnyx.com/api/number-lookup/lookup-number)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-fraud-firewall-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /blocklist`
+
+Blocklist.
+
+```bash
+curl http://localhost:5000/blocklist
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-fraud-firewall"}
+```
+
+### `POST /blocklist`
+
+Blocklist.
+
+```bash
+curl -X POST http://localhost:5000/blocklist \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /stats`
+
+Stats.
+
+```bash
+curl http://localhost:5000/stats
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-fraud-firewall"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-fraud-firewall"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/blocklist` | Blocklist |
+| `POST` | `/blocklist` | Blocklist |
+| `GET` | `/stats` | Stats |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing or wrong, so `client.webhooks.unwrap()` rejects the request | Copy the public key from your [Call Control Application](https://portal.telnyx.com/call-control/applications) into `.env` as `TELNYX_PUBLIC_KEY` and restart |
+| Webhooks never arrive / no logs on inbound calls | Webhook URL not reachable -- ngrok tunnel down or wrong path configured in the Portal | Confirm `ngrok http 5000` is running and the Application Webhook URL ends in `/webhooks/voice` |
+| App exits or 500s on startup | Required env var missing (`TELNYX_API_KEY` or `TELNYX_CONNECTION_ID`) | Ensure `.env` exists (`cp .env.example .env`) and both keys are filled from the [Portal](https://portal.telnyx.com/api-keys) |
+| Every caller classified `CLEAN` (no blocking) | AI inference call failed and fell back to `CLEAN`, or Number Lookup returned no carrier data | Check `Classification failed` / `Number lookup failed` in the logs, verify `AI_MODEL` is valid, and confirm the API key has Inference access |
+
+## Related Examples
+
+- [number-lookup-fraud-screener-python](../number-lookup-fraud-screener-python/) -- Score and screen callers with Number Lookup reputation data
+- [fraud-alert-verification-python](../fraud-alert-verification-python/) -- Verify suspicious activity with an outbound confirmation call
+- [edge-geo-smart-router-python](../edge-geo-smart-router-python/) -- Route inbound calls at the edge based on caller geography
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- Forward screened, verified calls to an AI voice agent
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-fraud-firewall-python/app.py
+++ b/edge-fraud-firewall-python/app.py
@@ -1,0 +1,178 @@
+"""Edge Fraud Firewall — screen every inbound call at the edge before it reaches your app.
+Runs number lookup, checks blocklist, classifies via AI inference. Clean calls pass through.
+Suspicious calls route to a honeypot that wastes the scammer's time."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+import telnyx
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+# public_key (from the Portal) lets the SDK verify inbound webhook signatures.
+client = telnyx.Telnyx(api_key=TELNYX_API_KEY, public_key=TELNYX_PUBLIC_KEY)
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+FORWARD_NUMBER = os.getenv("FORWARD_NUMBER")
+HONEYPOT_CONNECTION = os.getenv("HONEYPOT_CONNECTION_ID", "")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+
+blocklist = set()
+call_screening = {}
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+def lookup_number(phone):
+    """Check number reputation via Telnyx Number Lookup."""
+    try:
+        resp = requests.get(
+            f"https://api.telnyx.com/v2/number_lookup/{phone}",
+            headers=HEADERS, timeout=10
+        )
+        if resp.ok:
+            return resp.json().get("data", {})
+    except Exception as e:
+        app.logger.error("Number lookup failed: %s", e)
+    return {}
+
+def classify_caller(phone, lookup_data):
+    """Use AI to classify caller risk based on lookup data."""
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": "You are a fraud detection system. Analyze caller data and respond with ONLY one word: CLEAN, SUSPICIOUS, or BLOCK."},
+                         {"role": "user", "content": f"Caller: {phone}\nCarrier: {lookup_data.get('carrier', {}).get('name', 'unknown')}\nType: {lookup_data.get('carrier', {}).get('type', 'unknown')}\nCountry: {lookup_data.get('country_code', 'unknown')}"}]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"].strip().upper()
+    except Exception as e:
+        app.logger.error("Classification failed: %s", e)
+    return "CLEAN"
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the raw body before trusting
+    # anything. unwrap() reads the telnyx-signature-ed25519 / telnyx-timestamp
+    # headers and raises if the signature or timestamp (replay) check fails.
+    try:
+        client.webhooks.unwrap(request.get_data(as_text=True), headers=dict(request.headers))
+    except Exception:
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    call_control_id = event.get("payload", {}).get("call_control_id")
+    if not call_control_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated":
+        direction = event.get("payload", {}).get("direction")
+        caller = event.get("payload", {}).get("from", "")
+        if direction == "incoming":
+            if caller in blocklist:
+                app.logger.info("Blocked known bad caller: %s", caller)
+                requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/reject",
+                              headers=HEADERS, timeout=10)
+                return jsonify({"status": "blocked"})
+
+            lookup = lookup_number(caller)
+            risk = classify_caller(caller, lookup)
+            call_screening[call_control_id] = {"phone": caller, "risk": risk, "lookup": lookup, "ts": time.time()}
+            ttl_cleanup(call_screening)
+
+            if risk == "BLOCK":
+                blocklist.add(caller)
+                requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/reject",
+                              headers=HEADERS, timeout=10)
+                return jsonify({"status": "blocked"})
+            elif risk == "SUSPICIOUS" and HONEYPOT_CONNECTION:
+                requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/answer",
+                              headers=HEADERS, timeout=10,
+                              json={"client_state": encode_state({"flow": "honeypot"})})
+            else:
+                requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/answer",
+                              headers=HEADERS, timeout=10,
+                              json={"client_state": encode_state({"flow": "forward"})})
+
+    elif event_type == "call.answered":
+        state = decode_state(event.get("payload", {}).get("client_state", ""))
+        flow = state.get("flow", "forward")
+        if flow == "honeypot":
+            requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "Please hold while I connect you to a specialist.",
+                                "voice": "female", "language": "en-US",
+                                "client_state": encode_state({"flow": "honeypot_hold"})})
+        else:
+            if FORWARD_NUMBER:
+                requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/transfer",
+                              headers=HEADERS, timeout=10,
+                              json={"to": FORWARD_NUMBER})
+            else:
+                requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": "Welcome. Your call has been verified.",
+                                    "voice": "female", "language": "en-US"})
+
+    elif event_type == "call.speak.ended":
+        state = decode_state(event.get("payload", {}).get("client_state", ""))
+        if state.get("flow") == "honeypot_hold":
+            time.sleep(2)
+            requests.post(f"https://api.telnyx.com/v2/calls/{call_control_id}/actions/speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "All specialists are currently busy. Please continue to hold.",
+                                "voice": "female", "language": "en-US",
+                                "client_state": encode_state({"flow": "honeypot_hold"})})
+
+    elif event_type == "call.hangup":
+        call_screening.pop(call_control_id, None)
+
+    return jsonify({"status": "ok"})
+
+@app.route("/blocklist", methods=["GET"])
+def get_blocklist():
+    return jsonify({"blocklist": sorted(blocklist), "count": len(blocklist)})
+
+@app.route("/blocklist", methods=["POST"])
+def add_to_blocklist():
+    data = request.get_json() or {}
+    phone = data.get("phone")
+    if not phone:
+        return jsonify({"error": "phone required"}), 400
+    blocklist.add(phone)
+    return jsonify({"status": "added", "phone": phone})
+
+@app.route("/stats", methods=["GET"])
+def stats():
+    return jsonify({
+        "active_screenings": len(call_screening),
+        "blocklist_size": len(blocklist)
+    })
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-fraud-firewall"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-fraud-firewall-python/requirements.txt
+++ b/edge-fraud-firewall-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+telnyx>=4.0.0

--- a/edge-geo-smart-router-python/.env.example
+++ b/edge-geo-smart-router-python/.env.example
@@ -1,0 +1,7 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Cloud Storage bucket — https://portal.telnyx.com/storage
+STORAGE_BUCKET=my-bucket
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-geo-smart-router-python/API.md
+++ b/edge-geo-smart-router-python/API.md
@@ -1,0 +1,84 @@
+# API Reference -- Edge Geo Smart Router
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/regions` | Regions |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.recording.saved` | Recording available for download |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /regions`
+
+Regions.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/regions
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-geo-smart-router-python/GUIDE.md
+++ b/edge-geo-smart-router-python/GUIDE.md
@@ -1,0 +1,177 @@
+# Build a Edge Geo Smart Router
+
+Route calls by geography at the edge. US callers get English AI, LATAM gets Spanish with localized greetings, EU gets GDPR-compliant recording with explicit consent collection.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Call Recording** -- record calls for compliance and quality
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Record Start**: `POST /v2/calls/{id}/actions/record_start` -- [API reference](https://developers.telnyx.com/api/call-control/start-recording)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.recording.saved` -- Recording available for download
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-geo-smart-router-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (182 lines). Here is what each piece does.
+
+
+**`detect_region()`** -- Detect Region.
+
+```python
+def detect_region(phone):
+    if not phone:
+        return "DEFAULT"
+    for prefix in EU_PREFIXES:
+        if phone.startswith(prefix):
+            return "EU"
+    for prefix in LATAM_PREFIXES:
+        if phone.startswith(prefix):
+            return "LATAM"
+    if phone.startswith("+1"):
+        return "US"
+    return "DEFAULT"
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, language="en-US"):
+    try:
+        lang_instruction = "Respond in Spanish." if "es" in language else "Respond in English."
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": f"You are a helpful business assistant. Be concise. {lang_instruction}"},
+                         {"role": "user", "content": prompt}]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+```
+
+**`get_regions()`** -- Get Regions.
+
+```python
+def get_regions():
+    return jsonify({"regions": {k: {kk: vv for kk, vv in v.items() if kk != "greeting"} for k, v in REGION_CONFIG.items()}})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/regions` | Regions |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-geo-smart-router"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-geo-smart-router-python/README.md
+++ b/edge-geo-smart-router-python/README.md
@@ -1,0 +1,156 @@
+---
+name: edge-geo-smart-router
+title: "Edge Geo Smart Router"
+description: "Route calls by geography at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, AI Inference, Call Recording]
+channel: [voice]
+---
+
+# Edge Geo Smart Router
+
+> Also known as: geo routing, multilingual IVR, GDPR call recording, geographic call routing.
+
+Route calls by geography at the edge. US callers get English AI, LATAM gets Spanish with localized greetings, EU gets GDPR-compliant recording with explicit consent collection.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, and AI inference run on one private global network, so a call can be answered, routed by caller geography, transcribed, and answered by an AI model without leaving Telnyx. This example uses Call Control for region-aware greetings and consent, AI Inference for multilingual replies, and Telnyx Storage for compliant recording archival -- all under a single API key with low-latency edge routing.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Record Start**: `POST /v2/calls/{id}/actions/record_start` -- [API reference](https://developers.telnyx.com/api/call-control/start-recording)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.recording.saved` -- Recording available for download
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-geo-smart-router-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /regions`
+
+Regions.
+
+```bash
+curl http://localhost:5000/regions
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-geo-smart-router"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-geo-smart-router"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.recording.saved` -- Recording available for download
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/regions` | Regions |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` missing or wrong; webhook verification is rejected | Set `TELNYX_PUBLIC_KEY` (Portal -> Keys & Credentials) to the base64 Ed25519 key. If unset, every webhook is rejected by design. |
+| Telnyx never reaches your webhook | Local server not exposed; Webhook URL points at `localhost` | Run `ngrok http 5000` and set the Call Control Application Webhook URL to `https://<id>.ngrok.io/webhooks/voice`. |
+| Inference replies with "I'm having trouble right now" | `TELNYX_API_KEY` invalid/missing or `AI_MODEL` not available | Verify `TELNYX_API_KEY` in `.env`, confirm the `AI_MODEL` slug at [Models](https://developers.telnyx.com/docs/inference/models). |
+| Caller routed to `DEFAULT` instead of expected region | Number not in E.164 form, or its prefix isn't in `EU_PREFIXES` / `LATAM_PREFIXES` | Ensure the `from` number starts with `+<country code>`; add the prefix to the lists in `app.py`. |
+| Recordings not archived | EU caller pressed 2 (no consent), or `recording_url` not on a Telnyx host | EU recording only starts after consent (digit `1`); non-Telnyx URLs are skipped to guard against SSRF. |
+
+## Related Examples
+
+- [ai-powered-ivr-replacement-python](../ai-powered-ivr-replacement-python/) -- AI-driven IVR that replaces menu trees with natural language.
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- Connect inbound calls to a Telnyx AI voice agent.
+- [record-phone-calls-python](../record-phone-calls-python/) -- Start and retrieve Call Control recordings.
+- [edge-compliance-monitor-python](../edge-compliance-monitor-python/) -- Edge-based compliance and consent monitoring for calls.
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-geo-smart-router-python/app.py
+++ b/edge-geo-smart-router-python/app.py
@@ -1,0 +1,229 @@
+"""Edge Geo Smart Router — detect caller region and apply different business logic.
+US callers get English AI. LATAM gets Spanish. EU gets GDPR-compliant recording
+with mandatory consent collection before proceeding."""
+import os, json, time, base64, logging
+from urllib.parse import urlparse
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+import boto3
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+STORAGE_BUCKET = os.getenv("STORAGE_BUCKET", "call-recordings")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+
+s3 = boto3.client("s3", endpoint_url="https://storage.telnyx.com",
+                   aws_access_key_id=TELNYX_API_KEY, aws_secret_access_key=TELNYX_API_KEY)
+
+REGION_CONFIG = {
+    "US": {"language": "en-US", "voice": "female", "greeting": "Welcome. How can I help you today?",
+           "requires_consent": False, "record": True},
+    "LATAM": {"language": "es-MX", "voice": "female", "greeting": "Bienvenido. Como puedo ayudarle hoy?",
+              "requires_consent": False, "record": True},
+    "EU": {"language": "en-GB", "voice": "female",
+           "greeting": "This call will be recorded for quality purposes. Press 1 to consent and continue, or press 2 to proceed without recording.",
+           "requires_consent": True, "record": False},
+    "DEFAULT": {"language": "en-US", "voice": "female", "greeting": "Welcome. How can I help you?",
+                "requires_consent": False, "record": True}
+}
+
+EU_PREFIXES = ["+33", "+34", "+39", "+44", "+49", "+31", "+32", "+43", "+45", "+46", "+47",
+               "+48", "+351", "+353", "+358", "+352", "+356", "+370", "+371", "+372", "+420", "+421"]
+LATAM_PREFIXES = ["+52", "+55", "+54", "+56", "+57", "+51", "+58", "+53", "+506", "+507",
+                  "+502", "+503", "+504", "+505"]
+
+call_sessions = {}
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def detect_region(phone):
+    if not phone:
+        return "DEFAULT"
+    for prefix in EU_PREFIXES:
+        if phone.startswith(prefix):
+            return "EU"
+    for prefix in LATAM_PREFIXES:
+        if phone.startswith(prefix):
+            return "LATAM"
+    if phone.startswith("+1"):
+        return "US"
+    return "DEFAULT"
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try: return json.loads(base64.b64decode(b64).decode())
+    except: return {}
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+def is_telnyx_url(url):
+    """Only fetch recordings from Telnyx hosts (the API key is attached to the request)."""
+    try:
+        parts = urlparse(url or "")
+    except ValueError:
+        return False
+    host = (parts.hostname or "").lower()
+    return parts.scheme == "https" and (host == "telnyx.com" or host.endswith(".telnyx.com"))
+
+def call_inference(prompt, language="en-US"):
+    try:
+        lang_instruction = "Respond in Spanish." if "es" in language else "Respond in English."
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": f"You are a helpful business assistant. Be concise. {lang_instruction}"},
+                         {"role": "user", "content": prompt}]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "I apologize, I'm having trouble right now. Please try again."
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        caller = ep.get("from", "")
+        region = detect_region(caller)
+        config = REGION_CONFIG.get(region, REGION_CONFIG["DEFAULT"])
+        call_sessions[cc_id] = {"region": region, "config": config, "caller": caller, "ts": time.time()}
+        ttl_cleanup(call_sessions)
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                      headers=HEADERS, timeout=10,
+                      json={"client_state": encode_state({"region": region, "step": "greeting"})})
+
+    elif event_type == "call.answered":
+        state = decode_state(ep.get("client_state", ""))
+        region = state.get("region", "DEFAULT")
+        config = REGION_CONFIG.get(region, REGION_CONFIG["DEFAULT"])
+        session = call_sessions.get(cc_id, {})
+        if config["requires_consent"]:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": config["greeting"], "voice": config["voice"],
+                                "language": config["language"], "minimum_digits": 1, "maximum_digits": 1,
+                                "client_state": encode_state({"region": region, "step": "consent"})})
+        else:
+            if config.get("record"):
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/record_start",
+                              headers=HEADERS, timeout=10, json={"format": "mp3", "channels": "dual"})
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": config["greeting"], "voice": config["voice"],
+                                "language": config["language"], "input_type": "speech", "timeout_secs": 30,
+                                "client_state": encode_state({"region": region, "step": "conversation"})})
+
+    elif event_type == "call.gather.ended":
+        state = decode_state(ep.get("client_state", ""))
+        region = state.get("region", "DEFAULT")
+        config = REGION_CONFIG.get(region, REGION_CONFIG["DEFAULT"])
+        step = state.get("step")
+
+        if step == "consent":
+            digits = ep.get("digits", "")
+            if digits == "1":
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/record_start",
+                              headers=HEADERS, timeout=10, json={"format": "mp3", "channels": "dual"})
+                call_sessions.get(cc_id, {})["consented"] = True
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "Thank you. How can I help you today?" if region == "EU" else config["greeting"],
+                                "voice": config["voice"], "language": config["language"],
+                                "input_type": "speech", "timeout_secs": 30,
+                                "client_state": encode_state({"region": region, "step": "conversation"})})
+        elif step == "conversation":
+            speech = ep.get("speech", {}).get("result", "")
+            if speech:
+                response = call_inference(speech, config["language"])
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": response, "voice": config["voice"],
+                                    "language": config["language"], "input_type": "speech", "timeout_secs": 30,
+                                    "client_state": encode_state({"region": region, "step": "conversation"})})
+
+    elif event_type == "call.recording.saved":
+        recording_url = ep.get("recording_urls", {}).get("mp3")
+        session = call_sessions.get(cc_id, {})
+        # recording_url comes from the webhook body — only fetch it (with the API key
+        # attached) if it points at a Telnyx host. Guards against SSRF.
+        if recording_url and is_telnyx_url(recording_url):
+            try:
+                audio = requests.get(recording_url, headers=HEADERS, timeout=30).content
+                region = session.get("region", "unknown")
+                key = f"recordings/{region}/{ep.get('call_session_id', 'unknown')}.mp3"
+                s3.put_object(Bucket=STORAGE_BUCKET, Key=key, Body=audio, ContentType="audio/mpeg")
+            except Exception as e:
+                app.logger.error("Recording archive failed: %s", e)
+
+    elif event_type == "call.hangup":
+        call_sessions.pop(cc_id, None)
+
+    return jsonify({"status": "ok"})
+
+@app.route("/regions", methods=["GET"])
+def get_regions():
+    return jsonify({"regions": {k: {kk: vv for kk, vv in v.items() if kk != "greeting"} for k, v in REGION_CONFIG.items()}})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-geo-smart-router", "active_calls": len(call_sessions)})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-geo-smart-router-python/requirements.txt
+++ b/edge-geo-smart-router-python/requirements.txt
@@ -1,0 +1,5 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+boto3>=1.34
+cryptography>=42.0

--- a/edge-ivr-ab-tester-python/.env.example
+++ b/edge-ivr-ab-tester-python/.env.example
@@ -1,0 +1,7 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Cloud Storage bucket — https://portal.telnyx.com/storage
+STORAGE_BUCKET=my-bucket
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-ivr-ab-tester-python/API.md
+++ b/edge-ivr-ab-tester-python/API.md
@@ -1,0 +1,129 @@
+# API Reference -- Edge IVR A/B Tester
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/experiments` | Experiments |
+| `GET` | `/experiments` | Experiments |
+| `GET` | `/experiments/<exp_id>` | <Exp Id> |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /experiments`
+
+Experiments.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/experiments \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `GET /experiments`
+
+Experiments.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/experiments
+```
+
+---
+
+## `GET /experiments/<exp_id>`
+
+<Exp Id>.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/experiments/<exp_id>
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-ivr-ab-tester-python/GUIDE.md
+++ b/edge-ivr-ab-tester-python/GUIDE.md
@@ -1,0 +1,187 @@
+# Build a Edge IVR A/B Tester
+
+A/B test different IVR flows at the edge. Randomly assigns callers to variants, tracks completion rates per variant, and auto-promotes the winner when statistical significance is reached.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-ivr-ab-tester-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (163 lines). Here is what each piece does.
+
+
+**`get_variant()`** -- Get Variant.
+
+```python
+def get_variant(experiment_id):
+    exp = experiments.get(experiment_id)
+    if not exp:
+        return "A"
+    if exp.get("winner"):
+        return exp["winner"]
+    a_n = exp["variants"]["A"]["calls"]
+    b_n = exp["variants"]["B"]["calls"]
+    if a_n >= MIN_SAMPLE and b_n >= MIN_SAMPLE:
+        a_rate = exp["variants"]["A"]["completions"] / max(a_n, 1)
+        b_rate = exp["variants"]["B"]["completions"] / max(b_n, 1)
+        pooled = (exp["variants"]["A"]["completions"] + exp["variants"]["B"]["completions"]) / (a_n + b_n)
+```
+
+**`create_experiment()`** -- Create Experiment.
+
+```python
+def create_experiment():
+    data = request.get_json() or {}
+    exp_id = data.get("id", f"exp-{int(time.time())}")
+    experiments[exp_id] = {
+        "id": exp_id, "created": time.time(),
+        "variant_a_greeting": data.get("variant_a_greeting", "Press 1 for support, 2 for sales."),
+        "variant_b_greeting": data.get("variant_b_greeting", "Tell me how I can help you today."),
+        "variant_a_gather": data.get("variant_a_gather", "dtmf"),
+        "variant_b_gather": data.get("variant_b_gather", "speech"),
+        "winner": None,
+        "variants": {"A": {"calls": 0, "completions": 0, "dropoffs": 0, "total_duration": 0},
+                      "B": {"calls": 0, "completions": 0, "dropoffs": 0, "total_duration": 0}}
+```
+
+**`list_experiments()`** -- List Experiments.
+
+```python
+def list_experiments():
+    return jsonify({"experiments": list(experiments.values())})
+```
+
+**`get_experiment()`** -- Get Experiment.
+
+```python
+def get_experiment(exp_id):
+    exp = experiments.get(exp_id)
+    if not exp:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(exp)
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    cc_id = event.get("payload", {}).get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated":
+        if event.get("payload", {}).get("direction") == "incoming":
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/experiments` | Experiments |
+| `GET` | `/experiments` | Experiments |
+| `GET` | `/experiments/<exp_id>` | <Exp Id> |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-ivr-ab-tester"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-ivr-ab-tester-python/README.md
+++ b/edge-ivr-ab-tester-python/README.md
@@ -1,0 +1,185 @@
+---
+name: edge-ivr-ab-tester
+title: "Edge IVR A/B Tester"
+description: "A/B test different IVR flows at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, AI Inference]
+channel: [voice]
+---
+
+# Edge IVR A/B Tester
+
+> Also known as: IVR testing, A/B test phone menu, call flow optimization, IVR analytics.
+
+A/B test different IVR flows at the edge. Randomly assigns callers to variants, tracks completion rates per variant, and auto-promotes the winner when statistical significance is reached.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, and AI inference run on one private global network, so the call control, text-to-speech, and AI Inference calls this experiment relies on share a single API and the same low-latency backbone. Routing IVR variant logic and TTS prompts through Telnyx Call Control keeps caller audio and decisioning close to the edge, reducing latency on every gather and speak action. One key and one platform cover answering calls, gathering DTMF/speech, and running model inference -- no stitching together separate vendors.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-ivr-ab-tester-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /experiments`
+
+Experiments.
+
+```bash
+curl -X POST http://localhost:5000/experiments \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /experiments`
+
+Experiments.
+
+```bash
+curl http://localhost:5000/experiments
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-ivr-ab-tester"}
+```
+
+### `GET /experiments/<exp_id>`
+
+<Exp Id>.
+
+```bash
+curl http://localhost:5000/experiments/<exp_id>
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-ivr-ab-tester"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-ivr-ab-tester"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/experiments` | Experiments |
+| `GET` | `/experiments` | Experiments |
+| `GET` | `/experiments/<exp_id>` | <Exp Id> |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is unset, malformed, or webhook signature verification is disabled | Set `TELNYX_PUBLIC_KEY` to the base64 Ed25519 key from [Portal -> Keys & Credentials](https://portal.telnyx.com); it must be the public key for the same account/app sending the events. |
+| `TELNYX_API_KEY` missing or `401` from the Telnyx API | The API key env var is empty or wrong | Copy `.env.example` to `.env` and set `TELNYX_API_KEY` from [Portal API Keys](https://portal.telnyx.com/api-keys), then restart `python app.py`. |
+| Webhooks never arrive | Local server not reachable from Telnyx | Run `ngrok http 5000` and set the Call Control Application Webhook URL to `https://<id>.ngrok.io/webhooks/voice`. |
+| All callers land on variant `A` / no split happens | No experiment created, so `get_variant` defaults to `A` | `POST /experiments` to create one before testing; both variants need `MIN_SAMPLE_SIZE` calls (default 100) before a winner is auto-promoted. |
+
+## Related Examples
+
+- [smart-ivr-ab-tester-python](../smart-ivr-ab-tester-python/) -- IVR A/B testing without the edge layer
+- [ai-powered-ivr-replacement-python](../ai-powered-ivr-replacement-python/) -- replace a menu-driven IVR with an AI voice agent
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- route inbound calls into an AI agent flow
+- [edge-geo-smart-router-python](../edge-geo-smart-router-python/) -- edge sibling that routes calls by geography
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-ivr-ab-tester-python/app.py
+++ b/edge-ivr-ab-tester-python/app.py
@@ -1,0 +1,198 @@
+"""Edge IVR A/B Tester — randomly assign callers to different call flows.
+Track completion rates, drop-offs, resolution times. Auto-shift traffic
+to the winning variant after statistical significance."""
+import os, json, time, random, math, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+import boto3
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+STORAGE_BUCKET = os.getenv("STORAGE_BUCKET", "ivr-experiments")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MIN_SAMPLE = int(os.getenv("MIN_SAMPLE_SIZE", "100"))
+
+s3 = boto3.client("s3", endpoint_url="https://storage.telnyx.com",
+                   aws_access_key_id=TELNYX_API_KEY, aws_secret_access_key=TELNYX_API_KEY)
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+experiments = {}
+call_sessions = {}
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try: return json.loads(base64.b64decode(b64).decode())
+    except: return {}
+
+def get_variant(experiment_id):
+    exp = experiments.get(experiment_id)
+    if not exp:
+        return "A"
+    if exp.get("winner"):
+        return exp["winner"]
+    a_n = exp["variants"]["A"]["calls"]
+    b_n = exp["variants"]["B"]["calls"]
+    if a_n >= MIN_SAMPLE and b_n >= MIN_SAMPLE:
+        a_rate = exp["variants"]["A"]["completions"] / max(a_n, 1)
+        b_rate = exp["variants"]["B"]["completions"] / max(b_n, 1)
+        pooled = (exp["variants"]["A"]["completions"] + exp["variants"]["B"]["completions"]) / (a_n + b_n)
+        if pooled > 0 and pooled < 1:
+            se = math.sqrt(pooled * (1 - pooled) * (1/a_n + 1/b_n))
+            if se > 0:
+                z = abs(a_rate - b_rate) / se
+                if z > 1.96:
+                    winner = "A" if a_rate > b_rate else "B"
+                    exp["winner"] = winner
+                    app.logger.info("Experiment %s winner: %s (A=%.2f B=%.2f z=%.2f)", experiment_id, winner, a_rate, b_rate, z)
+                    return winner
+    return random.choice(["A", "B"])
+
+@app.route("/experiments", methods=["POST"])
+def create_experiment():
+    data = request.get_json() or {}
+    exp_id = data.get("id", f"exp-{int(time.time())}")
+    experiments[exp_id] = {
+        "id": exp_id, "created": time.time(),
+        "variant_a_greeting": data.get("variant_a_greeting", "Press 1 for support, 2 for sales."),
+        "variant_b_greeting": data.get("variant_b_greeting", "Tell me how I can help you today."),
+        "variant_a_gather": data.get("variant_a_gather", "dtmf"),
+        "variant_b_gather": data.get("variant_b_gather", "speech"),
+        "winner": None,
+        "variants": {"A": {"calls": 0, "completions": 0, "dropoffs": 0, "total_duration": 0},
+                      "B": {"calls": 0, "completions": 0, "dropoffs": 0, "total_duration": 0}}
+    }
+    return jsonify({"status": "created", "experiment": experiments[exp_id]})
+
+@app.route("/experiments", methods=["GET"])
+def list_experiments():
+    return jsonify({"experiments": list(experiments.values())})
+
+@app.route("/experiments/<exp_id>", methods=["GET"])
+def get_experiment(exp_id):
+    exp = experiments.get(exp_id)
+    if not exp:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(exp)
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    cc_id = event.get("payload", {}).get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated":
+        if event.get("payload", {}).get("direction") == "incoming":
+            exp_id = list(experiments.keys())[-1] if experiments else None
+            variant = get_variant(exp_id) if exp_id else "A"
+            call_sessions[cc_id] = {"exp_id": exp_id, "variant": variant, "start": time.time(), "ts": time.time()}
+            ttl_cleanup(call_sessions)
+            if exp_id:
+                experiments[exp_id]["variants"][variant]["calls"] += 1
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                          headers=HEADERS, timeout=10,
+                          json={"client_state": encode_state({"exp": exp_id, "var": variant, "step": "greeting"})})
+
+    elif event_type == "call.answered":
+        state = decode_state(event.get("payload", {}).get("client_state", ""))
+        exp_id = state.get("exp")
+        variant = state.get("var", "A")
+        exp = experiments.get(exp_id, {})
+        greeting = exp.get(f"variant_{variant.lower()}_greeting", "Welcome.")
+        gather_type = exp.get(f"variant_{variant.lower()}_gather", "dtmf")
+        if gather_type == "speech":
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": greeting, "voice": "female", "language": "en-US",
+                                "input_type": "speech", "minimum_digits": 1,
+                                "client_state": encode_state({"exp": exp_id, "var": variant, "step": "gather"})})
+        else:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": greeting, "voice": "female", "language": "en-US",
+                                "minimum_digits": 1, "maximum_digits": 1,
+                                "client_state": encode_state({"exp": exp_id, "var": variant, "step": "gather"})})
+
+    elif event_type == "call.gather.ended":
+        state = decode_state(event.get("payload", {}).get("client_state", ""))
+        exp_id = state.get("exp")
+        variant = state.get("var", "A")
+        if exp_id and exp_id in experiments:
+            experiments[exp_id]["variants"][variant]["completions"] += 1
+            session = call_sessions.get(cc_id, {})
+            duration = time.time() - session.get("start", time.time())
+            experiments[exp_id]["variants"][variant]["total_duration"] += duration
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "Thank you. Connecting you now.", "voice": "female", "language": "en-US"})
+
+    elif event_type == "call.hangup":
+        session = call_sessions.pop(cc_id, {})
+        exp_id = session.get("exp_id")
+        variant = session.get("variant", "A")
+        if exp_id and exp_id in experiments and not session.get("completed"):
+            experiments[exp_id]["variants"][variant]["dropoffs"] += 1
+
+    return jsonify({"status": "ok"})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-ivr-ab-tester"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-ivr-ab-tester-python/requirements.txt
+++ b/edge-ivr-ab-tester-python/requirements.txt
@@ -1,0 +1,5 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+boto3>=1.34
+cryptography>=42.0

--- a/edge-merge-ai-receptionist-python/.env.example
+++ b/edge-merge-ai-receptionist-python/.env.example
@@ -1,0 +1,11 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Phone number — https://portal.telnyx.com/numbers/my-numbers
+TELNYX_PHONE_NUMBER=+1xxxxxxxxxx
+# Merge.dev API key — https://app.merge.dev/keys
+MERGE_API_KEY=
+# Merge linked account token
+MERGE_ACCOUNT_TOKEN=
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-merge-ai-receptionist-python/API.md
+++ b/edge-merge-ai-receptionist-python/API.md
@@ -1,0 +1,84 @@
+# API Reference -- Edge Merge AI Receptionist
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/messages` | Messages |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /messages`
+
+Messages.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/messages
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-merge-ai-receptionist-python/GUIDE.md
+++ b/edge-merge-ai-receptionist-python/GUIDE.md
@@ -1,0 +1,198 @@
+# Build a Edge Merge AI Receptionist
+
+Edge worker answers every call. Matches requested name against Merge HRIS employees and CRM contacts simultaneously. Employees get transferred, CRM contacts get deal-context briefings, unknown callers are screened.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-merge-ai-receptionist-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (188 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params)
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`find_employee_by_name()`** -- Find Employee By Name.
+
+```python
+def find_employee_by_name(name):
+    result = merge_get("/hris/v1/employees", params={"display_full_name": name})
+    if result and result.get("results"):
+        return result["results"][0]
+    return None
+```
+
+**`find_crm_contact()`** -- Find Crm Contact.
+
+```python
+def find_crm_contact(name):
+    result = merge_get("/crm/v1/contacts", params={"name": name})
+    if result and result.get("results"):
+        return result["results"][0]
+    return None
+```
+
+**`get_deals_for_contact()`** -- Get Deals For Contact.
+
+```python
+def get_deals_for_contact(contact_id):
+    result = merge_get("/crm/v1/opportunities", params={"contact_id": contact_id})
+    return (result or {}).get("results", [])
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [
+                {"role": "system", "content": f"You are a professional receptionist. Use this context to route the call:\n{json.dumps(context)}\nBe concise. 1-2 sentences."},
+                {"role": "user", "content": prompt}
+            ]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/messages` | Messages |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-merge-ai-receptionist"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-merge-ai-receptionist-python/README.md
+++ b/edge-merge-ai-receptionist-python/README.md
@@ -1,0 +1,162 @@
+---
+name: edge-merge-ai-receptionist
+title: "Edge Merge AI Receptionist"
+description: "Edge worker answers every call."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, AI Inference]
+integrations: [Merge HRIS, Merge CRM]
+channel: [voice]
+---
+
+# Edge Merge AI Receptionist
+
+> Also known as: AI receptionist, smart receptionist, auto attendant, intelligent call routing.
+
+Edge worker answers every call. Matches requested name against Merge HRIS employees and CRM contacts simultaneously. Employees get transferred, CRM contacts get deal-context briefings, unknown callers are screened.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: programmable voice, AI inference, and edge compute run on one privately owned global network, so the receptionist answers, reasons, and routes calls without hopping between vendors. Call Control TTS and speech gathering, the chat-completions inference endpoint, and live PSTN transfers are all driven from a single API and account. Keeping media and AI on Telnyx's private backbone cuts latency between the greeting, the Merge lookup, and the transfer so callers never wait on a hand-off.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-merge-ai-receptionist-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /messages`
+
+Messages.
+
+```bash
+curl http://localhost:5000/messages
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-ai-receptionist"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-ai-receptionist"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/messages` | Messages |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing or wrong | Set `TELNYX_PUBLIC_KEY` to the base64 public key from the [Portal](https://portal.telnyx.com); the app rejects every webhook when it is empty. |
+| Webhooks never arrive / call rings forever | Telnyx cannot reach your local server | Confirm `ngrok http 5000` is running and the Call Control Application's Webhook URL points to `https://<id>.ngrok.io/webhooks/voice`. |
+| Calls connect but no one is found / no transfer | `MERGE_API_KEY` or `MERGE_ACCOUNT_TOKEN` missing or unset | Fill both in `.env`; HRIS and CRM lookups silently return no results without a valid Merge key and account token. |
+| Greeting plays but AI briefing is generic | `TELNYX_API_KEY` invalid or `AI_MODEL` not available | Verify the API key in the [Portal](https://portal.telnyx.com/api-keys); inference falls back to "Let me transfer you now." on any error. |
+
+## Related Examples
+
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- core Call Control answer/gather/transfer flow for an AI agent
+- [omnichannel-ai-receptionist-python](../omnichannel-ai-receptionist-python/) -- AI receptionist across voice and messaging channels
+- [edge-merge-reference-checker-python](../edge-merge-reference-checker-python/) -- edge worker driving calls against Merge data
+- [merge-employee-hotline-python](../merge-employee-hotline-python/) -- routes callers to employees pulled from Merge HRIS
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-merge-ai-receptionist-python/app.py
+++ b/edge-merge-ai-receptionist-python/app.py
@@ -1,0 +1,221 @@
+"""Edge Merge AI Receptionist — edge worker answers calls, matches caller against
+Merge HRIS employees AND CRM contacts. Internal: transfer. External known contact:
+pull deal context, whisper brief. Unknown: screen and take message."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+WEBHOOK_TOLERANCE_SECS = 300  # reject webhooks older than 5 minutes (replay protection)
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {"Authorization": f"Bearer {MERGE_API_KEY}", "X-Account-Token": MERGE_ACCOUNT_TOKEN or "", "Content-Type": "application/json"}
+MERGE_BASE = "https://api.merge.dev/api"
+
+call_sessions = {}
+messages = []
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 webhook signature over "<timestamp>|<raw body>".
+
+    Telnyx signs the bytes ``b"<telnyx-timestamp>|<raw request body>"`` with its
+    Ed25519 key; the base64 public key is in the Portal. Rejects bad signatures
+    and timestamps older than WEBHOOK_TOLERANCE_SECS (replay protection)."""
+    if not TELNYX_PUBLIC_KEY:
+        app.logger.error("TELNYX_PUBLIC_KEY not configured; rejecting webhook")
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > WEBHOOK_TOLERANCE_SECS:
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        signed = f"{timestamp}|".encode() + raw_body
+        public_key.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError) as e:
+        app.logger.error("Webhook signature verification failed: %s", e)
+        return False
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params)
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+def find_employee_by_name(name):
+    result = merge_get("/hris/v1/employees", params={"display_full_name": name})
+    if result and result.get("results"):
+        return result["results"][0]
+    return None
+
+def find_crm_contact(name):
+    result = merge_get("/crm/v1/contacts", params={"name": name})
+    if result and result.get("results"):
+        return result["results"][0]
+    return None
+
+def get_deals_for_contact(contact_id):
+    result = merge_get("/crm/v1/opportunities", params={"contact_id": contact_id})
+    return (result or {}).get("results", [])
+
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [
+                {"role": "system", "content": f"You are a professional receptionist. Use this context to route the call:\n{json.dumps(context)}\nBe concise. 1-2 sentences."},
+                {"role": "user", "content": prompt}
+            ]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "Let me transfer you now."
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting it.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        caller = ep.get("from", "")
+        call_sessions[cc_id] = {"caller": caller, "ts": time.time()}
+        ttl_cleanup(call_sessions)
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                      headers=HEADERS, timeout=10,
+                      json={"client_state": encode_state({"step": "greeting"})})
+
+    elif event_type == "call.answered":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "Thank you for calling. Who would you like to speak with?",
+                            "voice": "female", "language": "en-US", "input_type": "speech", "timeout_secs": 15,
+                            "client_state": encode_state({"step": "who"})})
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        state = decode_state(ep.get("client_state", ""))
+        session = call_sessions.get(cc_id, {})
+
+        if state.get("step") == "who" and speech:
+            employee = find_employee_by_name(speech)
+            if employee:
+                emp_phone = None
+                for pn in employee.get("phone_numbers", []):
+                    if pn.get("value"):
+                        emp_phone = pn["value"]
+                        break
+                if emp_phone:
+                    requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                                  headers=HEADERS, timeout=10,
+                                  json={"payload": f"Connecting you to {employee.get('first_name', '')} now.",
+                                        "voice": "female", "language": "en-US",
+                                        "client_state": encode_state({"step": "transferring", "target": emp_phone})})
+                    return jsonify({"status": "ok"})
+            contact = find_crm_contact(speech)
+            if contact:
+                deals = get_deals_for_contact(contact.get("id", ""))
+                session["context"] = {"contact": contact.get("name"), "deals": len(deals)}
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": f"I found {speech} in our system. How can I help you today?",
+                                    "voice": "female", "language": "en-US", "input_type": "speech", "timeout_secs": 30,
+                                    "client_state": encode_state({"step": "conversation"})})
+            else:
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": "I could not find that person. Can I take a message?",
+                                    "voice": "female", "language": "en-US", "input_type": "speech", "timeout_secs": 60,
+                                    "client_state": encode_state({"step": "message"})})
+
+        elif state.get("step") == "message" and speech:
+            messages.append({"caller": session.get("caller"), "message": speech, "ts": time.time()})
+            if len(messages) > MAX_ENTRIES:
+                messages[:] = messages[-MAX_ENTRIES:]
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "Thank you. I have recorded your message. Goodbye.",
+                                "voice": "female", "language": "en-US"})
+
+        elif state.get("step") == "conversation" and speech:
+            context = session.get("context", {})
+            response = call_inference(speech, context)
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": response, "voice": "female", "language": "en-US",
+                                "input_type": "speech", "timeout_secs": 30,
+                                "client_state": encode_state({"step": "conversation"})})
+
+    elif event_type == "call.speak.ended":
+        state = decode_state(ep.get("client_state", ""))
+        if state.get("step") == "transferring":
+            target = state.get("target")
+            if target:
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/transfer",
+                              headers=HEADERS, timeout=10, json={"to": target})
+        else:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+                          headers=HEADERS, timeout=10)
+
+    elif event_type == "call.hangup":
+        call_sessions.pop(cc_id, None)
+
+    return jsonify({"status": "ok"})
+
+@app.route("/messages", methods=["GET"])
+def get_messages():
+    return jsonify({"messages": messages[-50:]})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-merge-ai-receptionist"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-merge-ai-receptionist-python/requirements.txt
+++ b/edge-merge-ai-receptionist-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/edge-merge-reference-checker-python/.env.example
+++ b/edge-merge-reference-checker-python/.env.example
@@ -1,0 +1,14 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Phone number — https://portal.telnyx.com/numbers/my-numbers
+TELNYX_PHONE_NUMBER=+1xxxxxxxxxx
+# Call Control app — https://portal.telnyx.com/call-control/applications
+TELNYX_CONNECTION_ID=
+# Merge.dev API key — https://app.merge.dev/keys
+MERGE_API_KEY=
+# Merge linked account token
+MERGE_ACCOUNT_TOKEN=
+HIRING_MANAGER_PHONE=+1xxxxxxxxxx
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-merge-reference-checker-python/API.md
+++ b/edge-merge-reference-checker-python/API.md
@@ -1,0 +1,129 @@
+# API Reference -- Edge Merge Reference Checker
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/check` | Check |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/reports` | Reports |
+| `GET` | `/reports/<check_id>` | <Check Id> |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /check`
+
+Check.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/check \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /reports`
+
+Reports.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/reports
+```
+
+---
+
+## `GET /reports/<check_id>`
+
+<Check Id>.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/reports/<check_id>
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-merge-reference-checker-python/GUIDE.md
+++ b/edge-merge-reference-checker-python/GUIDE.md
@@ -1,0 +1,210 @@
+# Build a Edge Merge Reference Checker
+
+ATS application reaches reference-check stage. Calls each reference. AI conducts structured 5-question interview, scores responses, updates ATS, SMS summary to hiring manager.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-merge-reference-checker-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (208 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params)
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`merge_patch()`** -- Merge Patch.
+
+```python
+def merge_patch(path, data):
+    try:
+        resp = requests.patch(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data})
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge PATCH %s failed: %s", path, e)
+    return None
+```
+
+**`score_reference()`** -- Score Reference.
+
+```python
+def score_reference(answers):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [
+                {"role": "system", "content": "Score this reference check. Respond with JSON: {\"overall_score\": 1-5, \"strengths\": [list], \"concerns\": [list], \"recommendation\": \"strong yes|yes|neutral|no|strong no\", \"summary\": \"2 sentence summary\"}"},
+                {"role": "user", "content": json.dumps(answers)}
+            ],
+            "response_format": {"type": "json_object"}
+        })
+        if resp.ok:
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+```
+
+**`start_reference_check()`** -- Start Reference Check.
+
+```python
+def start_reference_check():
+    data = request.get_json() or {}
+    candidate_name = data.get("candidate_name", "the candidate")
+    references = data.get("references", [])
+    application_id = data.get("application_id", "")
+    if not references:
+        return jsonify({"error": "references array required (each with name and phone)"}), 400
+    check_id = f"ref-{int(time.time())}"
+    reference_reports[check_id] = {
+        "id": check_id, "candidate": candidate_name, "application_id": application_id,
+        "references": [], "status": "in_progress", "ts": time.time()
+    }
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.answered":
+```
+
+**`list_reports()`** -- List Reports.
+
+```python
+def list_reports():
+    return jsonify({"reports": list(reference_reports.values())})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/check` | Check |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/reports` | Reports |
+| `GET` | `/reports/<check_id>` | <Check Id> |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-merge-reference-checker"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-merge-reference-checker-python/README.md
+++ b/edge-merge-reference-checker-python/README.md
@@ -1,0 +1,195 @@
+---
+name: edge-merge-reference-checker
+title: "Edge Merge Reference Checker"
+description: "ATS application reaches reference-check stage."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, AI Inference, Messaging]
+integrations: [Merge ATS]
+channel: [voice, sms]
+---
+
+# Edge Merge Reference Checker
+
+> Also known as: reference check automation, automated reference calls, hiring reference checker.
+
+ATS application reaches reference-check stage. Calls each reference. AI conducts structured 5-question interview, scores responses, updates ATS, SMS summary to hiring manager.
+
+## Why Telnyx
+
+This example runs outbound voice calls, real-time AI inference, and SMS notifications on Telnyx's **AI Communications Infrastructure** — one private global network instead of bolting together separate voice, AI, and messaging vendors. The same API key places the reference call, scores the responses with AI Inference, and texts the hiring manager the summary, so reference checks complete end-to-end with low latency and a single point of integration.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `HIRING_MANAGER_PHONE` | `string` | `+12125551234` | no | Hiring manager phone | -- |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-merge-reference-checker-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /check`
+
+Check.
+
+```bash
+curl -X POST http://localhost:5000/check \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /reports`
+
+Reports.
+
+```bash
+curl http://localhost:5000/reports
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-reference-checker"}
+```
+
+### `GET /reports/<check_id>`
+
+<Check Id>.
+
+```bash
+curl http://localhost:5000/reports/<check_id>
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-reference-checker"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-reference-checker"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/check` | Check |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/reports` | Reports |
+| `GET` | `/reports/<check_id>` | <Check Id> |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing or wrong, so Ed25519 verification fails | Set `TELNYX_PUBLIC_KEY` from [Portal -> Keys & Credentials -> Public Key](https://portal.telnyx.com); it must be the base64 public key, not the API key |
+| Reference calls never place | `TELNYX_CONNECTION_ID`, `TELNYX_PHONE_NUMBER`, or `TELNYX_API_KEY` unset | Fill all required vars in `.env`; the Connection ID must be a Call Control Application |
+| Webhooks not received / signature timestamp rejected | Telnyx cannot reach your local server, or clock skew exceeds the 5-min replay window | Expose the server with `ngrok http 5000`, set the public HTTPS URL as the Call Control webhook, and sync your machine clock |
+| No SMS summary to hiring manager | `HIRING_MANAGER_PHONE` not set, or no references completed all questions | Set `HIRING_MANAGER_PHONE` in E.164 format; SMS only fires once every reference finishes the interview |
+| AI score always returns the `3` fallback | AI Inference call failed (bad `TELNYX_API_KEY` or model name) | Verify the API key and that `AI_MODEL` is a valid [Telnyx model](https://developers.telnyx.com/docs/inference/models) |
+
+## Related Examples
+
+- [edge-merge-ai-receptionist-python](../edge-merge-ai-receptionist-python/) — Edge voice + Merge ATS/CRM AI receptionist sibling
+- [edge-merge-shift-coverage-python](../edge-merge-shift-coverage-python/) — outbound voice + Merge integration for filling open shifts
+- [ai-hiring-phone-screen-python](../ai-hiring-phone-screen-python/) — AI-conducted structured phone screen for candidates
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — Call Control patterns for connecting calls to an AI agent
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-merge-reference-checker-python/app.py
+++ b/edge-merge-reference-checker-python/app.py
@@ -1,0 +1,237 @@
+"""Edge Merge Reference Checker — ATS application reaches reference-check stage.
+Calls each reference. AI conducts structured interview with scored questions.
+Updates ATS with results. SMS summary to hiring manager."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HIRING_MANAGER_PHONE = os.getenv("HIRING_MANAGER_PHONE", "")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {"Authorization": f"Bearer {MERGE_API_KEY}", "X-Account-Token": MERGE_ACCOUNT_TOKEN or "", "Content-Type": "application/json"}
+MERGE_BASE = "https://api.merge.dev/api"
+
+def verify_telnyx_signature(body: bytes, headers: dict, tolerance: int = 300) -> bool:
+    """Verify the Telnyx Ed25519 signature over "<telnyx-timestamp>|<raw body>".
+
+    Telnyx signs every webhook (telnyx-signature-ed25519 / telnyx-timestamp headers).
+    This app uses raw requests rather than the Telnyx SDK, so verify directly with the
+    public key (Portal > Keys & Credentials > Public Key). Reject >5 min skew (replay).
+    """
+    sig_b64 = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not (sig_b64 and timestamp and TELNYX_PUBLIC_KEY):
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > tolerance:
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        public_key.verify(base64.b64decode(sig_b64), f"{timestamp}|".encode() + body)
+        return True
+    except (InvalidSignature, ValueError, Exception):
+        return False
+
+
+QUESTIONS = [
+    "How long did you work with the candidate and in what capacity?",
+    "What were their greatest strengths in the role?",
+    "Can you describe a challenging situation they handled well?",
+    "On a scale of 1 to 5, how strongly would you recommend them for a similar role?",
+    "Is there anything else you think we should know?"
+]
+
+call_sessions = {}
+reference_reports = {}
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try: return json.loads(base64.b64decode(b64).decode())
+    except: return {}
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params)
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+def merge_patch(path, data):
+    try:
+        resp = requests.patch(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data})
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge PATCH %s failed: %s", path, e)
+    return None
+
+def score_reference(answers):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [
+                {"role": "system", "content": "Score this reference check. Respond with JSON: {\"overall_score\": 1-5, \"strengths\": [list], \"concerns\": [list], \"recommendation\": \"strong yes|yes|neutral|no|strong no\", \"summary\": \"2 sentence summary\"}"},
+                {"role": "user", "content": json.dumps(answers)}
+            ],
+            "response_format": {"type": "json_object"}
+        })
+        if resp.ok:
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+    except Exception as e:
+        app.logger.error("Scoring failed: %s", e)
+    return {"overall_score": 3, "summary": "Unable to score automatically."}
+
+@app.route("/check", methods=["POST"])
+def start_reference_check():
+    data = request.get_json() or {}
+    candidate_name = data.get("candidate_name", "the candidate")
+    references = data.get("references", [])
+    application_id = data.get("application_id", "")
+    if not references:
+        return jsonify({"error": "references array required (each with name and phone)"}), 400
+    check_id = f"ref-{int(time.time())}"
+    reference_reports[check_id] = {
+        "id": check_id, "candidate": candidate_name, "application_id": application_id,
+        "references": [], "status": "in_progress", "ts": time.time()
+    }
+    for ref in references:
+        phone = ref.get("phone")
+        if not phone:
+            continue
+        ref_id = f"{check_id}-{len(reference_reports[check_id]['references'])}"
+        call_sessions[ref_id] = {
+            "check_id": check_id, "reference_name": ref.get("name", ""),
+            "candidate": candidate_name, "question_idx": 0, "answers": [], "ts": time.time()
+        }
+        ttl_cleanup(call_sessions)
+        try:
+            requests.post("https://api.telnyx.com/v2/calls", headers=HEADERS, timeout=10, json={
+                "connection_id": CONNECTION_ID, "to": phone, "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice"
+            })
+        except Exception as e:
+            app.logger.error("Reference call to %s failed: %s", phone, e)
+    return jsonify({"status": "calling", "check_id": check_id, "references": len(references)})
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    # request.headers is case-insensitive (Werkzeug); dict() would Title-case keys
+    # and break the lowercase header lookups in verify_telnyx_signature.
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.answered":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": f"Hello, this is an automated reference check call. I have a few questions. {QUESTIONS[0]}",
+                            "voice": "female", "language": "en-US", "input_type": "speech", "timeout_secs": 60,
+                            "client_state": encode_state({"step": "question", "q_idx": 0})})
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        state = decode_state(ep.get("client_state", ""))
+        q_idx = state.get("q_idx", 0)
+        session = None
+        for k, v in call_sessions.items():
+            if k.startswith("ref-"):
+                session = v
+                session_key = k
+                break
+        if session and speech:
+            session["answers"].append({"question": QUESTIONS[q_idx], "answer": speech})
+            next_idx = q_idx + 1
+            if next_idx < len(QUESTIONS):
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": QUESTIONS[next_idx], "voice": "female", "language": "en-US",
+                                    "input_type": "speech", "timeout_secs": 60,
+                                    "client_state": encode_state({"step": "question", "q_idx": next_idx})})
+            else:
+                scored = score_reference(session["answers"])
+                check_id = session.get("check_id")
+                report = reference_reports.get(check_id, {})
+                report.setdefault("references", []).append({
+                    "name": session.get("reference_name"), "answers": session["answers"], "score": scored
+                })
+                if len(report["references"]) >= len([s for s in call_sessions.values() if s.get("check_id") == check_id]):
+                    report["status"] = "complete"
+                    if HIRING_MANAGER_PHONE:
+                        avg_score = sum(r.get("score", {}).get("overall_score", 3) for r in report["references"]) / max(len(report["references"]), 1)
+                        try:
+                            requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                                          json={"from": TELNYX_PHONE, "to": HIRING_MANAGER_PHONE,
+                                                "text": f"Reference check complete for {report.get('candidate', '')}. Avg score: {avg_score:.1f}/5. {len(report['references'])} references checked."})
+                        except Exception as e:
+                            app.logger.error("Summary SMS failed: %s", e)
+                    if report.get("application_id"):
+                        merge_patch(f"/ats/v1/applications/{report['application_id']}", {"current_stage": "reference_complete"})
+                requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                              headers=HEADERS, timeout=10,
+                              json={"payload": "Thank you for your time. Your responses have been recorded. Goodbye.",
+                                    "voice": "female", "language": "en-US"})
+
+    elif event_type == "call.speak.ended":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+                      headers=HEADERS, timeout=10)
+
+    elif event_type == "call.hangup":
+        for k in list(call_sessions.keys()):
+            if k.startswith("ref-"):
+                del call_sessions[k]
+                break
+
+    return jsonify({"status": "ok"})
+
+@app.route("/reports", methods=["GET"])
+def list_reports():
+    return jsonify({"reports": list(reference_reports.values())})
+
+@app.route("/reports/<check_id>", methods=["GET"])
+def get_report(check_id):
+    report = reference_reports.get(check_id)
+    if not report:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(report)
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-merge-reference-checker"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-merge-reference-checker-python/requirements.txt
+++ b/edge-merge-reference-checker-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/edge-merge-shift-coverage-python/.env.example
+++ b/edge-merge-shift-coverage-python/.env.example
@@ -1,0 +1,13 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Phone number — https://portal.telnyx.com/numbers/my-numbers
+TELNYX_PHONE_NUMBER=+1xxxxxxxxxx
+# Call Control app — https://portal.telnyx.com/call-control/applications
+TELNYX_CONNECTION_ID=
+# Merge.dev API key — https://app.merge.dev/keys
+MERGE_API_KEY=
+# Merge linked account token
+MERGE_ACCOUNT_TOKEN=
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-merge-shift-coverage-python/API.md
+++ b/edge-merge-shift-coverage-python/API.md
@@ -1,0 +1,105 @@
+# API Reference -- Edge Merge Shift Coverage
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/sms` | Sms |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/shifts` | Shifts |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/sms`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /shifts`
+
+Shifts.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/shifts
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-merge-shift-coverage-python/GUIDE.md
+++ b/edge-merge-shift-coverage-python/GUIDE.md
@@ -1,0 +1,212 @@
+# Build a Edge Merge Shift Coverage
+
+Manager texts need a closer tonight. Edge worker checks HRIS schedule via Merge, calls available employees in priority order, negotiates, confirms via SMS to both parties.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-merge-shift-coverage-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (201 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params)
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`get_available_employees()`** -- Get Available Employees.
+
+```python
+def get_available_employees():
+    result = merge_get("/hris/v1/employees", params={"employment_status": "ACTIVE", "page_size": 50})
+    employees = (result or {}).get("results", [])
+    available = []
+    for emp in employees:
+        phone = None
+        for pn in emp.get("phone_numbers", []):
+            if pn.get("value"):
+                phone = pn["value"]
+                break
+        if phone:
+            available.append({"id": emp.get("id"), "name": f"{emp.get('first_name', '')} {emp.get('last_name', '')}".strip(), "phone": phone})
+```
+
+**`call_next_employee()`** -- Call Next Employee.
+
+```python
+def call_next_employee(shift_id):
+    shift = shift_requests.get(shift_id)
+    if not shift:
+        return
+    candidates = shift.get("candidates", [])
+    idx = shift.get("current_idx", 0)
+    if idx >= len(candidates):
+        manager_phone = shift.get("manager_phone")
+        if manager_phone:
+            try:
+                requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                              json={"from": TELNYX_PHONE, "to": manager_phone,
+```
+
+**`handle_sms()`** -- Handle Sms.
+
+```python
+def handle_sms():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    ep = event.get("payload", {})
+    text = ep.get("text", "").strip().lower()
+    sender = ep.get("from", {})
+    if isinstance(sender, dict):
+        sender = sender.get("phone_number", "")
+    if "need" in text and ("closer" in text or "shift" in text or "cover" in text):
+        shift_id = f"shift-{int(time.time())}"
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.answered":
+```
+
+**`list_shifts()`** -- List Shifts.
+
+```python
+def list_shifts():
+    return jsonify({"shifts": list(shift_requests.values())})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/sms` | Sms |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/shifts` | Shifts |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-merge-shift-coverage"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-merge-shift-coverage-python/README.md
+++ b/edge-merge-shift-coverage-python/README.md
@@ -1,0 +1,162 @@
+---
+name: edge-merge-shift-coverage
+title: "Edge Merge Shift Coverage"
+description: "Manager texts need a closer tonight."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, Messaging]
+integrations: [Merge HRIS]
+channel: [voice, sms]
+---
+
+# Edge Merge Shift Coverage
+
+> Also known as: shift coverage, schedule filling, employee availability, shift management.
+
+Manager texts need a closer tonight. Edge worker checks HRIS schedule via Merge, calls available employees in priority order, negotiates, confirms via SMS to both parties.
+
+## Why Telnyx
+
+This example runs SMS, outbound voice calls, and AI inference over Telnyx's **AI Communications Infrastructure** -- a single private global network where messaging, programmable voice, and AI live together instead of being stitched across separate vendors. The inbound manager text, the priority-ordered employee calls with TTS negotiation, and the confirmation SMS to both parties all flow through one Telnyx account and one set of credentials, so a shift-coverage workflow stays low-latency and easy to operate end to end.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-merge-shift-coverage-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /shifts`
+
+Shifts.
+
+```bash
+curl http://localhost:5000/shifts
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-shift-coverage"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-merge-shift-coverage"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/sms` | Sms |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/shifts` | Shifts |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| `401 invalid signature` on `/webhooks/sms` or `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing, wrong, or the request was tampered with | Set `TELNYX_PUBLIC_KEY` to the Ed25519 public key from [Portal -> Keys & Credentials](https://portal.telnyx.com); it must be the base64 value, not the API key. |
+| Webhooks never arrive / call never starts | The webhook URL is not reachable from Telnyx, or `ngrok` is down | Re-run `ngrok http 5000`, then point the Call Control Application webhook URL at `https://<id>.ngrok.io/webhooks/voice`. The manager-text SMS profile must point at `/webhooks/sms`. |
+| App exits or calls fail with auth errors | A required env var is unset (`TELNYX_API_KEY`, `TELNYX_PHONE_NUMBER`, `TELNYX_CONNECTION_ID`) | Confirm `.env` is filled in from `.env.example`; `TELNYX_CONNECTION_ID` must be the Call Control Application ID used to place outbound calls. |
+| `"Calling 0 available employees now."` | Merge returned no employees with phone numbers | Verify `MERGE_API_KEY` and `MERGE_ACCOUNT_TOKEN`, that the linked HRIS account has `ACTIVE` employees, and that those records include phone numbers. |
+
+## Related Examples
+
+- [shift-fill-engine-python](../shift-fill-engine-python/) -- standalone shift-fill workflow without the Edge/Merge layer
+- [edge-merge-ai-receptionist-python](../edge-merge-ai-receptionist-python/) -- sibling Edge + Merge HRIS example using voice and AI
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- Call Control routing and AI-driven voice interaction
+- [merge-employee-hotline-python](../merge-employee-hotline-python/) -- employee-facing voice line backed by Merge HRIS data
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-merge-shift-coverage-python/app.py
+++ b/edge-merge-shift-coverage-python/app.py
@@ -1,0 +1,231 @@
+"""Edge Merge Shift Coverage — manager texts need a closer tonight. Edge worker checks
+HRIS schedule via Merge, calls available employees in priority order, negotiates,
+confirms via SMS to both parties."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {"Authorization": f"Bearer {MERGE_API_KEY}", "X-Account-Token": MERGE_ACCOUNT_TOKEN or "", "Content-Type": "application/json"}
+MERGE_BASE = "https://api.merge.dev/api"
+
+
+def verify_telnyx_signature(body: bytes, headers, tolerance: int = 300) -> bool:
+    """Verify the inbound Telnyx Ed25519 signature over "<timestamp>|<raw body>".
+
+    Telnyx signs every webhook (telnyx-signature-ed25519 / telnyx-timestamp headers).
+    Public key from Portal > Keys & Credentials. Rejects timestamps older than
+    ``tolerance`` seconds (replay protection).
+    """
+    sig_b64 = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not (sig_b64 and timestamp and TELNYX_PUBLIC_KEY):
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > tolerance:  # replay protection
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        public_key.verify(base64.b64decode(sig_b64), f"{timestamp}|".encode() + body)
+        return True
+    except (InvalidSignature, ValueError, Exception):
+        return False
+
+
+shift_requests = {}
+call_sessions = {}
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try: return json.loads(base64.b64decode(b64).decode())
+    except: return {}
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params)
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+def get_available_employees():
+    result = merge_get("/hris/v1/employees", params={"employment_status": "ACTIVE", "page_size": 50})
+    employees = (result or {}).get("results", [])
+    available = []
+    for emp in employees:
+        phone = None
+        for pn in emp.get("phone_numbers", []):
+            if pn.get("value"):
+                phone = pn["value"]
+                break
+        if phone:
+            available.append({"id": emp.get("id"), "name": f"{emp.get('first_name', '')} {emp.get('last_name', '')}".strip(), "phone": phone})
+    return available
+
+def call_next_employee(shift_id):
+    shift = shift_requests.get(shift_id)
+    if not shift:
+        return
+    candidates = shift.get("candidates", [])
+    idx = shift.get("current_idx", 0)
+    if idx >= len(candidates):
+        manager_phone = shift.get("manager_phone")
+        if manager_phone:
+            try:
+                requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                              json={"from": TELNYX_PHONE, "to": manager_phone,
+                                    "text": f"Could not fill shift: {shift.get('description', '')}. All candidates declined or unavailable."})
+            except Exception as e:
+                app.logger.error("Escalation SMS failed: %s", e)
+        return
+    candidate = candidates[idx]
+    shift["current_idx"] = idx + 1
+    try:
+        resp = requests.post("https://api.telnyx.com/v2/calls", headers=HEADERS, timeout=10, json={
+            "connection_id": CONNECTION_ID, "to": candidate["phone"], "from": TELNYX_PHONE,
+            "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice" if hasattr(request, "url_root") else ""
+        })
+        call_sessions[f"shift-{shift_id}-{idx}"] = {"shift_id": shift_id, "candidate": candidate, "ts": time.time()}
+    except Exception as e:
+        app.logger.error("Call to %s failed: %s", candidate["name"], e)
+        call_next_employee(shift_id)
+
+@app.route("/webhooks/sms", methods=["POST"])
+def handle_sms():
+    # Verify the Telnyx Ed25519 signature over the RAW body before trusting it.
+    if not verify_telnyx_signature(request.get_data(), request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    ep = event.get("payload", {})
+    text = ep.get("text", "").strip().lower()
+    sender = ep.get("from", {})
+    if isinstance(sender, dict):
+        sender = sender.get("phone_number", "")
+    if "need" in text and ("closer" in text or "shift" in text or "cover" in text):
+        shift_id = f"shift-{int(time.time())}"
+        candidates = get_available_employees()
+        shift_requests[shift_id] = {
+            "id": shift_id, "manager_phone": sender, "description": text,
+            "candidates": candidates, "current_idx": 0, "status": "calling", "ts": time.time()
+        }
+        ttl_cleanup(shift_requests)
+        try:
+            requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                          json={"from": TELNYX_PHONE, "to": sender,
+                                "text": f"Got it. Calling {len(candidates)} available employees now."})
+        except Exception as e:
+            app.logger.error("Ack SMS failed: %s", e)
+        if candidates:
+            call_next_employee(shift_id)
+    return jsonify({"status": "ok"})
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature over the RAW body before trusting it.
+    if not verify_telnyx_signature(request.get_data(), request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.answered":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "Hi, we need shift coverage tonight. Can you work the closing shift? Press 1 for yes, 2 for no.",
+                            "voice": "female", "language": "en-US", "minimum_digits": 1, "maximum_digits": 1,
+                            "client_state": encode_state({"step": "ask"})})
+
+    elif event_type == "call.gather.ended":
+        digits = ep.get("digits", "")
+        session_key = None
+        session = None
+        for k, v in call_sessions.items():
+            if k.startswith("shift-"):
+                session_key = k
+                session = v
+                break
+        if digits == "1" and session:
+            shift_id = session.get("shift_id")
+            shift = shift_requests.get(shift_id, {})
+            candidate = session.get("candidate", {})
+            shift["status"] = "filled"
+            shift["filled_by"] = candidate.get("name")
+            manager_phone = shift.get("manager_phone")
+            if manager_phone:
+                try:
+                    requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                                  json={"from": TELNYX_PHONE, "to": manager_phone,
+                                        "text": f"Shift covered! {candidate.get('name', '')} accepted."})
+                    requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                                  json={"from": TELNYX_PHONE, "to": candidate.get("phone", ""),
+                                        "text": "Confirmed! You are on the closing shift tonight. Thanks!"})
+                except Exception as e:
+                    app.logger.error("Confirmation SMS failed: %s", e)
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "Great, you are confirmed. Check your texts for details. Thank you!",
+                                "voice": "female", "language": "en-US"})
+        else:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "No problem. Have a good evening.", "voice": "female", "language": "en-US"})
+            if session:
+                shift_id = session.get("shift_id")
+                call_next_employee(shift_id)
+
+    elif event_type == "call.speak.ended":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+                      headers=HEADERS, timeout=10)
+
+    elif event_type == "call.hangup":
+        for k in list(call_sessions.keys()):
+            if k.startswith("shift-"):
+                del call_sessions[k]
+                break
+
+    return jsonify({"status": "ok"})
+
+@app.route("/shifts", methods=["GET"])
+def list_shifts():
+    return jsonify({"shifts": list(shift_requests.values())})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-merge-shift-coverage"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-merge-shift-coverage-python/requirements.txt
+++ b/edge-merge-shift-coverage-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=41.0

--- a/edge-number-masking-python/.env.example
+++ b/edge-number-masking-python/.env.example
@@ -1,0 +1,8 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Cloud Storage bucket — https://portal.telnyx.com/storage
+STORAGE_BUCKET=my-bucket
+# Messaging profile — https://portal.telnyx.com/messaging/profiles
+MESSAGING_PROFILE_ID=

--- a/edge-number-masking-python/API.md
+++ b/edge-number-masking-python/API.md
@@ -1,0 +1,156 @@
+# API Reference -- Edge Number Masking
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/pool` | Pool |
+| `POST` | `/bookings` | Bookings |
+| `DELETE` | `/bookings/<booking_id>` | <Booking Id> |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/bookings` | Bookings |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /pool`
+
+Pool.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/pool \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /bookings`
+
+Bookings.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/bookings \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `DELETE /bookings/<booking_id>`
+
+<Booking Id>.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/bookings/<booking_id>
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.recording.saved` | Recording available for download |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /bookings`
+
+Bookings.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/bookings
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-number-masking-python/GUIDE.md
+++ b/edge-number-masking-python/GUIDE.md
@@ -1,0 +1,202 @@
+# Build a Edge Number Masking
+
+Marketplace-style proxy number pool at the edge. Dynamically assigns masked number pairs per booking, routes calls bidirectionally through the proxy, records for dispute resolution, and auto-expires at checkout.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Numbers** -- search, order, and manage phone numbers
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **Call Recording** -- record calls for compliance and quality
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Reject**: `POST /v2/calls/{id}/actions/reject` -- [API reference](https://developers.telnyx.com/api/call-control/reject-call)
+- **Call Control: Record Start**: `POST /v2/calls/{id}/actions/record_start` -- [API reference](https://developers.telnyx.com/api/call-control/start-recording)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.recording.saved` -- Recording available for download
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-number-masking-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (146 lines). Here is what each piece does.
+
+
+**`ttl_cleanup_masks()`** -- Ttl Cleanup Masks.
+
+```python
+def ttl_cleanup_masks():
+    now = time.time()
+    expired = [k for k, v in active_masks.items() if v.get("expires_at", float("inf")) < now]
+    for k in expired:
+        booking_id = active_masks[k].get("booking_id")
+        proxy_pool.append(k)
+        del active_masks[k]
+        bookings.pop(booking_id, None)
+        app.logger.info("Expired mask for booking %s, returned %s to pool", booking_id, k)
+```
+
+**`add_to_pool()`** -- Add To Pool.
+
+```python
+def add_to_pool():
+    data = request.get_json() or {}
+    numbers = data.get("numbers", [])
+    if not numbers:
+        return jsonify({"error": "numbers array required"}), 400
+    proxy_pool.extend(numbers)
+    return jsonify({"status": "added", "pool_size": len(proxy_pool)})
+```
+
+**`create_booking()`** -- Create Booking.
+
+```python
+def create_booking():
+    ttl_cleanup_masks()
+    data = request.get_json() or {}
+    party_a = data.get("party_a")
+    party_b = data.get("party_b")
+    booking_id = data.get("booking_id", f"book-{int(time.time())}")
+    hours = data.get("duration_hours", 24)
+    if not party_a or not party_b:
+        return jsonify({"error": "party_a and party_b required"}), 400
+    if not proxy_pool:
+        return jsonify({"error": "No proxy numbers available"}), 503
+    proxy = proxy_pool.pop(0)
+```
+
+**`expire_booking()`** -- Expire Booking.
+
+```python
+def expire_booking(booking_id):
+    mask = bookings.pop(booking_id, None)
+    if not mask:
+        return jsonify({"error": "Not found"}), 404
+    proxy = mask["proxy"]
+    active_masks.pop(proxy, None)
+    proxy_pool.append(proxy)
+    return jsonify({"status": "expired", "booking_id": booking_id, "proxy_returned": proxy})
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+    ttl_cleanup_masks()
+
+```
+
+**`list_bookings()`** -- List Bookings.
+
+```python
+def list_bookings():
+    ttl_cleanup_masks()
+    return jsonify({"bookings": list(bookings.values()), "pool_available": len(proxy_pool)})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/pool` | Pool |
+| `POST` | `/bookings` | Bookings |
+| `DELETE` | `/bookings/<booking_id>` | <Booking Id> |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/bookings` | Bookings |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-number-masking"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-number-masking-python/README.md
+++ b/edge-number-masking-python/README.md
@@ -1,0 +1,204 @@
+---
+name: edge-number-masking
+title: "Edge Number Masking"
+description: "Marketplace-style proxy number pool at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Numbers, Voice, Call Recording]
+channel: [voice]
+---
+
+# Edge Number Masking
+
+> Also known as: number masking, proxy numbers, anonymous calling, marketplace phone masking.
+
+Marketplace-style proxy number pool at the edge. Dynamically assigns masked number pairs per booking, routes calls bidirectionally through the proxy, records for dispute resolution, and auto-expires at checkout.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, numbers, and inference run on one private global network instead of the public internet. This example leans on that single stack, provisioning the proxy number pool, bridging both call legs with Call Control, and recording to Telnyx Storage all through one API and one set of credentials. Owning the network means lower call latency and consistent quality on every masked leg, with no third-party carrier in the path.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Reject**: `POST /v2/calls/{id}/actions/reject` -- [API reference](https://developers.telnyx.com/api/call-control/reject-call)
+- **Call Control: Record Start**: `POST /v2/calls/{id}/actions/record_start` -- [API reference](https://developers.telnyx.com/api/call-control/start-recording)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.recording.saved` -- Recording available for download
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-number-masking-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /pool`
+
+Pool.
+
+```bash
+curl -X POST http://localhost:5000/pool \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `POST /bookings`
+
+Bookings.
+
+```bash
+curl -X POST http://localhost:5000/bookings \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `DELETE /bookings/<booking_id>`
+
+<Booking Id>.
+
+```bash
+curl http://localhost:5000/bookings/<booking_id>
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-number-masking"}
+```
+
+### `GET /bookings`
+
+Bookings.
+
+```bash
+curl http://localhost:5000/bookings
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-number-masking"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-number-masking"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.recording.saved` -- Recording available for download
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/pool` | Pool |
+| `POST` | `/bookings` | Bookings |
+| `DELETE` | `/bookings/<booking_id>` | <Booking Id> |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/bookings` | Bookings |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is unset, wrong, or the body was modified by a proxy | Set `TELNYX_PUBLIC_KEY` to the base64 Ed25519 key from the [Portal](https://portal.telnyx.com); verification runs over the raw body, so don't re-serialize the payload. A blank key makes every request fail closed. |
+| `401` only on older or replayed events | `telnyx-timestamp` drifts more than 5 minutes (`MAX_SKEW_SECONDS`) | Sync the server clock (NTP) and ensure events are delivered promptly; intentional replays are rejected by design. |
+| Inbound calls get `503 No proxy numbers available` | The proxy pool is empty when a booking is created | `POST /pool` with a `numbers` array first, and confirm masks are auto-expiring back into the pool at checkout. |
+| Calls to a proxy number are rejected (`UNALLOCATED_NUMBER`) | No active mask maps the dialed number to a booking | Create the booking via `POST /bookings` before the parties dial, and check the mask has not passed `expires_at`. |
+| Webhooks never arrive | Telnyx can't reach your local server | Run `ngrok http 5000` and set the Call Control Application Webhook URL to `https://<id>.ngrok.io/webhooks/voice`. |
+| `call.recording.saved` archives nothing | `recording_url` failed the Telnyx-host SSRF guard or `STORAGE_BUCKET` is wrong | Confirm the recording URL is a `*.telnyx.com` host and that `STORAGE_BUCKET` exists in Telnyx Storage. |
+
+## Related Examples
+
+- [multi-number-identity-router-python](../multi-number-identity-router-python/) — route inbound calls across a pool of numbers by identity
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — Call Control answer/transfer routing patterns
+- [record-phone-calls-python](../record-phone-calls-python/) — start recordings and handle `call.recording.saved`
+- [edge-geo-smart-router-python](../edge-geo-smart-router-python/) — edge-deployed Call Control routing sibling
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-number-masking-python/app.py
+++ b/edge-number-masking-python/app.py
@@ -1,0 +1,192 @@
+"""Edge Number Masking — marketplace proxy number pool for two-party anonymity.
+Dynamically assigns number pairs per booking, routes calls through, records for
+disputes, auto-expires masks at checkout."""
+import os, json, time, base64, logging
+from urllib.parse import urlparse
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+import boto3
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+STORAGE_BUCKET = os.getenv("STORAGE_BUCKET", "call-recordings")
+MESSAGING_PROFILE = os.getenv("MESSAGING_PROFILE_ID", "")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MAX_SKEW_SECONDS = 300  # reject webhooks whose timestamp drifts more than 5 minutes
+
+s3 = boto3.client("s3", endpoint_url="https://storage.telnyx.com",
+                   aws_access_key_id=TELNYX_API_KEY, aws_secret_access_key=TELNYX_API_KEY)
+
+
+def verify_webhook_signature(raw_body: bytes) -> bool:
+    """Verify the Telnyx Ed25519 signature over ``<telnyx-timestamp>|<raw body>``.
+
+    No telnyx client SDK is used here, so we verify natively: the public key is the
+    base64-encoded Ed25519 key from the Telnyx Portal. Rejects missing headers, bad
+    signatures, and timestamps that drift more than ``MAX_SKEW_SECONDS`` (replay).
+    """
+    if not TELNYX_PUBLIC_KEY:
+        return False
+    signature = request.headers.get("telnyx-signature-ed25519", "")
+    timestamp = request.headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        signed = f"{timestamp}|".encode() + raw_body
+        public_key.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+def is_telnyx_url(url: str) -> bool:
+    """Only fetch recordings from Telnyx hosts (the API key is attached to the request)."""
+    try:
+        parts = urlparse(url or "")
+    except ValueError:
+        return False
+    host = (parts.hostname or "").lower()
+    return parts.scheme == "https" and (host == "telnyx.com" or host.endswith(".telnyx.com"))
+
+proxy_pool = []  # Available proxy numbers
+active_masks = {}  # proxy_number -> {party_a, party_b, booking_id, expires_at}
+bookings = {}  # booking_id -> mask info
+MAX_ENTRIES = 10000
+
+def ttl_cleanup_masks():
+    now = time.time()
+    expired = [k for k, v in active_masks.items() if v.get("expires_at", float("inf")) < now]
+    for k in expired:
+        booking_id = active_masks[k].get("booking_id")
+        proxy_pool.append(k)
+        del active_masks[k]
+        bookings.pop(booking_id, None)
+        app.logger.info("Expired mask for booking %s, returned %s to pool", booking_id, k)
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except (ValueError, TypeError):
+        return {}
+
+@app.route("/pool", methods=["POST"])
+def add_to_pool():
+    data = request.get_json() or {}
+    numbers = data.get("numbers", [])
+    if not numbers:
+        return jsonify({"error": "numbers array required"}), 400
+    proxy_pool.extend(numbers)
+    return jsonify({"status": "added", "pool_size": len(proxy_pool)})
+
+@app.route("/bookings", methods=["POST"])
+def create_booking():
+    ttl_cleanup_masks()
+    data = request.get_json() or {}
+    party_a = data.get("party_a")
+    party_b = data.get("party_b")
+    booking_id = data.get("booking_id", f"book-{int(time.time())}")
+    hours = data.get("duration_hours", 24)
+    if not party_a or not party_b:
+        return jsonify({"error": "party_a and party_b required"}), 400
+    if not proxy_pool:
+        return jsonify({"error": "No proxy numbers available"}), 503
+    proxy = proxy_pool.pop(0)
+    mask = {"proxy": proxy, "party_a": party_a, "party_b": party_b,
+            "booking_id": booking_id, "expires_at": time.time() + hours * 3600, "created": time.time()}
+    active_masks[proxy] = mask
+    bookings[booking_id] = mask
+    return jsonify({"status": "created", "booking_id": booking_id, "proxy_number": proxy,
+                    "expires_at": mask["expires_at"]})
+
+@app.route("/bookings/<booking_id>", methods=["DELETE"])
+def expire_booking(booking_id):
+    mask = bookings.pop(booking_id, None)
+    if not mask:
+        return jsonify({"error": "Not found"}), 404
+    proxy = mask["proxy"]
+    active_masks.pop(proxy, None)
+    proxy_pool.append(proxy)
+    return jsonify({"status": "expired", "booking_id": booking_id, "proxy_returned": proxy})
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_webhook_signature(raw_body):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+    ttl_cleanup_masks()
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        called = ep.get("to", "")
+        caller = ep.get("from", "")
+        mask = active_masks.get(called)
+        if not mask:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/reject",
+                          headers=HEADERS, timeout=10, json={"cause": "UNALLOCATED_NUMBER"})
+            return jsonify({"status": "no_mask"})
+        target = mask["party_b"] if caller == mask["party_a"] else mask["party_a"]
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                      headers=HEADERS, timeout=10,
+                      json={"client_state": encode_state({"target": target, "booking": mask["booking_id"]})})
+
+    elif event_type == "call.answered":
+        state = decode_state(ep.get("client_state", ""))
+        target = state.get("target")
+        if target:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/transfer",
+                          headers=HEADERS, timeout=10, json={"to": target})
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/record_start",
+                          headers=HEADERS, timeout=10, json={"format": "mp3", "channels": "dual"})
+
+    elif event_type == "call.recording.saved":
+        recording_url = ep.get("recording_urls", {}).get("mp3")
+        # SSRF guard: recording_url is webhook-provided. Only fetch from Telnyx hosts
+        # before attaching the API key (in HEADERS) to the request.
+        if recording_url and is_telnyx_url(recording_url):
+            try:
+                audio = requests.get(recording_url, headers=HEADERS, timeout=30).content
+                key = f"recordings/{ep.get('call_session_id', 'unknown')}.mp3"
+                s3.put_object(Bucket=STORAGE_BUCKET, Key=key, Body=audio, ContentType="audio/mpeg")
+                app.logger.info("Archived recording: %s", key)
+            except Exception as e:
+                app.logger.error("Recording archive failed: %s", e)
+
+    elif event_type == "call.hangup":
+        pass
+
+    return jsonify({"status": "ok"})
+
+@app.route("/bookings", methods=["GET"])
+def list_bookings():
+    ttl_cleanup_masks()
+    return jsonify({"bookings": list(bookings.values()), "pool_available": len(proxy_pool)})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-number-masking", "pool": len(proxy_pool), "active": len(active_masks)})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-number-masking-python/requirements.txt
+++ b/edge-number-masking-python/requirements.txt
@@ -1,0 +1,5 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+boto3>=1.34
+cryptography>=42.0

--- a/edge-voicemail-to-action-python/.env.example
+++ b/edge-voicemail-to-action-python/.env.example
@@ -1,0 +1,11 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Phone number — https://portal.telnyx.com/numbers/my-numbers
+TELNYX_PHONE_NUMBER=+1xxxxxxxxxx
+# Call Control app — https://portal.telnyx.com/call-control/applications
+TELNYX_CONNECTION_ID=
+ONCALL_NUMBER=+1xxxxxxxxxx
+DIGEST_RECIPIENTS=+1xxxxxxxxxx,+1yyyyyyyyyy
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/edge-voicemail-to-action-python/API.md
+++ b/edge-voicemail-to-action-python/API.md
@@ -1,0 +1,107 @@
+# API Reference -- Edge Voicemail to Action
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `POST` | `/webhooks/oncall` | Oncall |
+| `GET` | `/voicemails` | Voicemails |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /webhooks/oncall`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /voicemails`
+
+Voicemails.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/voicemails
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-voicemail-to-action-python/GUIDE.md
+++ b/edge-voicemail-to-action-python/GUIDE.md
@@ -1,0 +1,221 @@
+# Build a Edge Voicemail to Action
+
+AI-powered voicemail triage at the edge. Transcribes voicemails, classifies them (urgent, routine, spam), and takes action: urgent triggers callback, routine goes to SMS digest, spam gets blocklisted.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **Call Control: Reject**: `POST /v2/calls/{id}/actions/reject` -- [API reference](https://developers.telnyx.com/api/call-control/reject-call)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-voicemail-to-action-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (186 lines). Here is what each piece does.
+
+
+**`classify_voicemail()`** -- Classify Voicemail.
+
+```python
+def classify_voicemail(transcript):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": CLASSIFY_PROMPT},
+                         {"role": "user", "content": transcript}],
+            "response_format": {"type": "json_object"}
+        })
+        if resp.ok:
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+    except Exception as e:
+        app.logger.error("Classification failed: %s", e)
+```
+
+**`call_oncall()`** -- Call Oncall.
+
+```python
+def call_oncall(voicemail_data):
+    if not ONCALL_NUMBER:
+        return
+    try:
+        summary = voicemail_data.get("summary", "urgent voicemail")
+        caller = voicemail_data.get("from", "unknown")
+        requests.post("https://api.telnyx.com/v2/calls", headers=HEADERS, timeout=10, json={
+            "connection_id": os.getenv("TELNYX_CONNECTION_ID", ""),
+            "to": ONCALL_NUMBER, "from": TELNYX_PHONE,
+            "webhook_url": request.url_root.rstrip("/") + "/webhooks/oncall"
+        })
+        app.logger.info("Calling on-call for urgent voicemail from %s", caller)
+```
+
+**`send_digest()`** -- Send Digest.
+
+```python
+def send_digest():
+    while True:
+        time.sleep(3600)
+        if not routine_queue:
+            continue
+        batch = routine_queue.copy()
+        routine_queue.clear()
+        digest_text = f"{len(batch)} voicemail(s):\n"
+        for vm in batch[:20]:
+            digest_text += f"- {vm.get('from', '?')}: {vm.get('summary', '')}\n"
+        for recipient in DIGEST_RECIPIENTS:
+            recipient = recipient.strip()
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+    caller = ep.get("from", "")
+
+```
+
+**`handle_oncall()`** -- Handle Oncall.
+
+```python
+def handle_oncall():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    cc_id = event.get("payload", {}).get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.answered":
+        urgent = [v for v in voicemails if v.get("classification") == "urgent"]
+```
+
+**`get_voicemails()`** -- Get Voicemails.
+
+```python
+def get_voicemails():
+    classification = request.args.get("classification")
+    limit = request.args.get("limit", 50, type=int)
+    filtered = [v for v in voicemails if not classification or v.get("classification") == classification]
+    return jsonify({"voicemails": filtered[-limit:], "total": len(filtered)})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `POST` | `/webhooks/oncall` | Oncall |
+| `GET` | `/voicemails` | Voicemails |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-voicemail-to-action"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-voicemail-to-action-python/README.md
+++ b/edge-voicemail-to-action-python/README.md
@@ -1,0 +1,164 @@
+---
+name: edge-voicemail-to-action
+title: "Edge Voicemail to Action"
+description: "AI-powered voicemail triage at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, AI Inference, Messaging]
+channel: [voice, sms]
+---
+
+# Edge Voicemail to Action
+
+> Also known as: voicemail transcription, voicemail triage, smart voicemail, voicemail AI.
+
+AI-powered voicemail triage at the edge. Transcribes voicemails, classifies them (urgent, routine, spam), and takes action: urgent triggers callback, routine goes to SMS digest, spam gets blocklisted.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice (Call Control), messaging (SMS), and AI Inference run on one private global network, so this app captures a voicemail, classifies it with an LLM, and escalates by phone or SMS without stitching together separate vendors. Speech gathering, TTS briefings, outbound callbacks, and chat completions are all served from the same low-latency platform, which keeps the urgent-callback path fast and the spam-blocklist logic close to where calls land. One API key and one billing relationship cover the entire transcribe-classify-act loop.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **Call Control: Reject**: `POST /v2/calls/{id}/actions/reject` -- [API reference](https://developers.telnyx.com/api/call-control/reject-call)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `ONCALL_NUMBER` | `string` | `+12125551234` | **yes** | On-call engineer phone | -- |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-voicemail-to-action-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /voicemails`
+
+Voicemails.
+
+```bash
+curl http://localhost:5000/voicemails
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-voicemail-to-action"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-voicemail-to-action"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `POST` | `/webhooks/oncall` | Oncall |
+| `GET` | `/voicemails` | Voicemails |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `401 invalid signature` on `/webhooks/voice` or `/webhooks/oncall` | `TELNYX_PUBLIC_KEY` is unset or wrong (the app rejects every webhook when it is missing) | Copy the Ed25519 public key from your [Portal Call Control application](https://portal.telnyx.com/call-control/applications) into `TELNYX_PUBLIC_KEY` in `.env` and restart |
+| `401 invalid signature` even with a key set | Webhook timestamp is older than 300s, or a proxy altered the raw body | Ensure server clock is in sync (replay window is `MAX_TIMESTAMP_SKEW = 300`) and that the tunnel forwards the body unmodified |
+| Telnyx never reaches your app | Local server is not publicly reachable | Run `ngrok http 5000` and set the Call Control Webhook URL to `https://<id>.ngrok.io/webhooks/voice` |
+| Urgent voicemails do not trigger a callback | `ONCALL_NUMBER` or `TELNYX_CONNECTION_ID` is missing | Set both in `.env`; `call_oncall` returns early when `ONCALL_NUMBER` is empty and needs the connection ID to place the outbound call |
+| Routine digest SMS never arrives | `DIGEST_RECIPIENTS` is empty or the digest interval has not elapsed | Set `DIGEST_RECIPIENTS` (comma-separated); the digest thread sends once per hour and only when the routine queue is non-empty |
+
+## Related Examples
+
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — route inbound calls into a Telnyx AI agent
+- [ai-voicemail-transcription-forwarding-python](../ai-voicemail-transcription-forwarding-python/) — transcribe voicemails and forward them
+- [record-phone-calls-python](../record-phone-calls-python/) — record calls with Call Control
+- [edge-merge-ai-receptionist-python](../edge-merge-ai-receptionist-python/) — edge AI receptionist that triages callers
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-voicemail-to-action-python/app.py
+++ b/edge-voicemail-to-action-python/app.py
@@ -1,0 +1,220 @@
+"""Edge Voicemail to Action — voicemail arrives, AI transcribes, classifies, and acts.
+Urgent: immediately calls on-call person with spoken briefing.
+Routine: hourly SMS digest. Spam: deleted, number blocklisted."""
+import os, json, time, threading, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+import requests
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+MAX_TIMESTAMP_SKEW = 300  # seconds; reject replayed/stale webhooks
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+ONCALL_NUMBER = os.getenv("ONCALL_NUMBER")
+DIGEST_RECIPIENTS = os.getenv("DIGEST_RECIPIENTS", "").split(",")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+
+voicemails = []
+routine_queue = []
+spam_blocklist = set()
+MAX_ENTRIES = 10000
+
+def verify_telnyx_signature(raw_body: bytes) -> bool:
+    """Verify the Telnyx Ed25519 webhook signature over "<timestamp>|<raw body>".
+
+    Native verification (no SDK dependency) suited to edge deployments: decodes the
+    Portal public key, checks the signature, and rejects stale/replayed timestamps.
+    """
+    if not TELNYX_PUBLIC_KEY:
+        app.logger.error("TELNYX_PUBLIC_KEY not configured; rejecting webhook")
+        return False
+    signature = request.headers.get("telnyx-signature-ed25519", "")
+    timestamp = request.headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_TIMESTAMP_SKEW:
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        signed_payload = f"{timestamp}|".encode() + raw_body
+        public_key.verify(base64.b64decode(signature), signed_payload)
+        return True
+    except (InvalidSignature, ValueError, TypeError) as e:
+        app.logger.error("Webhook signature verification failed: %s", e)
+        return False
+
+
+CLASSIFY_PROMPT = """Classify this voicemail transcription. Respond with JSON only:
+{"classification": "urgent|routine|spam", "summary": "one line summary", "callback_number": "extracted phone or null", "entities": ["key entities mentioned"]}
+
+Urgent: medical, security, system down, legal deadline, customer emergency.
+Routine: appointment confirmations, general inquiries, follow-ups.
+Spam: robocalls, solicitations, scams, silence."""
+
+def classify_voicemail(transcript):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [{"role": "system", "content": CLASSIFY_PROMPT},
+                         {"role": "user", "content": transcript}],
+            "response_format": {"type": "json_object"}
+        })
+        if resp.ok:
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+    except Exception as e:
+        app.logger.error("Classification failed: %s", e)
+    return {"classification": "routine", "summary": transcript[:100]}
+
+def call_oncall(voicemail_data):
+    if not ONCALL_NUMBER:
+        return
+    try:
+        summary = voicemail_data.get("summary", "urgent voicemail")
+        caller = voicemail_data.get("from", "unknown")
+        requests.post("https://api.telnyx.com/v2/calls", headers=HEADERS, timeout=10, json={
+            "connection_id": os.getenv("TELNYX_CONNECTION_ID", ""),
+            "to": ONCALL_NUMBER, "from": TELNYX_PHONE,
+            "webhook_url": request.url_root.rstrip("/") + "/webhooks/oncall"
+        })
+        app.logger.info("Calling on-call for urgent voicemail from %s", caller)
+    except Exception as e:
+        app.logger.error("On-call escalation failed: %s", e)
+
+def send_digest():
+    while True:
+        time.sleep(3600)
+        if not routine_queue:
+            continue
+        batch = routine_queue.copy()
+        routine_queue.clear()
+        digest_text = f"{len(batch)} voicemail(s):\n"
+        for vm in batch[:20]:
+            digest_text += f"- {vm.get('from', '?')}: {vm.get('summary', '')}\n"
+        for recipient in DIGEST_RECIPIENTS:
+            recipient = recipient.strip()
+            if not recipient:
+                continue
+            try:
+                requests.post("https://api.telnyx.com/v2/messages", headers=HEADERS, timeout=10,
+                              json={"from": TELNYX_PHONE, "to": recipient, "text": digest_text})
+            except Exception as e:
+                app.logger.error("Digest SMS to %s failed: %s", recipient, e)
+
+digest_thread = threading.Thread(target=send_digest, daemon=True)
+digest_thread.start()
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    raw_body = request.get_data()  # capture the RAW body for signature verification
+    if not verify_telnyx_signature(raw_body):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+    caller = ep.get("from", "")
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        if caller in spam_blocklist:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/reject",
+                          headers=HEADERS, timeout=10)
+            return jsonify({"status": "blocked"})
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                      headers=HEADERS, timeout=10,
+                      json={"client_state": base64.b64encode(json.dumps({"from": caller}).encode()).decode()})
+
+    elif event_type == "call.answered":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "Please leave your message after the tone. Press pound when finished.",
+                            "voice": "female", "language": "en-US",
+                            "input_type": "speech", "timeout_secs": 120,
+                            "client_state": ep.get("client_state", "")})
+
+    elif event_type == "call.gather.ended":
+        transcript = ep.get("speech", {}).get("result", "")
+        caller = json.loads(base64.b64decode(ep.get("client_state", "")).decode()).get("from", "") if ep.get("client_state") else ""
+        if transcript:
+            result = classify_voicemail(transcript)
+            vm_record = {"from": caller, "transcript": transcript, "ts": time.time(), **result}
+            voicemails.append(vm_record)
+            if len(voicemails) > MAX_ENTRIES:
+                voicemails[:] = voicemails[-MAX_ENTRIES:]
+            classification = result.get("classification", "routine")
+            if classification == "urgent":
+                call_oncall(vm_record)
+            elif classification == "spam":
+                spam_blocklist.add(caller)
+                app.logger.info("Spam voicemail from %s — blocklisted", caller)
+            else:
+                routine_queue.append(vm_record)
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": "Thank you. Your message has been received.", "voice": "female", "language": "en-US"})
+
+    elif event_type == "call.speak.ended":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+                      headers=HEADERS, timeout=10)
+
+    elif event_type == "call.hangup":
+        pass
+
+    return jsonify({"status": "ok"})
+
+@app.route("/webhooks/oncall", methods=["POST"])
+def handle_oncall():
+    raw_body = request.get_data()  # capture the RAW body for signature verification
+    if not verify_telnyx_signature(raw_body):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    cc_id = event.get("payload", {}).get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.answered":
+        urgent = [v for v in voicemails if v.get("classification") == "urgent"]
+        latest = urgent[-1] if urgent else {}
+        briefing = f"Urgent voicemail from {latest.get('from', 'unknown')}. {latest.get('summary', 'No details available.')}."
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                      headers=HEADERS, timeout=10,
+                      json={"payload": briefing, "voice": "female", "language": "en-US"})
+
+    elif event_type == "call.speak.ended":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+                      headers=HEADERS, timeout=10)
+
+    return jsonify({"status": "ok"})
+
+@app.route("/voicemails", methods=["GET"])
+def get_voicemails():
+    classification = request.args.get("classification")
+    limit = request.args.get("limit", 50, type=int)
+    filtered = [v for v in voicemails if not classification or v.get("classification") == classification]
+    return jsonify({"voicemails": filtered[-limit:], "total": len(filtered)})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-voicemail-to-action",
+                    "voicemails": len(voicemails), "routine_queue": len(routine_queue),
+                    "blocklist": len(spam_blocklist)})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-voicemail-to-action-python/requirements.txt
+++ b/edge-voicemail-to-action-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/edge-webhook-aggregator-python/.env.example
+++ b/edge-webhook-aggregator-python/.env.example
@@ -1,0 +1,6 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Cloud Storage bucket — https://portal.telnyx.com/storage
+STORAGE_BUCKET=my-bucket

--- a/edge-webhook-aggregator-python/API.md
+++ b/edge-webhook-aggregator-python/API.md
@@ -1,0 +1,125 @@
+# API Reference -- Edge Webhook Aggregator
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ingest` | Ingest |
+| `POST` | `/tenants` | Tenants |
+| `GET` | `/tenants` | Tenants |
+| `GET` | `/stats` | Stats |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/ingest`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /tenants`
+
+Tenants.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/tenants \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `GET /tenants`
+
+Tenants.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/tenants
+```
+
+---
+
+## `GET /stats`
+
+Stats.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/stats
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/edge-webhook-aggregator-python/GUIDE.md
+++ b/edge-webhook-aggregator-python/GUIDE.md
@@ -1,0 +1,180 @@
+# Build a Edge Webhook Aggregator
+
+Multi-tenant webhook consolidation at the edge. Receives all Telnyx voice and messaging events, classifies by tenant from phone number mapping, batches events per interval, and forwards one consolidated payload per tenant.
+
+## Telnyx Products Used
+
+- **Edge Compute** -- run code at the network edge for low-latency processing
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- See code for API calls
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-webhook-aggregator-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (118 lines). Here is what each piece does.
+
+
+**`flush_batches()`** -- Flush Batches.
+
+```python
+def flush_batches():
+    """Flush accumulated events to tenant endpoints."""
+    while True:
+        time.sleep(BATCH_INTERVAL)
+        with flush_lock:
+            for tenant_id, events in list(event_batches.items()):
+                if not events:
+                    continue
+                batch = events.copy()
+                event_batches[tenant_id] = []
+                endpoint = tenant_endpoints.get(tenant_id)
+                if endpoint:
+```
+
+**`ingest_webhook()`** -- Ingest Webhook.
+
+```python
+def ingest_webhook():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_payload = event.get("payload", {})
+    phone = event_payload.get("to", event_payload.get("from", ""))
+    if isinstance(phone, list):
+        phone = phone[0].get("phone_number", "") if phone else ""
+    elif isinstance(phone, dict):
+        phone = phone.get("phone_number", phone)
+    tenant_id = tenant_map.get(phone, "unassigned")
+```
+
+**`register_tenant()`** -- Register Tenant.
+
+```python
+def register_tenant():
+    data = request.get_json() or {}
+    tenant_id = data.get("tenant_id")
+    phones = data.get("phone_numbers", [])
+    endpoint = data.get("callback_url")
+    if not tenant_id or not endpoint:
+        return jsonify({"error": "tenant_id and callback_url required"}), 400
+    for phone in phones:
+        tenant_map[phone] = tenant_id
+    tenant_endpoints[tenant_id] = endpoint
+    if tenant_id not in event_batches:
+        event_batches[tenant_id] = []
+```
+
+**`list_tenants()`** -- List Tenants.
+
+```python
+def list_tenants():
+    return jsonify({"tenants": {tid: {"endpoint": tenant_endpoints.get(tid, ""), "pending": len(event_batches.get(tid, []))}
+                                for tid in tenant_endpoints}})
+```
+
+**`stats()`** -- Stats.
+
+```python
+def stats():
+    return jsonify({"tenants": len(tenant_endpoints), "mapped_numbers": len(tenant_map),
+                    "pending_events": sum(len(v) for v in event_batches.values())})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ingest` | Ingest |
+| `POST` | `/tenants` | Tenants |
+| `GET` | `/tenants` | Tenants |
+| `GET` | `/stats` | Stats |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "edge-webhook-aggregator"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/edge-webhook-aggregator-python/README.md
+++ b/edge-webhook-aggregator-python/README.md
@@ -1,0 +1,177 @@
+---
+name: edge-webhook-aggregator
+title: "Edge Webhook Aggregator"
+description: "Multi-tenant webhook consolidation at the edge."
+language: python
+framework: flask
+telnyx_products: [Edge Compute, Voice, Messaging]
+channel: [voice, sms]
+---
+
+# Edge Webhook Aggregator
+
+> Also known as: webhook batching, multi-tenant webhooks, event aggregation, webhook proxy, event consolidation.
+
+Multi-tenant webhook consolidation at the edge. Receives all Telnyx voice and messaging events, classifies by tenant from phone number mapping, batches events per interval, and forwards one consolidated payload per tenant.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, and AI on one private global network instead of the public internet. Because every voice and SMS event already flows through that network, this aggregator can verify each webhook's Ed25519 signature, consolidate events per tenant at the edge, and forward a single batched payload — cutting backend traffic without bolting on a third-party event bus. One provider, one signing key, and one billing relationship across all channels.
+
+## Telnyx API Endpoints Used
+
+- See code for API calls
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-webhook-aggregator-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /tenants`
+
+Tenants.
+
+```bash
+curl -X POST http://localhost:5000/tenants \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /tenants`
+
+Tenants.
+
+```bash
+curl http://localhost:5000/tenants
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-webhook-aggregator"}
+```
+
+### `GET /stats`
+
+Stats.
+
+```bash
+curl http://localhost:5000/stats
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-webhook-aggregator"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "edge-webhook-aggregator"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ingest` | Ingest |
+| `POST` | `/tenants` | Tenants |
+| `GET` | `/tenants` | Tenants |
+| `GET` | `/stats` | Stats |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `401 invalid signature` on `/webhooks/ingest` | `TELNYX_PUBLIC_KEY` is unset, wrong, or signature verification is disabled | Set `TELNYX_PUBLIC_KEY` from [Portal -> Keys & Credentials](https://portal.telnyx.com/api-keys) (base64 Ed25519 public key). An empty/invalid key disables verification and rejects every request. |
+| `401` despite a valid key | Request timestamp is more than 5 minutes off (`MAX_SKEW_SECONDS`), or a proxy altered the raw body before it reached Flask | Sync the server clock and ensure the signature is verified against the unmodified raw body — do not re-serialize the JSON upstream. |
+| Webhooks never arrive | Telnyx cannot reach your server, or the URL points at `/webhooks/voice` instead of the ingest route | Expose the server with `ngrok http 5000` and configure the public webhook URL to `https://<id>.ngrok.io/webhooks/ingest`. |
+| Events land under `unassigned` | The event's `to`/`from` number is not in `tenant_map` | Register the tenant first via `POST /tenants` with the matching `phone_numbers`. |
+| `callback_url must be a public https URL` on `POST /tenants` | Callback is non-https or resolves to a private/loopback/metadata address (SSRF guard) | Use a publicly reachable `https://` endpoint; localhost and internal IPs are rejected by design. |
+
+## Related Examples
+
+- [edge-compute-webhook-proxy-python](../edge-compute-webhook-proxy-python/) — single-tenant webhook proxy/transform at the edge
+- [edge-fraud-firewall-python](../edge-fraud-firewall-python/) — inspect and filter Telnyx events at the edge before they hit your backend
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — handle the voice events this aggregator consolidates
+- [receive-sms-webhook-python](../receive-sms-webhook-python/) — receive and verify the messaging webhooks aggregated here
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/edge-webhook-aggregator-python/app.py
+++ b/edge-webhook-aggregator-python/app.py
@@ -1,0 +1,180 @@
+"""Edge Webhook Aggregator — multi-tenant SaaS webhook consolidation.
+Receives all Telnyx webhooks, classifies by tenant, batches, and forwards one
+consolidated payload per tenant per interval. Reduces backend traffic by 90%."""
+import os, json, time, base64, ipaddress, threading, logging, socket
+from urllib.parse import urlparse
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+import boto3
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+STORAGE_BUCKET = os.getenv("STORAGE_BUCKET", "webhook-overflow")
+BATCH_INTERVAL = int(os.getenv("BATCH_INTERVAL_SECONDS", "5"))
+HOST = os.getenv("HOST", "127.0.0.1")
+
+s3 = boto3.client("s3", endpoint_url="https://storage.telnyx.com",
+                   aws_access_key_id=TELNYX_API_KEY, aws_secret_access_key=TELNYX_API_KEY)
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+def safe_callback_url(url):
+    """Tenant callback URLs are arbitrary external endpoints, so we cannot pin them to
+    a single host — but a tenant must not be able to point us at internal/metadata
+    services. Require https and reject any URL that resolves to a private, loopback,
+    link-local, or otherwise non-global address (SSRF guard)."""
+    try:
+        parts = urlparse(url or "")
+    except ValueError:
+        return False
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https" or not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, parts.port or 443, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError):
+        return False
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global or ip.is_multicast or ip.is_reserved:
+            return False
+    return True
+
+tenant_map = {}  # phone_number -> tenant_id
+event_batches = {}  # tenant_id -> [events]
+tenant_endpoints = {}  # tenant_id -> callback_url
+flush_lock = threading.Lock()
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if isinstance(store, dict) and len(store) > max_size:
+        oldest = sorted(store, key=lambda k: len(store.get(k, [])) if isinstance(store.get(k), list) else 0)
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def flush_batches():
+    """Flush accumulated events to tenant endpoints."""
+    while True:
+        time.sleep(BATCH_INTERVAL)
+        with flush_lock:
+            for tenant_id, events in list(event_batches.items()):
+                if not events:
+                    continue
+                batch = events.copy()
+                event_batches[tenant_id] = []
+                endpoint = tenant_endpoints.get(tenant_id)
+                if endpoint:
+                    try:
+                        requests.post(endpoint, json={"tenant_id": tenant_id, "events": batch,
+                                                       "count": len(batch), "flushed_at": time.time()},
+                                      timeout=10)
+                        app.logger.info("Flushed %s events to tenant %s", len(batch), tenant_id)
+                    except Exception as e:
+                        app.logger.error("Flush to %s failed: %s — archiving to storage", tenant_id, e)
+                        try:
+                            key = f"overflow/{tenant_id}/{int(time.time())}.json"
+                            s3.put_object(Bucket=STORAGE_BUCKET, Key=key,
+                                          Body=json.dumps(batch), ContentType="application/json")
+                        except Exception as se:
+                            app.logger.error("Storage archive failed: %s", se)
+
+flush_thread = threading.Thread(target=flush_batches, daemon=True)
+flush_thread.start()
+
+@app.route("/webhooks/ingest", methods=["POST"])
+def ingest_webhook():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_payload = event.get("payload", {})
+    phone = event_payload.get("to", event_payload.get("from", ""))
+    if isinstance(phone, list):
+        phone = phone[0].get("phone_number", "") if phone else ""
+    elif isinstance(phone, dict):
+        phone = phone.get("phone_number", phone)
+    tenant_id = tenant_map.get(phone, "unassigned")
+    with flush_lock:
+        if tenant_id not in event_batches:
+            event_batches[tenant_id] = []
+        event_batches[tenant_id].append({
+            "event_type": event.get("event_type"),
+            "payload": event_payload,
+            "received_at": time.time()
+        })
+        ttl_cleanup(event_batches)
+    return jsonify({"status": "queued", "tenant": tenant_id})
+
+@app.route("/tenants", methods=["POST"])
+def register_tenant():
+    data = request.get_json() or {}
+    tenant_id = data.get("tenant_id")
+    phones = data.get("phone_numbers", [])
+    endpoint = data.get("callback_url")
+    if not tenant_id or not endpoint:
+        return jsonify({"error": "tenant_id and callback_url required"}), 400
+    # callback_url is attacker-controllable; reject anything that could reach an
+    # internal/metadata host before we ever POST batched events to it (SSRF guard).
+    if not safe_callback_url(endpoint):
+        return jsonify({"error": "callback_url must be a public https URL"}), 400
+    for phone in phones:
+        tenant_map[phone] = tenant_id
+    tenant_endpoints[tenant_id] = endpoint
+    if tenant_id not in event_batches:
+        event_batches[tenant_id] = []
+    return jsonify({"status": "registered", "tenant_id": tenant_id, "numbers": len(phones)})
+
+@app.route("/tenants", methods=["GET"])
+def list_tenants():
+    return jsonify({"tenants": {tid: {"endpoint": tenant_endpoints.get(tid, ""), "pending": len(event_batches.get(tid, []))}
+                                for tid in tenant_endpoints}})
+
+@app.route("/stats", methods=["GET"])
+def stats():
+    return jsonify({"tenants": len(tenant_endpoints), "mapped_numbers": len(tenant_map),
+                    "pending_events": sum(len(v) for v in event_batches.values())})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "edge-webhook-aggregator"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/edge-webhook-aggregator-python/requirements.txt
+++ b/edge-webhook-aggregator-python/requirements.txt
@@ -1,0 +1,5 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+boto3>=1.34
+cryptography>=41.0

--- a/merge-deal-desk-alerts-python/.env.example
+++ b/merge-deal-desk-alerts-python/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification (Ed25519 public key) — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=

--- a/merge-deal-desk-alerts-python/API.md
+++ b/merge-deal-desk-alerts-python/API.md
@@ -1,0 +1,151 @@
+# API Reference -- Merge Deal Desk Alerts
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/crm` | Crm |
+| `POST` | `/alert` | Alert |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/deals` | Deals |
+| `GET` | `/alerts` | Alerts |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/crm`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /alert`
+
+Alert.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/alert \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /deals`
+
+Deals.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/deals
+```
+
+---
+
+## `GET /alerts`
+
+Alerts.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/alerts
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-deal-desk-alerts-python/GUIDE.md
+++ b/merge-deal-desk-alerts-python/GUIDE.md
@@ -1,0 +1,221 @@
+# Build a Merge Deal Desk Alerts
+
+CRM webhook fires when a deal moves to negotiation or exceeds a revenue threshold. Calls VP Sales with AI-generated spoken briefing. VP can say connect me to warm-transfer to the account executive.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-deal-desk-alerts-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (311 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+```
+
+**`should_alert()`** -- Should Alert.
+
+```python
+def should_alert(deal):
+    stage = (deal.get("stage") or deal.get("status") or "").lower().replace(" ", "_")
+    amount = float(deal.get("amount") or 0)
+    if stage in ALERT_STAGES:
+        return True
+    if amount >= DEAL_THRESHOLD:
+        return True
+    return False
+```
+
+**`handle_crm_webhook()`** -- Handle Crm Webhook.
+
+```python
+def handle_crm_webhook():
+    """Merge CRM webhook — deal stage change triggers VP alert call."""
+    data = request.get_json() or {}
+    deal_id = data.get("id", "")
+    deal = merge_get(f"/crm/v1/opportunities/{deal_id}") if deal_id else data
+    if not deal:
+        return jsonify({"error": "Deal not found"}), 404
+    if not should_alert(deal):
+        return jsonify({"status": "skipped", "reason": "Below threshold"})
+    if not VP_SALES_NUMBER:
+        return jsonify({"error": "VP_SALES_NUMBER not configured"}), 500
+    deal_context = {
+```
+
+**`manual_alert()`** -- Manual Alert.
+
+```python
+def manual_alert():
+    """Manually trigger a deal alert for testing."""
+    data = request.get_json() or {}
+    deal_name = data.get("deal_name", "Test Deal")
+    amount = data.get("amount", 100000)
+    stage = data.get("stage", "negotiation")
+    if not VP_SALES_NUMBER:
+        return jsonify({"error": "VP_SALES_NUMBER not configured"}), 500
+    alert_id = f"alert-{int(time.time())}"
+    deal_context = {"name": deal_name, "amount": amount, "stage": stage}
+    call_sessions[alert_id] = {"deal": deal_context, "ts": time.time()}
+    ttl_cleanup(call_sessions)
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/crm` | Crm |
+| `POST` | `/alert` | Alert |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/deals` | Deals |
+| `GET` | `/alerts` | Alerts |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-deal-desk-alerts"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-deal-desk-alerts-python/README.md
+++ b/merge-deal-desk-alerts-python/README.md
@@ -1,0 +1,195 @@
+---
+name: merge-deal-desk-alerts
+title: "Merge Deal Desk Alerts"
+description: "CRM webhook fires when a deal moves to negotiation or exceeds a revenue threshold."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference]
+integrations: [Merge CRM]
+channel: [voice]
+---
+
+# Merge Deal Desk Alerts
+
+> Also known as: deal alerts, CRM voice alerts, sales notifications, deal desk automation.
+
+CRM webhook fires when a deal moves to negotiation or exceeds a revenue threshold. Calls VP Sales with AI-generated spoken briefing. VP can say connect me to warm-transfer to the account executive.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: outbound voice, AI inference, and real-time warm transfers run on one private global network, so a CRM event can place a call, speak an AI-generated briefing, and connect the VP to the account executive without stitching together separate vendors. Programmable Call Control and the AI Inference API let you turn deal data into a spoken alert and route the live call in a single workflow, billed per-minute with no per-message markup. The same network carries the media end to end, keeping latency low for the gather/speak/transfer loop that makes these alerts feel real-time.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `VP_SALES_NUMBER` | `string` | `+12125551234` | **yes** | VP Sales phone number | -- |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-deal-desk-alerts-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /alert`
+
+Alert.
+
+```bash
+curl -X POST http://localhost:5000/alert \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /deals`
+
+Deals.
+
+```bash
+curl http://localhost:5000/deals
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-deal-desk-alerts"}
+```
+
+### `GET /alerts`
+
+Alerts.
+
+```bash
+curl http://localhost:5000/alerts
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-deal-desk-alerts"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-deal-desk-alerts"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/crm` | Crm |
+| `POST` | `/alert` | Alert |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/deals` | Deals |
+| `GET` | `/alerts` | Alerts |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| `/webhooks/voice` returns `401 invalid signature` | `TELNYX_PUBLIC_KEY` missing or wrong | Copy the Ed25519 public key from [Portal -> Keys & Credentials](https://portal.telnyx.com) into `.env`; it must match the Call Control app sending the events. |
+| Alert call never places (`Failed to place alert call`) | Missing `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`, `TELNYX_PHONE_NUMBER`, or `VP_SALES_NUMBER` | Confirm every required variable in `.env` is set; the Connection ID must be the Call Control Application whose webhook points at this server. |
+| Voice events never arrive after the call connects | Webhook URL not reachable from Telnyx | Expose the server with `ngrok http 5000` and set the Call Control app webhook to `https://<id>.ngrok.io/webhooks/voice`; `localhost` will not receive events. |
+| Deal alerts get skipped (`Below threshold`) or briefing is generic | Stage not in `ALERT_STAGES`, amount under `DEAL_THRESHOLD`, or Merge token invalid | Verify `MERGE_API_KEY` / `MERGE_ACCOUNT_TOKEN`, lower `DEAL_THRESHOLD`, or send a stage like `negotiation`; check `app.logger` output for `Merge GET ... failed`. |
+
+## Related Examples
+
+- [merge-pipeline-briefing-python](../merge-pipeline-briefing-python/) — pull a CRM pipeline summary and deliver it as a spoken briefing.
+- [warm-transfer-ai-briefing-python](../warm-transfer-ai-briefing-python/) — AI-generated briefing on a live warm transfer between agents.
+- [transfer-live-phone-calls-python](../transfer-live-phone-calls-python/) — Call Control transfer mechanics used to connect the VP to the rep.
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — route inbound calls into an AI voice agent with gather/speak.
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-deal-desk-alerts-python/app.py
+++ b/merge-deal-desk-alerts-python/app.py
@@ -1,0 +1,349 @@
+"""Merge Deal Desk Alerts — CRM webhook fires when a deal moves to negotiation
+or exceeds a revenue threshold. Calls VP Sales with a spoken AI briefing that
+includes deal size, stage, owner, and recent activity. VP can say "connect me"
+to warm-transfer directly to the account executive."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+VP_SALES_NUMBER = os.getenv("VP_SALES_NUMBER")
+DEAL_THRESHOLD = float(os.getenv("DEAL_THRESHOLD", "50000"))
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+
+ALERT_STAGES = {"negotiation", "contract_sent", "verbal_commit", "closing"}
+
+call_sessions = {}
+alert_log = []
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a deal desk assistant briefing the VP of Sales. "
+                            "Be concise and data-driven. Include deal name, amount, stage, "
+                            "and what action is needed. Speak in 2-3 sentences max.\n\n"
+                            f"Deal data: {json.dumps(context)}"
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "A significant deal requires your attention. Please check your CRM."
+
+
+def should_alert(deal):
+    stage = (deal.get("stage") or deal.get("status") or "").lower().replace(" ", "_")
+    amount = float(deal.get("amount") or 0)
+    if stage in ALERT_STAGES:
+        return True
+    if amount >= DEAL_THRESHOLD:
+        return True
+    return False
+
+
+@app.route("/webhooks/crm", methods=["POST"])
+def handle_crm_webhook():
+    """Merge CRM webhook — deal stage change triggers VP alert call."""
+    data = request.get_json() or {}
+    deal_id = data.get("id", "")
+    deal = merge_get(f"/crm/v1/opportunities/{deal_id}") if deal_id else data
+    if not deal:
+        return jsonify({"error": "Deal not found"}), 404
+    if not should_alert(deal):
+        return jsonify({"status": "skipped", "reason": "Below threshold"})
+    if not VP_SALES_NUMBER:
+        return jsonify({"error": "VP_SALES_NUMBER not configured"}), 500
+    deal_context = {
+        "name": deal.get("name", "Unknown"),
+        "amount": deal.get("amount"),
+        "stage": deal.get("stage") or deal.get("status"),
+        "close_date": deal.get("close_date"),
+        "owner": deal.get("owner", {}).get("name", "Unassigned") if isinstance(deal.get("owner"), dict) else str(deal.get("owner", "Unassigned")),
+        "account": deal.get("account", {}).get("name", "Unknown") if isinstance(deal.get("account"), dict) else str(deal.get("account", "Unknown")),
+        "description": (deal.get("description") or "")[:200],
+    }
+    owner_phone = None
+    owner = deal.get("owner", {})
+    if isinstance(owner, dict):
+        for pn in owner.get("phone_numbers", []):
+            if pn.get("value"):
+                owner_phone = pn["value"]
+                break
+    alert_id = f"alert-{int(time.time())}"
+    call_sessions[alert_id] = {
+        "deal": deal_context,
+        "owner_phone": owner_phone,
+        "ts": time.time(),
+    }
+    ttl_cleanup(call_sessions)
+    alert_log.append({"id": alert_id, "deal": deal_context["name"], "amount": deal_context["amount"], "ts": time.time()})
+    if len(alert_log) > MAX_ENTRIES:
+        alert_log[:] = alert_log[-MAX_ENTRIES:]
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": VP_SALES_NUMBER,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"alert_id": alert_id, "step": "briefing"}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("VP call failed: %s", e)
+        return jsonify({"error": "Failed to place alert call"}), 500
+    return jsonify({"status": "alerting", "alert_id": alert_id, "deal": deal_context["name"]})
+
+
+@app.route("/alert", methods=["POST"])
+def manual_alert():
+    """Manually trigger a deal alert for testing."""
+    data = request.get_json() or {}
+    deal_name = data.get("deal_name", "Test Deal")
+    amount = data.get("amount", 100000)
+    stage = data.get("stage", "negotiation")
+    if not VP_SALES_NUMBER:
+        return jsonify({"error": "VP_SALES_NUMBER not configured"}), 500
+    alert_id = f"alert-{int(time.time())}"
+    deal_context = {"name": deal_name, "amount": amount, "stage": stage}
+    call_sessions[alert_id] = {"deal": deal_context, "ts": time.time()}
+    ttl_cleanup(call_sessions)
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": VP_SALES_NUMBER,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"alert_id": alert_id, "step": "briefing"}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("Manual alert call failed: %s", e)
+        return jsonify({"error": "Failed to place alert call"}), 500
+    return jsonify({"status": "calling", "alert_id": alert_id})
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+    alert_id = state.get("alert_id", "")
+    session = call_sessions.get(alert_id, {})
+    deal = session.get("deal", {})
+
+    if event_type == "call.answered":
+        briefing = call_inference("Brief me on this deal.", deal)
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": f"Deal desk alert. {briefing} Say connect me to transfer to the rep, or hang up to dismiss.",
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 15,
+                "client_state": encode_state({"alert_id": alert_id, "step": "awaiting_action"}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = (ep.get("speech", {}).get("result", "") or "").lower()
+        if "connect" in speech or "transfer" in speech:
+            owner_phone = session.get("owner_phone")
+            if owner_phone:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "Connecting you now.",
+                        "voice": "female",
+                        "language": "en-US",
+                        "client_state": encode_state({"alert_id": alert_id, "step": "transferring", "target": owner_phone}),
+                    },
+                )
+            else:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "No phone number on file for the deal owner. Please reach out directly. Goodbye.",
+                        "voice": "female",
+                        "language": "en-US",
+                    },
+                )
+        else:
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": "Alert acknowledged. Goodbye.",
+                    "voice": "female",
+                    "language": "en-US",
+                },
+            )
+
+    elif event_type == "call.speak.ended":
+        if state.get("step") == "transferring":
+            target = state.get("target")
+            if target:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/transfer",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={"to": target},
+                )
+                return jsonify({"status": "ok"})
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        pass
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/deals", methods=["GET"])
+def list_deals():
+    """List recent deals from CRM."""
+    result = merge_get("/crm/v1/opportunities", params={"page_size": 20})
+    return jsonify(result or {"results": []})
+
+
+@app.route("/alerts", methods=["GET"])
+def list_alerts():
+    """List recent alert history."""
+    return jsonify({"alerts": alert_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-deal-desk-alerts", "pending_alerts": len(call_sessions)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-deal-desk-alerts-python/requirements.txt
+++ b/merge-deal-desk-alerts-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-employee-hotline-python/.env.example
+++ b/merge-employee-hotline-python/.env.example
@@ -1,0 +1,9 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=
+# Merge.dev API key — https://app.merge.dev/keys
+MERGE_API_KEY=
+# Merge linked account token
+MERGE_ACCOUNT_TOKEN=
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/merge-employee-hotline-python/API.md
+++ b/merge-employee-hotline-python/API.md
@@ -1,0 +1,65 @@
+# API Reference -- Merge Employee Hotline
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-employee-hotline-python/GUIDE.md
+++ b/merge-employee-hotline-python/GUIDE.md
@@ -1,0 +1,185 @@
+# Build a Merge Employee Hotline
+
+Employees call and authenticate via caller ID matched against Merge HRIS. AI pulls their PTO balance, department, manager, and upcoming time off, then answers HR questions conversationally.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-employee-hotline-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (152 lines). Here is what each piece does.
+
+
+**`lookup_employee()`** -- Lookup Employee.
+
+```python
+def lookup_employee(phone):
+    try:
+        resp = requests.get("https://api.merge.dev/api/hris/v1/employees",
+                            headers=MERGE_HEADERS, timeout=10,
+                            params={"personal_phone_number": phone})
+        if resp.ok:
+            results = resp.json().get("results", [])
+            if results:
+                return results[0]
+    except Exception as e:
+        app.logger.error("Merge employee lookup failed: %s", e)
+    return None
+```
+
+**`get_time_off()`** -- Get Time Off.
+
+```python
+def get_time_off(employee_id):
+    try:
+        resp = requests.get("https://api.merge.dev/api/hris/v1/time-off",
+                            headers=MERGE_HEADERS, timeout=10,
+                            params={"employee_id": employee_id, "status": "APPROVED"})
+        if resp.ok:
+            return resp.json().get("results", [])
+    except Exception as e:
+        app.logger.error("Merge time-off lookup failed: %s", e)
+    return []
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(question, employee_context):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [
+                {"role": "system", "content": f"You are an HR assistant. Answer concisely in 1-2 sentences using this data: {json.dumps(employee_context)}"},
+                {"role": "user", "content": question}
+            ]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-employee-hotline"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-employee-hotline-python/README.md
+++ b/merge-employee-hotline-python/README.md
@@ -1,0 +1,145 @@
+---
+name: merge-employee-hotline
+title: "Merge Employee Hotline"
+description: "Employees call and authenticate via caller ID matched against Merge HRIS."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference]
+integrations: [Merge HRIS]
+channel: [voice]
+---
+
+# Merge Employee Hotline
+
+> Also known as: employee self-service, HR hotline, PTO balance phone, employee benefits line.
+
+Employees call and authenticate via caller ID matched against Merge HRIS. AI pulls their PTO balance, department, manager, and upcoming time off, then answers HR questions conversationally.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, and AI inference run on one private global network, so this hotline answers calls, runs text-to-speech and speech recognition, and queries an AI model without leaving Telnyx. Call Control gives you programmatic answer, gather, speak, and hangup actions, while AI Inference handles the conversational HR responses inline. Owning the network end to end means lower latency on TTS and ASR plus predictable, usage-based pricing.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-employee-hotline-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-employee-hotline"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing, wrong, or not base64 | Copy the public key from [Portal -> Keys & Credentials](https://portal.telnyx.com) into `TELNYX_PUBLIC_KEY`; the log shows "webhook verification disabled" if it failed to parse. |
+| Webhook never fires / events not received | Telnyx cannot reach your local server | Run `ngrok http 5000` and set the Call Control Application webhook URL to `https://<id>.ngrok.io/webhooks/voice`. |
+| "Could not verify your identity" for a known employee | Caller ID does not match `personal_phone_number` in Merge, or `MERGE_API_KEY`/`MERGE_ACCOUNT_TOKEN` are unset | Confirm both Merge env vars are set and the employee's phone in the HRIS matches the calling number in E.164 format. |
+| AI replies "I could not process that request right now." | `TELNYX_API_KEY` invalid or `AI_MODEL` unavailable | Verify the API key and that `AI_MODEL` is a valid [Inference model](https://developers.telnyx.com/docs/inference/models). |
+
+## Related Examples
+
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- route inbound calls into a conversational AI agent
+- [merge-recruitment-hotline-python](../merge-recruitment-hotline-python/) -- caller-ID auth against Merge ATS for a recruiting line
+- [merge-employee-onboarding-python](../merge-employee-onboarding-python/) -- automate onboarding workflows backed by Merge HRIS
+- [edge-merge-ai-receptionist-python](../edge-merge-ai-receptionist-python/) -- AI receptionist combining Telnyx voice with Merge data
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-employee-hotline-python/app.py
+++ b/merge-employee-hotline-python/app.py
@@ -1,0 +1,187 @@
+"""Merge Employee Hotline - employees call, authenticate via caller ID against
+Merge HRIS. AI pulls PTO balance, benefits, org chart. Answers conversationally."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {"Authorization": f"Bearer {MERGE_API_KEY}", "X-Account-Token": MERGE_ACCOUNT_TOKEN or "", "Content-Type": "application/json"}
+
+call_sessions = {}
+MAX_ENTRIES = 10000
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[:len(store) - max_size]:
+            del store[k]
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+def decode_state(b64):
+    try: return json.loads(base64.b64decode(b64).decode())
+    except: return {}
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+def lookup_employee(phone):
+    try:
+        resp = requests.get("https://api.merge.dev/api/hris/v1/employees",
+                            headers=MERGE_HEADERS, timeout=10,
+                            params={"personal_phone_number": phone})
+        if resp.ok:
+            results = resp.json().get("results", [])
+            if results:
+                return results[0]
+    except Exception as e:
+        app.logger.error("Merge employee lookup failed: %s", e)
+    return None
+
+def get_time_off(employee_id):
+    try:
+        resp = requests.get("https://api.merge.dev/api/hris/v1/time-off",
+                            headers=MERGE_HEADERS, timeout=10,
+                            params={"employee_id": employee_id, "status": "APPROVED"})
+        if resp.ok:
+            return resp.json().get("results", [])
+    except Exception as e:
+        app.logger.error("Merge time-off lookup failed: %s", e)
+    return []
+
+def call_inference(question, employee_context):
+    try:
+        resp = requests.post(INFERENCE_URL, headers=HEADERS, timeout=15, json={
+            "model": AI_MODEL,
+            "messages": [
+                {"role": "system", "content": f"You are an HR assistant. Answer concisely in 1-2 sentences using this data: {json.dumps(employee_context)}"},
+                {"role": "user", "content": question}
+            ]
+        })
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "I could not process that request right now."
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        caller = ep.get("from", "")
+        employee = lookup_employee(caller)
+        if employee:
+            time_off = get_time_off(employee.get("id", ""))
+            emp_data = {
+                "name": f"{employee.get('first_name', '')} {employee.get('last_name', '')}".strip(),
+                "department": str(employee.get("department", "Unknown")),
+                "manager": str(employee.get("manager", "Unknown")),
+                "hire_date": employee.get("hire_date", "Unknown"),
+                "time_off_upcoming": [{"start": t.get("start_date"), "end": t.get("end_date")} for t in time_off[:5]]
+            }
+            call_sessions[cc_id] = {"employee": emp_data, "history": [], "ts": time.time()}
+            ttl_cleanup(call_sessions)
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                          headers=HEADERS, timeout=10,
+                          json={"client_state": encode_state({"auth": True})})
+        else:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+                          headers=HEADERS, timeout=10,
+                          json={"client_state": encode_state({"auth": False})})
+
+    elif event_type == "call.answered":
+        state = decode_state(ep.get("client_state", ""))
+        session = call_sessions.get(cc_id, {})
+        if state.get("auth"):
+            name = session.get("employee", {}).get("name", "")
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": f"Hi {name}. What would you like to know?",
+                                "voice": "female", "language": "en-US", "input_type": "speech", "timeout_secs": 30,
+                                "client_state": encode_state({"step": "conversation"})})
+        else:
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": "Could not verify your identity. Please call from your registered number.",
+                                "voice": "female", "language": "en-US"})
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        session = call_sessions.get(cc_id, {})
+        if speech and session.get("employee"):
+            response = call_inference(speech, session["employee"])
+            requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                          headers=HEADERS, timeout=10,
+                          json={"payload": response, "voice": "female", "language": "en-US",
+                                "input_type": "speech", "timeout_secs": 30,
+                                "client_state": encode_state({"step": "conversation"})})
+
+    elif event_type == "call.speak.ended":
+        requests.post(f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+                      headers=HEADERS, timeout=10)
+
+    elif event_type == "call.hangup":
+        call_sessions.pop(cc_id, None)
+
+    return jsonify({"status": "ok"})
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-employee-hotline"})
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-employee-hotline-python/requirements.txt
+++ b/merge-employee-hotline-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-employee-onboarding-python/.env.example
+++ b/merge-employee-onboarding-python/.env.example
@@ -1,0 +1,2 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=

--- a/merge-employee-onboarding-python/API.md
+++ b/merge-employee-onboarding-python/API.md
@@ -1,0 +1,106 @@
+# API Reference -- Merge Employee Onboarding
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/hris` | Hris |
+| `POST` | `/onboard` | Onboard |
+| `GET` | `/onboardings` | Onboardings |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/hris`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /onboard`
+
+Onboard.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/onboard \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `GET /onboardings`
+
+Onboardings.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/onboardings
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-employee-onboarding-python/GUIDE.md
+++ b/merge-employee-onboarding-python/GUIDE.md
@@ -1,0 +1,218 @@
+# Build a Merge Employee Onboarding
+
+New employee webhook from Merge HRIS triggers full provisioning: Telnyx phone number, AI voicemail greeting, welcome SMS with IT setup instructions, and IT ticket via Merge Ticketing.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+- **Numbers** -- search, order, and manage phone numbers
+
+## API Endpoints
+
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Search Available Numbers**: `GET /v2/available_phone_numbers` -- [API reference](https://developers.telnyx.com/api/numbers/list-available-phone-numbers)
+- **Order Numbers**: `POST /v2/number_orders` -- [API reference](https://developers.telnyx.com/api/numbers/create-number-order)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-employee-onboarding-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (247 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`merge_post()`** -- Merge Post.
+
+```python
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+```
+
+**`provision_number()`** -- Provision Number.
+
+```python
+def provision_number(area_code=""):
+    """Search for and order a Telnyx phone number."""
+    params = {"filter[country_code]": "US", "filter[limit]": 1}
+    if area_code:
+        params["filter[national_destination_code]"] = area_code
+    try:
+        search = requests.get(
+            "https://api.telnyx.com/v2/available_phone_numbers",
+            headers=HEADERS,
+            timeout=10,
+            params=params,
+        )
+```
+
+**`generate_voicemail_greeting()`** -- Generate Voicemail Greeting.
+
+```python
+def generate_voicemail_greeting(name, department):
+    """Generate a personalized voicemail greeting via AI."""
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+```
+
+**`send_welcome_sms()`** -- Send Welcome Sms.
+
+```python
+def send_welcome_sms(phone, name, new_number):
+    """Send welcome SMS to new employee."""
+    msg = (
+        f"Welcome {name}! Your company phone number is {new_number}. "
+        f"Check your email for IT setup instructions including laptop, badge, and account access."
+    )
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/messages",
+            headers=HEADERS,
+            timeout=10,
+            json={"from": TELNYX_PHONE, "to": phone, "text": msg},
+```
+
+**`create_it_ticket()`** -- Create It Ticket.
+
+```python
+def create_it_ticket(name, start_date, department, employee_id):
+    """Create IT setup ticket in Merge Ticketing."""
+    ticket_data = {
+        "name": f"New hire IT setup: {name}",
+        "description": (
+            f"Provision laptop, accounts, badge, and office access for {name}.\n"
+            f"Department: {department}\n"
+            f"Start date: {start_date}\n"
+            f"Employee ID: {employee_id}\n\n"
+            f"Checklist:\n"
+            f"- [ ] Laptop ordered and configured\n"
+            f"- [ ] Email and Slack accounts created\n"
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/hris` | Hris |
+| `POST` | `/onboard` | Onboard |
+| `GET` | `/onboardings` | Onboardings |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-employee-onboarding"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-employee-onboarding-python/README.md
+++ b/merge-employee-onboarding-python/README.md
@@ -1,0 +1,172 @@
+---
+name: merge-employee-onboarding
+title: "Merge Employee Onboarding"
+description: "New employee webhook from Merge HRIS triggers full provisioning: Telnyx phone number, AI voicemail greeting, welcome SMS with IT setup instructions, and IT ticket via Merge Ticketing."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference, Messaging, Numbers]
+integrations: [Merge HRIS, Merge Ticketing]
+channel: [voice, sms]
+---
+
+# Merge Employee Onboarding
+
+> Also known as: employee onboarding, new hire automation, HR provisioning, onboarding workflow.
+
+New employee webhook from Merge HRIS triggers full provisioning: Telnyx phone number, AI voicemail greeting, welcome SMS with IT setup instructions, and IT ticket via Merge Ticketing.
+
+## Why Telnyx
+
+This onboarding flow provisions a phone number, generates an AI voicemail greeting, and sends welcome SMS in a single handler -- because Telnyx runs voice, messaging, and AI inference on one private global network as **AI Communications Infrastructure**. Numbers ordered here are immediately routable to your Call Control application, and AI Inference responds on the same low-latency backbone, so a new hire is fully reachable the moment Merge fires the webhook -- no stitching together separate carrier, SMS, and model vendors.
+
+## Telnyx API Endpoints Used
+
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Search Available Numbers**: `GET /v2/available_phone_numbers` -- [API reference](https://developers.telnyx.com/api/numbers/list-available-phone-numbers)
+- **Order Numbers**: `POST /v2/number_orders` -- [API reference](https://developers.telnyx.com/api/numbers/create-number-order)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `IT_ADMIN_PHONE` | `string` | `+12125551234` | no | IT admin phone | -- |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-employee-onboarding-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /onboard`
+
+Onboard.
+
+```bash
+curl -X POST http://localhost:5000/onboard \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /onboardings`
+
+Onboardings.
+
+```bash
+curl http://localhost:5000/onboardings
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-employee-onboarding"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-employee-onboarding"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/hris` | Hris |
+| `POST` | `/onboard` | Onboard |
+| `GET` | `/onboardings` | Onboardings |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `401 Unauthorized` from Telnyx | Missing or wrong `TELNYX_API_KEY` | Verify the v2 key in your `.env` against the [Portal](https://portal.telnyx.com/api-keys); restart the app so `load_dotenv()` re-reads it |
+| `number_provisioning_failed` action returned | No matching numbers, or `TELNYX_CONNECTION_ID` unset/invalid | Confirm a Call Control Application exists and set its ID in `.env`; numbers can only be ordered against a valid connection |
+| Welcome SMS never arrives | `TELNYX_PHONE_NUMBER` unset, or employee record has no `phone_numbers` value | Set a verified Telnyx `from` number; the SMS step is skipped when either the source or the employee personal phone is missing |
+| `Merge GET/POST rejected non-Merge host` in logs | A path resolved off the trusted `api.merge.dev` host | Pass only relative Merge paths (e.g. `/hris/v1/employees/{id}`); the SSRF guard in `_merge_url()` blocks anything else |
+| HRIS webhook returns `404 Employee not found` | `MERGE_API_KEY` / `MERGE_ACCOUNT_TOKEN` wrong, or the `id` in the payload is unknown to Merge | Re-check both Merge credentials and confirm the linked account token matches the HRIS integration |
+
+## Related Examples
+
+- [merge-employee-hotline-python](../merge-employee-hotline-python/) -- AI phone line backed by Merge HRIS employee data
+- [merge-ticket-escalation-python](../merge-ticket-escalation-python/) -- create and escalate tickets via Merge Ticketing
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- route the newly provisioned number to an AI agent
+- [send-sms-notifications-python](../send-sms-notifications-python/) -- standalone outbound SMS notification patterns
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-employee-onboarding-python/app.py
+++ b/merge-employee-onboarding-python/app.py
@@ -1,0 +1,273 @@
+"""Merge Employee Onboarding — new employee webhook from Merge HRIS triggers
+automated provisioning: provisions a Telnyx phone number, configures AI voicemail
+greeting, sends welcome SMS with IT setup instructions, and creates an IT setup
+ticket via Merge Ticketing."""
+import os, time, logging
+from urllib.parse import urlparse
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+IT_ADMIN_PHONE = os.getenv("IT_ADMIN_PHONE", "")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+MERGE_HOST = (urlparse(MERGE_BASE).hostname or "").lower()
+
+onboarding_log = []
+MAX_ENTRIES = 10000
+
+
+def _merge_url(path):
+    """Build a Merge API URL and confirm it stays on the trusted Merge host.
+
+    `path` may contain values derived from inbound webhook data (e.g. an
+    employee id), so the fully-resolved URL is validated before any request
+    is sent — otherwise a crafted value could redirect the call (and the
+    Merge API key in MERGE_HEADERS) to an attacker-controlled host (SSRF).
+    """
+    url = f"{MERGE_BASE}{path}"
+    parts = urlparse(url)
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https" or not (host == MERGE_HOST or host.endswith("." + MERGE_HOST)):
+        return None
+    return url
+
+
+def merge_get(path, params=None):
+    url = _merge_url(path)
+    if not url:
+        app.logger.error("Merge GET rejected non-Merge host for path: %s", path)
+        return None
+    try:
+        resp = requests.get(
+            url, headers=MERGE_HEADERS, timeout=10, params=params, allow_redirects=False
+        )
+        if resp.ok:
+            return resp.json()
+    except (requests.RequestException, ValueError) as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def merge_post(path, data):
+    url = _merge_url(path)
+    if not url:
+        app.logger.error("Merge POST rejected non-Merge host for path: %s", path)
+        return None
+    try:
+        resp = requests.post(
+            url, headers=MERGE_HEADERS, timeout=10, json={"model": data}, allow_redirects=False
+        )
+        if resp.ok:
+            return resp.json()
+    except (requests.RequestException, ValueError) as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+
+
+def provision_number(area_code=""):
+    """Search for and order a Telnyx phone number."""
+    params = {"filter[country_code]": "US", "filter[limit]": 1}
+    if area_code:
+        params["filter[national_destination_code]"] = area_code
+    try:
+        search = requests.get(
+            "https://api.telnyx.com/v2/available_phone_numbers",
+            headers=HEADERS,
+            timeout=10,
+            params=params,
+        )
+        if not search.ok:
+            return None
+        numbers = search.json().get("data", [])
+        if not numbers:
+            return None
+        phone = numbers[0]["phone_number"]
+        order = requests.post(
+            "https://api.telnyx.com/v2/number_orders",
+            headers=HEADERS,
+            timeout=10,
+            json={"phone_numbers": [{"phone_number": phone}], "connection_id": CONNECTION_ID},
+        )
+        if order.ok:
+            return phone
+    except Exception as e:
+        app.logger.error("Number provisioning failed: %s", e)
+    return None
+
+
+def generate_voicemail_greeting(name, department):
+    """Generate a personalized voicemail greeting via AI."""
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "Generate a short, professional voicemail greeting (under 30 words). Include the persons name and department.",
+                    },
+                    {"role": "user", "content": f"Name: {name}, Department: {department}"},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Greeting generation failed: %s", e)
+    return f"You have reached {name}. Please leave a message and I will return your call."
+
+
+def send_welcome_sms(phone, name, new_number):
+    """Send welcome SMS to new employee."""
+    msg = (
+        f"Welcome {name}! Your company phone number is {new_number}. "
+        f"Check your email for IT setup instructions including laptop, badge, and account access."
+    )
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/messages",
+            headers=HEADERS,
+            timeout=10,
+            json={"from": TELNYX_PHONE, "to": phone, "text": msg},
+        )
+        return True
+    except Exception as e:
+        app.logger.error("Welcome SMS failed: %s", e)
+        return False
+
+
+def create_it_ticket(name, start_date, department, employee_id):
+    """Create IT setup ticket in Merge Ticketing."""
+    ticket_data = {
+        "name": f"New hire IT setup: {name}",
+        "description": (
+            f"Provision laptop, accounts, badge, and office access for {name}.\n"
+            f"Department: {department}\n"
+            f"Start date: {start_date}\n"
+            f"Employee ID: {employee_id}\n\n"
+            f"Checklist:\n"
+            f"- [ ] Laptop ordered and configured\n"
+            f"- [ ] Email and Slack accounts created\n"
+            f"- [ ] Badge and office access provisioned\n"
+            f"- [ ] VPN credentials issued\n"
+            f"- [ ] Phone number assigned"
+        ),
+        "priority": "NORMAL",
+    }
+    return merge_post("/ticketing/v1/tickets", ticket_data)
+
+
+@app.route("/webhooks/hris", methods=["POST"])
+def handle_hris_webhook():
+    """Merge HRIS webhook — new employee triggers full onboarding flow."""
+    data = request.get_json() or {}
+    employee_id = data.get("id", "")
+    employee = merge_get(f"/hris/v1/employees/{employee_id}") if employee_id else data
+    if not employee:
+        return jsonify({"error": "Employee not found"}), 404
+    name = f"{employee.get('first_name', '')} {employee.get('last_name', '')}".strip() or "New Employee"
+    department = employee.get("department", {}).get("name", "General") if isinstance(employee.get("department"), dict) else str(employee.get("department", "General"))
+    start_date = employee.get("start_date", "TBD")
+    personal_phone = None
+    for pn in employee.get("phone_numbers", []):
+        if pn.get("value"):
+            personal_phone = pn["value"]
+            break
+    actions = []
+    # 1. Provision phone number
+    new_number = provision_number()
+    if new_number:
+        actions.append({"action": "number_provisioned", "number": new_number})
+    else:
+        actions.append({"action": "number_provisioning_failed"})
+    # 2. Generate voicemail greeting
+    greeting = generate_voicemail_greeting(name, department)
+    actions.append({"action": "voicemail_greeting_generated", "greeting": greeting[:100]})
+    # 3. Send welcome SMS
+    if personal_phone and TELNYX_PHONE:
+        sent = send_welcome_sms(personal_phone, name, new_number or "(pending)")
+        actions.append({"action": "welcome_sms_sent" if sent else "welcome_sms_failed"})
+    # 4. Create IT ticket
+    ticket = create_it_ticket(name, start_date, department, employee_id)
+    if ticket:
+        ticket_id = ticket.get("model", {}).get("id", "")
+        actions.append({"action": "it_ticket_created", "ticket_id": ticket_id})
+    else:
+        actions.append({"action": "it_ticket_failed"})
+    # 5. Notify IT admin
+    if IT_ADMIN_PHONE and TELNYX_PHONE:
+        try:
+            requests.post(
+                "https://api.telnyx.com/v2/messages",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "from": TELNYX_PHONE,
+                    "to": IT_ADMIN_PHONE,
+                    "text": f"New hire onboarding started: {name} ({department}). Start: {start_date}. Check ticket queue.",
+                },
+            )
+            actions.append({"action": "it_admin_notified"})
+        except Exception as e:
+            app.logger.error("IT admin notification failed: %s", e)
+    result = {"employee": name, "department": department, "start_date": start_date, "actions": actions}
+    onboarding_log.append({**result, "ts": time.time()})
+    if len(onboarding_log) > MAX_ENTRIES:
+        onboarding_log[:] = onboarding_log[-MAX_ENTRIES:]
+    return jsonify(result)
+
+
+@app.route("/onboard", methods=["POST"])
+def manual_onboard():
+    """Manually trigger onboarding for testing."""
+    data = request.get_json() or {}
+    name = data.get("name", "Test Employee")
+    phone = data.get("phone")
+    department = data.get("department", "Engineering")
+    actions = []
+    new_number = provision_number()
+    if new_number:
+        actions.append({"action": "number_provisioned", "number": new_number})
+    greeting = generate_voicemail_greeting(name, department)
+    actions.append({"action": "voicemail_greeting_generated", "greeting": greeting[:100]})
+    if phone and TELNYX_PHONE:
+        sent = send_welcome_sms(phone, name, new_number or "(pending)")
+        actions.append({"action": "welcome_sms_sent" if sent else "welcome_sms_failed"})
+    return jsonify({"employee": name, "department": department, "actions": actions})
+
+
+@app.route("/onboardings", methods=["GET"])
+def list_onboardings():
+    """List onboarding history."""
+    return jsonify({"onboardings": onboarding_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-employee-onboarding", "total_onboarded": len(onboarding_log)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-employee-onboarding-python/requirements.txt
+++ b/merge-employee-onboarding-python/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31

--- a/merge-expense-by-phone-python/.env.example
+++ b/merge-expense-by-phone-python/.env.example
@@ -1,0 +1,14 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=your_telnyx_api_key_here
+# Webhook signature verification (Ed25519 public key) — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=your_telnyx_public_key_here
+# Telnyx phone number — https://portal.telnyx.com/numbers/my-numbers
+TELNYX_PHONE_NUMBER=+18005551234
+# Call Control app ID — https://portal.telnyx.com/call-control/applications
+TELNYX_CONNECTION_ID=
+# Merge.dev API key — https://app.merge.dev/keys
+MERGE_API_KEY=your_merge_api_key_here
+# Merge linked account token — https://app.merge.dev
+MERGE_ACCOUNT_TOKEN=your_merge_account_token_here
+# AI model (optional)
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/merge-expense-by-phone-python/API.md
+++ b/merge-expense-by-phone-python/API.md
@@ -1,0 +1,84 @@
+# API Reference -- Merge Expense by Phone
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/expenses` | Expenses |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /expenses`
+
+Expenses.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/expenses
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-expense-by-phone-python/GUIDE.md
+++ b/merge-expense-by-phone-python/GUIDE.md
@@ -1,0 +1,218 @@
+# Build a Merge Expense by Phone
+
+Salesperson calls and dictates an expense. AI extracts amount, merchant, category, and deal context. Creates entry in accounting via Merge. Links to CRM opportunity if mentioned. SMS receipt.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-expense-by-phone-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (323 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`merge_post()`** -- Merge Post.
+
+```python
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+```
+
+**`extract_expense()`** -- Extract Expense.
+
+```python
+def extract_expense(speech):
+    """Use AI to extract structured expense data from spoken description."""
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+```
+
+**`find_deal()`** -- Find Deal.
+
+```python
+def find_deal(deal_name):
+    """Search CRM for matching opportunity."""
+    if not deal_name:
+        return None
+    result = merge_get("/crm/v1/opportunities", params={"name": deal_name, "page_size": 5})
+    if result and result.get("results"):
+        return result["results"][0]
+    return None
+```
+
+**`send_receipt()`** -- Send Receipt.
+
+```python
+def send_receipt(phone, expense_data):
+    """Send SMS receipt."""
+    amount = expense_data.get("amount", 0)
+    merchant = expense_data.get("merchant", "Unknown")
+    category = expense_data.get("category", "other")
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/messages",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "from": TELNYX_PHONE,
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/expenses` | Expenses |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-expense-by-phone"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-expense-by-phone-python/README.md
+++ b/merge-expense-by-phone-python/README.md
@@ -1,0 +1,165 @@
+---
+name: merge-expense-by-phone
+title: "Merge Expense by Phone"
+description: "Salesperson calls and dictates an expense."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference, Messaging]
+integrations: [Merge Accounting, Merge CRM]
+channel: [voice, sms]
+---
+
+# Merge Expense by Phone
+
+> Also known as: expense reporting by phone, voice expense logger, expense automation.
+
+Salesperson calls and dictates an expense. AI extracts amount, merchant, category, and deal context. Creates entry in accounting via Merge. Links to CRM opportunity if mentioned. SMS receipt.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, and AI inference run on one private global network, so a single dictated call can be answered, transcribed, structured by an LLM, and confirmed with an SMS receipt without stitching together separate vendors. This example uses Call Control for the inbound voice flow, AI Inference to extract structured expense data, and the Messaging API for the receipt — all behind one API key with usage-based pricing.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PUBLIC_KEY` | `string` | `eyJ...` | **yes** | Ed25519 public key for webhook signature verification | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-expense-by-phone-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /expenses`
+
+Expenses.
+
+```bash
+curl http://localhost:5000/expenses
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-expense-by-phone"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-expense-by-phone"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/expenses` | Expenses |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` missing, wrong, or webhook verification disabled | Set `TELNYX_PUBLIC_KEY` to the Ed25519 public key from the [Portal](https://portal.telnyx.com/api-keys); the app logs "Invalid TELNYX_PUBLIC_KEY" at startup if it cannot decode it. |
+| Calls connect but no greeting / actions fail | `TELNYX_API_KEY` missing or wrong, so Call Control `answer`/`gather_using_speak` requests fail | Confirm `TELNYX_API_KEY` is set and the key has Call Control permissions. |
+| Telnyx never reaches your app | Webhook URL not publicly reachable | Run `ngrok http 5000` and set the Call Control Application webhook URL to `https://<id>.ngrok.io/webhooks/voice`. |
+| "I could not extract the expense details" loop | AI Inference call failed or returned no amount | Check `AI_MODEL` is a valid [Inference model](https://developers.telnyx.com/docs/inference/models) and that the key has AI Inference enabled. |
+| Expense not created / no SMS receipt | `MERGE_API_KEY` / `MERGE_ACCOUNT_TOKEN` or `TELNYX_PHONE_NUMBER` missing | Set all three; Merge and receipt failures are logged via `app.logger` but do not interrupt the call. |
+
+## Related Examples
+
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — Call Control voice flow that routes callers to an AI agent.
+- [ai-sales-call-with-live-crm-updates-python](../ai-sales-call-with-live-crm-updates-python/) — voice call that writes structured data back to CRM via Merge.
+- [merge-invoice-collector-python](../merge-invoice-collector-python/) — sibling Merge accounting integration over voice.
+- [mms-receipt-scanner-expense-tracker-python](../mms-receipt-scanner-expense-tracker-python/) — expense capture from MMS receipt images.
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-expense-by-phone-python/app.py
+++ b/merge-expense-by-phone-python/app.py
@@ -1,0 +1,360 @@
+"""Merge Expense by Phone — salesperson calls, dictates an expense. AI extracts
+amount, merchant, category, and deal context. Creates entry in accounting via
+Merge. Tags to CRM opportunity if mentioned. Sends SMS receipt with details."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+call_sessions = {}
+expense_log = []
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+
+
+def extract_expense(speech):
+    """Use AI to extract structured expense data from spoken description."""
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Extract expense details from the spoken description. Return JSON: "
+                            '{"amount": number, "merchant": "string", "category": "meals|travel|office|entertainment|other", '
+                            '"description": "brief description", "deal_name": "string or null if no deal mentioned"}'
+                        ),
+                    },
+                    {"role": "user", "content": speech},
+                ],
+                "response_format": {"type": "json_object"},
+            },
+        )
+        if resp.ok:
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+    except Exception as e:
+        app.logger.error("Expense extraction failed: %s", e)
+    return None
+
+
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are an expense logging assistant. Confirm the expense details "
+                            "back to the user. Be concise — 1-2 sentences.\n\n"
+                            f"Expense data: {json.dumps(context)}"
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "I have recorded your expense."
+
+
+def find_deal(deal_name):
+    """Search CRM for matching opportunity."""
+    if not deal_name:
+        return None
+    result = merge_get("/crm/v1/opportunities", params={"name": deal_name, "page_size": 5})
+    if result and result.get("results"):
+        return result["results"][0]
+    return None
+
+
+def send_receipt(phone, expense_data):
+    """Send SMS receipt."""
+    amount = expense_data.get("amount", 0)
+    merchant = expense_data.get("merchant", "Unknown")
+    category = expense_data.get("category", "other")
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/messages",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "from": TELNYX_PHONE,
+                "to": phone,
+                "text": (
+                    f"Expense logged: ${amount:.2f} at {merchant} ({category}). "
+                    f"Ref: EXP-{int(time.time()) % 100000}"
+                ),
+            },
+        )
+        return True
+    except Exception as e:
+        app.logger.error("Receipt SMS failed: %s", e)
+        return False
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        caller = ep.get("from", "")
+        call_sessions[cc_id] = {"caller": caller, "ts": time.time()}
+        ttl_cleanup(call_sessions)
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+            headers=HEADERS,
+            timeout=10,
+            json={"client_state": encode_state({"step": "greeting"})},
+        )
+
+    elif event_type == "call.answered":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": (
+                    "Expense logger. Tell me what you spent, how much, where, "
+                    "and what client or deal it was for."
+                ),
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 60,
+                "client_state": encode_state({"step": "capture"}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        step = state.get("step", "capture")
+        session = call_sessions.get(cc_id, {})
+
+        if step == "capture" and speech:
+            expense_data = extract_expense(speech)
+            if expense_data and expense_data.get("amount"):
+                session["expense"] = expense_data
+                # Create expense in accounting
+                merge_post("/accounting/v1/expenses", {
+                    "total_amount": expense_data.get("amount"),
+                    "memo": expense_data.get("description", ""),
+                    "transaction_date": time.strftime("%Y-%m-%d"),
+                })
+                # Tag to deal if mentioned
+                deal_name = expense_data.get("deal_name")
+                if deal_name:
+                    deal = find_deal(deal_name)
+                    if deal:
+                        session["linked_deal"] = deal.get("name")
+                confirmation = call_inference("Confirm this expense.", expense_data)
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": f"{confirmation} Would you like to log another expense?",
+                        "voice": "female",
+                        "language": "en-US",
+                        "input_type": "speech",
+                        "timeout_secs": 15,
+                        "client_state": encode_state({"step": "another"}),
+                    },
+                )
+                # Send receipt
+                caller = session.get("caller")
+                if caller and TELNYX_PHONE:
+                    send_receipt(caller, expense_data)
+                # Log
+                expense_log.append({**expense_data, "caller": caller, "ts": time.time()})
+                if len(expense_log) > MAX_ENTRIES:
+                    expense_log[:] = expense_log[-MAX_ENTRIES:]
+            else:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "I could not extract the expense details. Please try again: how much, where, and for what?",
+                        "voice": "female",
+                        "language": "en-US",
+                        "input_type": "speech",
+                        "timeout_secs": 60,
+                        "client_state": encode_state({"step": "capture"}),
+                    },
+                )
+
+        elif step == "another" and speech:
+            if "yes" in speech.lower() or "another" in speech.lower():
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "Go ahead. What did you spend?",
+                        "voice": "female",
+                        "language": "en-US",
+                        "input_type": "speech",
+                        "timeout_secs": 60,
+                        "client_state": encode_state({"step": "capture"}),
+                    },
+                )
+            else:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "All done. Check your texts for receipts. Goodbye.",
+                        "voice": "female",
+                        "language": "en-US",
+                    },
+                )
+
+    elif event_type == "call.speak.ended":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        call_sessions.pop(cc_id, None)
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/expenses", methods=["GET"])
+def list_expenses():
+    """List logged expenses."""
+    return jsonify({"expenses": expense_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-expense-by-phone", "total_logged": len(expense_log)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-expense-by-phone-python/requirements.txt
+++ b/merge-expense-by-phone-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-interview-pipeline-python/.env.example
+++ b/merge-interview-pipeline-python/.env.example
@@ -1,0 +1,14 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=your_telnyx_api_key_here
+# Webhook signature verification (Ed25519 public key) — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=your_telnyx_public_key_here
+# Telnyx phone number — https://portal.telnyx.com/numbers/my-numbers
+TELNYX_PHONE_NUMBER=+18005551234
+# Call Control app ID — https://portal.telnyx.com/call-control/applications
+TELNYX_CONNECTION_ID=
+# Merge.dev API key — https://app.merge.dev/keys
+MERGE_API_KEY=your_merge_api_key_here
+# Merge linked account token — https://app.merge.dev
+MERGE_ACCOUNT_TOKEN=your_merge_account_token_here
+# AI model (optional)
+AI_MODEL=moonshotai/Kimi-K2.6

--- a/merge-interview-pipeline-python/API.md
+++ b/merge-interview-pipeline-python/API.md
@@ -1,0 +1,151 @@
+# API Reference -- Merge Interview Pipeline
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ats` | Ats |
+| `POST` | `/screen` | Screen |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/screens` | Screens |
+| `GET` | `/screens/<session_id>` | <Session Id> |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/ats`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /screen`
+
+Screen.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/screen \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /screens`
+
+Screens.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/screens
+```
+
+---
+
+## `GET /screens/<session_id>`
+
+<Session Id>.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/screens/<session_id>
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-interview-pipeline-python/GUIDE.md
+++ b/merge-interview-pipeline-python/GUIDE.md
@@ -1,0 +1,222 @@
+# Build a Merge Interview Pipeline
+
+ATS webhook fires when a new application arrives. App calls the candidate within 60 seconds for an AI-conducted structured phone screen. Scores responses with AI. Updates ATS application stage. Sends SMS confirmation.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-interview-pipeline-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (399 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`merge_post()`** -- Merge Post.
+
+```python
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+```
+
+**`merge_patch()`** -- Merge Patch.
+
+```python
+def merge_patch(path, data):
+    try:
+        resp = requests.patch(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge PATCH %s failed: %s", path, e)
+    return None
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+```
+
+**`score_screen()`** -- Score Screen.
+
+```python
+def score_screen(answers):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+```
+
+**`handle_ats_webhook()`** -- Handle Ats Webhook.
+
+```python
+def handle_ats_webhook():
+    """Merge ATS webhook — new application triggers outbound screen call."""
+    data = request.get_json() or {}
+    candidate_id = data.get("candidate", data.get("candidate_id", ""))
+    application_id = data.get("id", data.get("application_id", ""))
+    job_name = data.get("job_name", "the open position")
+    if not candidate_id:
+        return jsonify({"error": "No candidate ID"}), 400
+    candidate = merge_get(f"/ats/v1/candidates/{candidate_id}")
+    if not candidate:
+        return jsonify({"error": "Candidate not found in ATS"}), 404
+    phone = None
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ats` | Ats |
+| `POST` | `/screen` | Screen |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/screens` | Screens |
+| `GET` | `/screens/<session_id>` | <Session Id> |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-interview-pipeline"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-interview-pipeline-python/README.md
+++ b/merge-interview-pipeline-python/README.md
@@ -1,0 +1,194 @@
+---
+name: merge-interview-pipeline
+title: "Merge Interview Pipeline"
+description: "ATS webhook fires when a new application arrives."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference, Messaging]
+integrations: [Merge ATS]
+channel: [voice, sms]
+---
+
+# Merge Interview Pipeline
+
+> Also known as: automated phone screen, AI recruiter, ATS integration, candidate screening, hiring automation.
+
+ATS webhook fires when a new application arrives. App calls the candidate within 60 seconds for an AI-conducted structured phone screen. Scores responses with AI. Updates ATS application stage. Sends SMS confirmation.
+
+## Why Telnyx
+
+Telnyx is **AI Communications Infrastructure** — outbound calls, real-time speech gather, text-to-speech, AI inference, and SMS all run on one private global network, so this entire screen-call-score-confirm pipeline needs a single provider and a single API key. Placing the outbound call, conducting the AI conversation, scoring the transcript, and texting the confirmation happen with low latency and no carrier hop-off between vendors. That keeps candidate experience fast and your hiring automation simple to operate.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-interview-pipeline-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /screen`
+
+Screen.
+
+```bash
+curl -X POST http://localhost:5000/screen \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /screens`
+
+Screens.
+
+```bash
+curl http://localhost:5000/screens
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-interview-pipeline"}
+```
+
+### `GET /screens/<session_id>`
+
+<Session Id>.
+
+```bash
+curl http://localhost:5000/screens/<session_id>
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-interview-pipeline"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-interview-pipeline"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ats` | Ats |
+| `POST` | `/screen` | Screen |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/screens` | Screens |
+| `GET` | `/screens/<session_id>` | <Session Id> |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing or wrong, so Ed25519 verification fails | Set `TELNYX_PUBLIC_KEY` to the base64 public key from [Portal -> Keys & Credentials](https://portal.telnyx.com/app/account/keys-credentials); the app rejects all voice webhooks until it is valid |
+| `Failed to place call` / no outbound call | `TELNYX_API_KEY`, `TELNYX_PHONE_NUMBER`, or `TELNYX_CONNECTION_ID` unset or invalid | Confirm all three are filled in `.env` and the connection is a Call Control application tied to the from-number |
+| Webhooks never arrive | Telnyx cannot reach your local server, or the webhook URL is misconfigured | Run `ngrok http 5000` and set the Call Control app webhook URL to `https://<id>.ngrok.io/webhooks/voice`; the app derives the call's `webhook_url` from the request host |
+| `Candidate not found` / `No phone number on file` | `MERGE_API_KEY` / `MERGE_ACCOUNT_TOKEN` wrong, or the candidate record has no phone | Verify the Merge keys at [app.merge.dev](https://app.merge.dev) and that the candidate has a populated phone number before the screen fires |
+
+## Related Examples
+
+- [ai-hiring-phone-screen-python](../ai-hiring-phone-screen-python/) — AI-conducted phone screen without the ATS integration
+- [interview-screen-scheduler-python](../interview-screen-scheduler-python/) — schedule candidate screens over voice/SMS
+- [merge-recruitment-hotline-python](../merge-recruitment-hotline-python/) — Merge ATS-backed recruiting hotline
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — route inbound calls to an AI voice agent
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-interview-pipeline-python/app.py
+++ b/merge-interview-pipeline-python/app.py
@@ -1,0 +1,437 @@
+"""Merge Interview Pipeline — ATS webhook fires on new applicant. Calls candidate
+within 60 seconds. AI conducts structured phone screen with role-specific questions.
+Scores responses. Updates ATS with results. SMS confirmation to candidate."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+SCREEN_QUESTIONS = [
+    "Tell me about your most relevant experience for this role.",
+    "What attracted you to this position?",
+    "Describe a challenging project you led and the outcome.",
+    "What is your availability to start, and are you open to the listed location?",
+    "Do you have any questions about the role or company?",
+]
+
+call_sessions = {}
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+
+
+def merge_patch(path, data):
+    try:
+        resp = requests.patch(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge PATCH %s failed: %s", path, e)
+    return None
+
+
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a professional recruiter conducting a phone screen. "
+                            "Score answers 1-5. Be warm but efficient. One question at a time. "
+                            "Keep responses under 2 sentences.\n\n"
+                            f"Context: {json.dumps(context)}"
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "I could not process that. Let me move to the next question."
+
+
+def score_screen(answers):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Score this phone screen. Return JSON: "
+                            '{"overall_score": 1-5, "strengths": ["..."], '
+                            '"concerns": ["..."], "recommendation": '
+                            '"advance|hold|reject", "summary": "2 sentences"}'
+                        ),
+                    },
+                    {"role": "user", "content": json.dumps(answers)},
+                ],
+                "response_format": {"type": "json_object"},
+            },
+        )
+        if resp.ok:
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+    except Exception as e:
+        app.logger.error("Scoring failed: %s", e)
+    return {"overall_score": 3, "recommendation": "hold", "summary": "Auto-score unavailable."}
+
+
+@app.route("/webhooks/ats", methods=["POST"])
+def handle_ats_webhook():
+    """Merge ATS webhook — new application triggers outbound screen call."""
+    data = request.get_json() or {}
+    candidate_id = data.get("candidate", data.get("candidate_id", ""))
+    application_id = data.get("id", data.get("application_id", ""))
+    job_name = data.get("job_name", "the open position")
+    if not candidate_id:
+        return jsonify({"error": "No candidate ID"}), 400
+    candidate = merge_get(f"/ats/v1/candidates/{candidate_id}")
+    if not candidate:
+        return jsonify({"error": "Candidate not found in ATS"}), 404
+    phone = None
+    for pn in candidate.get("phone_numbers", []):
+        if pn.get("value"):
+            phone = pn["value"]
+            break
+    if not phone:
+        app.logger.warning("Candidate %s has no phone number", candidate_id)
+        return jsonify({"error": "No phone number on file"}), 400
+    session_id = f"screen-{int(time.time())}-{candidate_id[:8]}"
+    call_sessions[session_id] = {
+        "candidate_id": candidate_id,
+        "application_id": application_id,
+        "candidate_name": f"{candidate.get('first_name', '')} {candidate.get('last_name', '')}".strip(),
+        "job_name": job_name,
+        "phone": phone,
+        "question_idx": 0,
+        "answers": [],
+        "ts": time.time(),
+    }
+    ttl_cleanup(call_sessions)
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": phone,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"session_id": session_id}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("Outbound call failed: %s", e)
+        return jsonify({"error": "Failed to place call"}), 500
+    return jsonify({"status": "calling", "session_id": session_id, "candidate": call_sessions[session_id]["candidate_name"]})
+
+
+@app.route("/screen", methods=["POST"])
+def manual_screen():
+    """Manually trigger a phone screen."""
+    data = request.get_json() or {}
+    phone = data.get("phone")
+    name = data.get("name", "Candidate")
+    job = data.get("job_name", "Open Position")
+    if not phone:
+        return jsonify({"error": "phone required"}), 400
+    session_id = f"screen-{int(time.time())}"
+    call_sessions[session_id] = {
+        "candidate_name": name,
+        "job_name": job,
+        "phone": phone,
+        "question_idx": 0,
+        "answers": [],
+        "ts": time.time(),
+    }
+    ttl_cleanup(call_sessions)
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": phone,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"session_id": session_id}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("Outbound call failed: %s", e)
+        return jsonify({"error": "Failed to place call"}), 500
+    return jsonify({"status": "calling", "session_id": session_id})
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+    session_id = state.get("session_id", "")
+    session = call_sessions.get(session_id, {})
+
+    if event_type == "call.answered":
+        name = session.get("candidate_name", "")
+        job = session.get("job_name", "the position")
+        greeting = (
+            f"Hi {name}, this is an automated phone screen for {job}. "
+            f"I will ask you {len(SCREEN_QUESTIONS)} questions. Ready? "
+            f"Here is the first one. {SCREEN_QUESTIONS[0]}"
+        )
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": greeting,
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 60,
+                "client_state": encode_state({"session_id": session_id, "q_idx": 0}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        q_idx = state.get("q_idx", 0)
+        if speech and session:
+            session.setdefault("answers", []).append(
+                {"question": SCREEN_QUESTIONS[q_idx], "answer": speech}
+            )
+            next_idx = q_idx + 1
+            if next_idx < len(SCREEN_QUESTIONS):
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": f"Thank you. Next question. {SCREEN_QUESTIONS[next_idx]}",
+                        "voice": "female",
+                        "language": "en-US",
+                        "input_type": "speech",
+                        "timeout_secs": 60,
+                        "client_state": encode_state({"session_id": session_id, "q_idx": next_idx}),
+                    },
+                )
+            else:
+                scorecard = score_screen(session["answers"])
+                session["scorecard"] = scorecard
+                app_id = session.get("application_id")
+                if app_id:
+                    merge_patch(
+                        f"/ats/v1/applications/{app_id}",
+                        {"current_stage": "phone_screen_complete"},
+                    )
+                phone = session.get("phone")
+                if phone and TELNYX_PHONE:
+                    try:
+                        requests.post(
+                            "https://api.telnyx.com/v2/messages",
+                            headers=HEADERS,
+                            timeout=10,
+                            json={
+                                "from": TELNYX_PHONE,
+                                "to": phone,
+                                "text": (
+                                    f"Thanks for completing the phone screen for "
+                                    f"{session.get('job_name', 'the position')}! "
+                                    f"Our team will be in touch within 2 business days."
+                                ),
+                            },
+                        )
+                    except Exception as e:
+                        app.logger.error("Confirmation SMS failed: %s", e)
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "That is all the questions. Thank you for your time. You will hear from us within two business days. Goodbye.",
+                        "voice": "female",
+                        "language": "en-US",
+                    },
+                )
+        else:
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": "I did not catch that. Could you repeat your answer?",
+                    "voice": "female",
+                    "language": "en-US",
+                    "input_type": "speech",
+                    "timeout_secs": 60,
+                    "client_state": encode_state({"session_id": session_id, "q_idx": state.get("q_idx", 0)}),
+                },
+            )
+
+    elif event_type == "call.speak.ended":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        pass  # keep session for scorecard retrieval
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/screens", methods=["GET"])
+def list_screens():
+    """List all completed screens with scores."""
+    results = []
+    for sid, s in call_sessions.items():
+        results.append({
+            "session_id": sid,
+            "candidate": s.get("candidate_name"),
+            "job": s.get("job_name"),
+            "answers": len(s.get("answers", [])),
+            "scorecard": s.get("scorecard"),
+        })
+    return jsonify({"screens": results})
+
+
+@app.route("/screens/<session_id>", methods=["GET"])
+def get_screen(session_id):
+    """Get a specific screen result."""
+    session = call_sessions.get(session_id)
+    if not session:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(session)
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-interview-pipeline", "active_screens": len(call_sessions)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-interview-pipeline-python/requirements.txt
+++ b/merge-interview-pipeline-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-invoice-collector-python/.env.example
+++ b/merge-invoice-collector-python/.env.example
@@ -1,0 +1,18 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=your_telnyx_api_key_here
+# Telnyx public key — used to verify inbound webhook signatures (Portal > Account > Keys)
+TELNYX_PUBLIC_KEY=your_telnyx_public_key_here
+# Telnyx number that places collection calls and sends payment-link SMS
+TELNYX_PHONE_NUMBER=+15550001111
+# Telnyx Voice connection (Call Control) ID
+TELNYX_CONNECTION_ID=your_connection_id_here
+# Telnyx Inference model
+AI_MODEL=moonshotai/Kimi-K2.6
+# Merge.dev unified accounting API credentials
+MERGE_API_KEY=your_merge_api_key_here
+MERGE_ACCOUNT_TOKEN=your_merge_account_token_here
+# Base URL for hosted invoice payment pages
+PAYMENT_URL_BASE=https://pay.example.com/invoice
+# Local server bind host / port
+HOST=127.0.0.1
+PORT=5000

--- a/merge-invoice-collector-python/API.md
+++ b/merge-invoice-collector-python/API.md
@@ -1,0 +1,129 @@
+# API Reference -- Merge Invoice Collector
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/collect` | Collect |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/invoices` | Invoices |
+| `GET` | `/collections` | Collections |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /collect`
+
+Collect.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/collect \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /invoices`
+
+Invoices.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/invoices
+```
+
+---
+
+## `GET /collections`
+
+Collections.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/collections
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-invoice-collector-python/GUIDE.md
+++ b/merge-invoice-collector-python/GUIDE.md
@@ -1,0 +1,217 @@
+# Build a Merge Invoice Collector
+
+Pulls overdue invoices from accounting via Merge sorted by amount. AI calls debtors in priority order, negotiates payment terms conversationally, and sends SMS payment links mid-call.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-invoice-collector-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (307 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+```
+
+**`send_payment_link()`** -- Send Payment Link.
+
+```python
+def send_payment_link(phone, invoice_number, amount):
+    """Send SMS with payment link."""
+    pay_url = f"{PAYMENT_URL_BASE}/{invoice_number}"
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/messages",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "from": TELNYX_PHONE,
+                "to": phone,
+                "text": f"Pay invoice {invoice_number} (${amount:.2f}): {pay_url}",
+```
+
+**`start_collection()`** -- Start Collection.
+
+```python
+def start_collection():
+    """Pull overdue invoices from Merge Accounting and start calling."""
+    result = merge_get("/accounting/v1/invoices", params={"status": "OVERDUE", "page_size": 50})
+    if not result:
+        return jsonify({"error": "Failed to fetch invoices"}), 500
+    invoices = result.get("results", [])
+    sorted_inv = sorted(
+        invoices,
+        key=lambda x: float(x.get("total_amount") or x.get("amount") or 0),
+        reverse=True,
+    )
+    limit = int(request.args.get("limit", 5))
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+```
+
+**`list_invoices()`** -- List Invoices.
+
+```python
+def list_invoices():
+    """List overdue invoices from Merge Accounting."""
+    result = merge_get("/accounting/v1/invoices", params={"status": "OVERDUE", "page_size": 20})
+    return jsonify(result or {"results": []})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/collect` | Collect |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/invoices` | Invoices |
+| `GET` | `/collections` | Collections |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-invoice-collector"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-invoice-collector-python/README.md
+++ b/merge-invoice-collector-python/README.md
@@ -1,0 +1,194 @@
+---
+name: merge-invoice-collector
+title: "Merge Invoice Collector"
+description: "Pulls overdue invoices from accounting via Merge sorted by amount."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference, Messaging]
+integrations: [Merge Accounting]
+channel: [voice, sms]
+---
+
+# Merge Invoice Collector
+
+> Also known as: accounts receivable, invoice collection, payment reminders, AR automation.
+
+Pulls overdue invoices from accounting via Merge sorted by amount. AI calls debtors in priority order, negotiates payment terms conversationally, and sends SMS payment links mid-call.
+
+## Why Telnyx
+
+This collector places outbound calls, runs conversational AI inference, and fires SMS payment links from a single provider — Telnyx, the AI Communications Infrastructure that delivers voice, messaging, and AI inference over one private global network. Keeping Call Control, the inference API, and the messaging API on the same backbone means low-latency AI responses mid-call and a single API key to manage instead of stitching together separate voice, SMS, and LLM vendors.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-invoice-collector-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /collect`
+
+Collect.
+
+```bash
+curl -X POST http://localhost:5000/collect \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /invoices`
+
+Invoices.
+
+```bash
+curl http://localhost:5000/invoices
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-invoice-collector"}
+```
+
+### `GET /collections`
+
+Collections.
+
+```bash
+curl http://localhost:5000/collections
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-invoice-collector"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-invoice-collector"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/collect` | Collect |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/invoices` | Invoices |
+| `GET` | `/collections` | Collections |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` is missing or wrong, so Ed25519 verification fails (the app rejects every webhook when it's unset) | Set `TELNYX_PUBLIC_KEY` from the [Telnyx Portal](https://portal.telnyx.com) public key; ensure no whitespace was added when copying the base64 value |
+| `401 invalid signature` only on replays | Webhook timestamp is older than 5 minutes (`MAX_SKEW_SECONDS`) | Make sure your server clock is in sync (NTP); Telnyx must reach your endpoint promptly |
+| `Failed to fetch invoices` from `POST /collect` | `MERGE_API_KEY` or `MERGE_ACCOUNT_TOKEN` is missing/invalid, or the linked account has no accounting integration | Verify both values in the [Merge dashboard](https://app.merge.dev); confirm the linked account exposes `/accounting/v1/invoices` |
+| Calls never arrive / webhooks not received | Webhook URL not publicly reachable, or `TELNYX_CONNECTION_ID` / `TELNYX_PHONE_NUMBER` unset | Expose the server with `ngrok http 5000` and set the Call Control Application webhook URL; confirm all three Telnyx env vars are populated |
+| Invoices skipped (`skipped_no_phone` high) | Merge contacts lack a phone number | Ensure contacts in the accounting system have phone numbers synced through Merge |
+
+## Related Examples
+
+- [merge-expense-by-phone-python](../merge-expense-by-phone-python/) — voice + Merge accounting workflow over the phone
+- [merge-deal-desk-alerts-python](../merge-deal-desk-alerts-python/) — Merge-driven alerts routed through Telnyx
+- [merge-employee-hotline-python](../merge-employee-hotline-python/) — Merge data backing an AI voice hotline
+- [edge-merge-ai-receptionist-python](../edge-merge-ai-receptionist-python/) — AI receptionist combining Merge data with Telnyx voice
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-invoice-collector-python/app.py
+++ b/merge-invoice-collector-python/app.py
@@ -1,0 +1,342 @@
+"""Merge Invoice Collector — pulls overdue invoices from accounting via Merge.
+AI calls debtors in priority order (largest first). Negotiates payment terms
+conversationally. Sends SMS payment link mid-call. Logs outcomes."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+PAYMENT_URL_BASE = os.getenv("PAYMENT_URL_BASE", "https://pay.example.com/invoice")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+
+# Webhook replay window: reject events older than 5 minutes.
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body: bytes) -> bool:
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>``.
+
+    Mirrors ``client.webhooks.unwrap`` without the SDK: rejects bad signatures
+    and replayed events (timestamp skew > MAX_SKEW_SECONDS)."""
+    if not TELNYX_PUBLIC_KEY:
+        app.logger.error("TELNYX_PUBLIC_KEY not configured; rejecting webhook")
+        return False
+    signature = request.headers.get("telnyx-signature-ed25519", "")
+    timestamp = request.headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+        signed_payload = f"{timestamp}|".encode() + raw_body
+        public_key.verify(base64.b64decode(signature), signed_payload)
+        return True
+    except (InvalidSignature, ValueError, TypeError) as e:
+        app.logger.error("Webhook signature verification failed: %s", e)
+        return False
+
+
+call_sessions = {}
+collection_log = []
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a professional accounts receivable agent. Be firm but "
+                            "polite. Offer payment plan options when asked. Keep responses "
+                            "under 2 sentences. Never threaten — focus on resolution.\n\n"
+                            f"Invoice data: {json.dumps(context)}"
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "I can help resolve this balance. Would you like to discuss payment options?"
+
+
+def send_payment_link(phone, invoice_number, amount):
+    """Send SMS with payment link."""
+    pay_url = f"{PAYMENT_URL_BASE}/{invoice_number}"
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/messages",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "from": TELNYX_PHONE,
+                "to": phone,
+                "text": f"Pay invoice {invoice_number} (${amount:.2f}): {pay_url}",
+            },
+        )
+        return True
+    except Exception as e:
+        app.logger.error("Payment SMS failed: %s", e)
+        return False
+
+
+@app.route("/collect", methods=["POST"])
+def start_collection():
+    """Pull overdue invoices from Merge Accounting and start calling."""
+    result = merge_get("/accounting/v1/invoices", params={"status": "OVERDUE", "page_size": 50})
+    if not result:
+        return jsonify({"error": "Failed to fetch invoices"}), 500
+    invoices = result.get("results", [])
+    sorted_inv = sorted(
+        invoices,
+        key=lambda x: float(x.get("total_amount") or x.get("amount") or 0),
+        reverse=True,
+    )
+    limit = int(request.args.get("limit", 5))
+    called = 0
+    skipped = 0
+    for inv in sorted_inv[:limit]:
+        inv_id = inv.get("id", "")
+        inv_number = inv.get("number", inv_id[:8])
+        amount = float(inv.get("total_amount") or inv.get("amount") or 0)
+        contact = inv.get("contact", {})
+        phone = None
+        if isinstance(contact, dict):
+            for pn in contact.get("phone_numbers", []):
+                if pn.get("number") or pn.get("value"):
+                    phone = pn.get("number") or pn.get("value")
+                    break
+        if not phone:
+            skipped += 1
+            continue
+        session_id = f"collect-{inv_id[:12]}"
+        call_sessions[session_id] = {
+            "invoice_id": inv_id,
+            "invoice_number": inv_number,
+            "amount": amount,
+            "due_date": inv.get("due_date"),
+            "phone": phone,
+            "contact_name": contact.get("name", "Customer") if isinstance(contact, dict) else "Customer",
+            "history": [],
+            "outcome": "pending",
+            "ts": time.time(),
+        }
+        ttl_cleanup(call_sessions)
+        try:
+            requests.post(
+                "https://api.telnyx.com/v2/calls",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "connection_id": CONNECTION_ID,
+                    "to": phone,
+                    "from": TELNYX_PHONE,
+                    "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                    "client_state": encode_state({"session_id": session_id}),
+                },
+            )
+            called += 1
+        except Exception as e:
+            # Don't log the debtor's phone number (PII / clear-text sensitive data).
+            app.logger.error("Collection call for invoice %s failed: %s", inv_number, e)
+    return jsonify({"status": "collecting", "overdue_total": len(invoices), "calling": called, "skipped_no_phone": skipped})
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting it.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+    session_id = state.get("session_id", "")
+    session = call_sessions.get(session_id, {})
+
+    if event_type == "call.answered":
+        name = session.get("contact_name", "")
+        amount = session.get("amount", 0)
+        inv_num = session.get("invoice_number", "")
+        greeting = (
+            f"Hello {name}, this is a courtesy call regarding invoice {inv_num} "
+            f"for ${amount:.2f} which is past due. I would like to help you resolve this today. "
+            f"Would you like to pay now, or discuss a payment plan?"
+        )
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": greeting,
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 30,
+                "client_state": encode_state({"session_id": session_id, "step": "negotiation"}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        if speech and session:
+            session.setdefault("history", []).append({"role": "customer", "text": speech})
+            lower = speech.lower()
+            if "pay now" in lower or "send" in lower or "link" in lower:
+                phone = session.get("phone")
+                inv_num = session.get("invoice_number", "")
+                amount = session.get("amount", 0)
+                sent = send_payment_link(phone, inv_num, amount) if phone else False
+                if sent:
+                    response = "I just sent a payment link to your phone. You can complete the payment there. Is there anything else?"
+                else:
+                    response = "I was unable to send the link. Please visit our website to make a payment. Is there anything else?"
+                session["outcome"] = "payment_link_sent"
+            else:
+                inv_data = {
+                    "invoice": session.get("invoice_number"),
+                    "amount": session.get("amount"),
+                    "due_date": session.get("due_date"),
+                }
+                response = call_inference(speech, inv_data)
+            session["history"].append({"role": "agent", "text": response})
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": response,
+                    "voice": "female",
+                    "language": "en-US",
+                    "input_type": "speech",
+                    "timeout_secs": 30,
+                    "client_state": encode_state({"session_id": session_id, "step": "negotiation"}),
+                },
+            )
+        else:
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": "Thank you for your time. Please reach out if you have questions about your balance. Goodbye.",
+                    "voice": "female",
+                    "language": "en-US",
+                },
+            )
+
+    elif event_type == "call.speak.ended":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        if session and session.get("outcome") == "pending":
+            session["outcome"] = "completed_no_payment"
+        if session:
+            collection_log.append({
+                "session_id": session_id,
+                "invoice": session.get("invoice_number"),
+                "amount": session.get("amount"),
+                "outcome": session.get("outcome"),
+                "turns": len(session.get("history", [])),
+                "ts": time.time(),
+            })
+            if len(collection_log) > MAX_ENTRIES:
+                collection_log[:] = collection_log[-MAX_ENTRIES:]
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/invoices", methods=["GET"])
+def list_invoices():
+    """List overdue invoices from Merge Accounting."""
+    result = merge_get("/accounting/v1/invoices", params={"status": "OVERDUE", "page_size": 20})
+    return jsonify(result or {"results": []})
+
+
+@app.route("/collections", methods=["GET"])
+def list_collections():
+    """List collection call outcomes."""
+    return jsonify({"collections": collection_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-invoice-collector", "active_calls": len(call_sessions)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-invoice-collector-python/requirements.txt
+++ b/merge-invoice-collector-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-pipeline-briefing-python/.env.example
+++ b/merge-pipeline-briefing-python/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification (Ed25519 public key) — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=

--- a/merge-pipeline-briefing-python/API.md
+++ b/merge-pipeline-briefing-python/API.md
@@ -1,0 +1,137 @@
+# API Reference -- Merge Pipeline Briefing
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/briefing` | Briefing |
+| `POST` | `/briefing/preview` | Preview |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/briefings` | Briefings |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /briefing`
+
+Briefing.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/briefing \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /briefing/preview`
+
+Preview.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/briefing/preview \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /briefings`
+
+Briefings.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/briefings
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-pipeline-briefing-python/GUIDE.md
+++ b/merge-pipeline-briefing-python/GUIDE.md
@@ -1,0 +1,223 @@
+# Build a Merge Pipeline Briefing
+
+Morning pipeline briefing. Pulls rep pipeline from CRM via Merge. AI generates spoken briefing covering total deals, value, deals closing this week, and stale opportunities. Calls rep with personalized briefing.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-pipeline-briefing-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (298 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`build_pipeline_summary()`** -- Build Pipeline Summary.
+
+```python
+def build_pipeline_summary(deals):
+    """Analyze deals and build pipeline summary."""
+    today = time.strftime("%Y-%m-%d")
+    week_from_now = time.strftime("%Y-%m-%d", time.localtime(time.time() + 7 * 86400))
+    stale_cutoff = time.strftime("%Y-%m-%d", time.localtime(time.time() - STALE_DAYS * 86400))
+    total_value = sum(float(d.get("amount") or 0) for d in deals)
+    closing_soon = [
+        d for d in deals
+        if d.get("close_date") and today <= d["close_date"][:10] <= week_from_now
+    ]
+    stale = []
+    for d in deals:
+```
+
+**`generate_briefing()`** -- Generate Briefing.
+
+```python
+def generate_briefing(summary):
+    """Use AI to generate spoken pipeline briefing."""
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+```
+
+**`trigger_briefing()`** -- Trigger Briefing.
+
+```python
+def trigger_briefing():
+    """Trigger a pipeline briefing call."""
+    data = request.get_json() or {}
+    phone = data.get("phone")
+    rep_name = data.get("rep_name", "")
+    owner_id = data.get("owner_id")
+    if not phone:
+        return jsonify({"error": "phone required"}), 400
+    # Pull pipeline from CRM
+    params = {"page_size": 100}
+    if owner_id:
+        params["owner_id"] = owner_id
+```
+
+**`preview_briefing()`** -- Preview Briefing.
+
+```python
+def preview_briefing():
+    """Preview briefing without calling — returns text and summary."""
+    data = request.get_json() or {}
+    owner_id = data.get("owner_id")
+    params = {"page_size": 100}
+    if owner_id:
+        params["owner_id"] = owner_id
+    pipeline = merge_get("/crm/v1/opportunities", params=params)
+    deals = (pipeline or {}).get("results", [])
+    summary = build_pipeline_summary(deals)
+    briefing_text = generate_briefing(summary)
+    return jsonify({"summary": summary, "briefing_text": briefing_text})
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/briefing` | Briefing |
+| `POST` | `/briefing/preview` | Preview |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/briefings` | Briefings |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-pipeline-briefing"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-pipeline-briefing-python/README.md
+++ b/merge-pipeline-briefing-python/README.md
@@ -1,0 +1,194 @@
+---
+name: merge-pipeline-briefing
+title: "Merge Pipeline Briefing"
+description: "Morning pipeline briefing."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference]
+integrations: [Merge CRM]
+channel: [voice]
+---
+
+# Merge Pipeline Briefing
+
+> Also known as: sales briefing, pipeline review, morning standup, CRM voice briefing.
+
+Morning pipeline briefing. Pulls rep pipeline from CRM via Merge. AI generates spoken briefing covering total deals, value, deals closing this week, and stale opportunities. Calls rep with personalized briefing.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: voice, messaging, and AI inference run on one private global network, so the outbound call, the spoken briefing, and the AI text generation all happen behind a single API and key. That means lower latency between generating the briefing and speaking it, no third-party AI hop, and predictable carrier-grade call quality for every rep you dial.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-pipeline-briefing-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /briefing`
+
+Briefing.
+
+```bash
+curl -X POST http://localhost:5000/briefing \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `POST /briefing/preview`
+
+Preview.
+
+```bash
+curl -X POST http://localhost:5000/briefing/preview \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /briefings`
+
+Briefings.
+
+```bash
+curl http://localhost:5000/briefings
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-pipeline-briefing"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-pipeline-briefing"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/briefing` | Briefing |
+| `POST` | `/briefing/preview` | Preview |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/briefings` | Briefings |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Likely cause | Fix |
+|-------|--------------|-----|
+| Webhook returns `401 invalid signature` | `TELNYX_PUBLIC_KEY` missing or wrong | Copy the Ed25519 public key from [Portal -> Keys & Credentials](https://portal.telnyx.com/app/account/keys) into `TELNYX_PUBLIC_KEY`; it must be the base64 value Telnyx shows. |
+| Briefing call never starts (`500 briefing call failed`) | Missing/invalid `TELNYX_API_KEY`, `TELNYX_PHONE_NUMBER`, or `TELNYX_CONNECTION_ID` | Confirm all three are set in `.env` and the connection ID matches the Call Control Application whose webhook points at this server. |
+| Telnyx never sends webhook events | Webhook URL not reachable | Run `ngrok http 5000` and set the Call Control Application webhook to `https://<id>.ngrok.io/webhooks/voice`; the URL must be public HTTPS. |
+| Briefing says "No pipeline data available" or empty summary | `MERGE_API_KEY` / `MERGE_ACCOUNT_TOKEN` wrong, or no `owner_id` deals | Verify the Merge keys at [app.merge.dev](https://app.merge.dev) and confirm the linked CRM account has opportunities; test with `POST /briefing/preview` first. |
+
+## Related Examples
+
+- [merge-deal-desk-alerts-python](../merge-deal-desk-alerts-python/) — CRM-driven deal alerts over voice via Merge.
+- [merge-invoice-collector-python](../merge-invoice-collector-python/) — another Merge + voice automation sibling.
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — Call Control + AI inference routing patterns.
+- [record-phone-calls-python](../record-phone-calls-python/) — capturing audio on Call Control calls.
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-pipeline-briefing-python/app.py
+++ b/merge-pipeline-briefing-python/app.py
@@ -1,0 +1,335 @@
+"""Merge Pipeline Briefing — morning pipeline briefing system. Pulls each reps
+pipeline from CRM via Merge. AI generates a spoken briefing covering total deals,
+value, deals closing this week, and stale opportunities. Calls each rep with
+their personalized briefing."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+STALE_DAYS = int(os.getenv("STALE_DAYS", "7"))
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+
+call_sessions = {}
+briefing_log = []
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def build_pipeline_summary(deals):
+    """Analyze deals and build pipeline summary."""
+    today = time.strftime("%Y-%m-%d")
+    week_from_now = time.strftime("%Y-%m-%d", time.localtime(time.time() + 7 * 86400))
+    stale_cutoff = time.strftime("%Y-%m-%d", time.localtime(time.time() - STALE_DAYS * 86400))
+    total_value = sum(float(d.get("amount") or 0) for d in deals)
+    closing_soon = [
+        d for d in deals
+        if d.get("close_date") and today <= d["close_date"][:10] <= week_from_now
+    ]
+    stale = []
+    for d in deals:
+        last_activity = d.get("last_activity_at") or d.get("modified_at") or ""
+        if last_activity and last_activity[:10] < stale_cutoff:
+            stale.append(d)
+    top_deals = sorted(deals, key=lambda x: float(x.get("amount") or 0), reverse=True)[:5]
+    return {
+        "total_deals": len(deals),
+        "total_value": total_value,
+        "closing_this_week": len(closing_soon),
+        "closing_value": sum(float(d.get("amount") or 0) for d in closing_soon),
+        "stale_deals": len(stale),
+        "top_deals": [{"name": d.get("name"), "amount": d.get("amount"), "stage": d.get("stage")} for d in top_deals],
+    }
+
+
+def generate_briefing(summary):
+    """Use AI to generate spoken pipeline briefing."""
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a sales intelligence assistant delivering a morning "
+                            "pipeline briefing by phone. Be concise, data-driven, and "
+                            "actionable. Mention total pipeline value, deals closing this "
+                            "week, stale deals, and top opportunities. Keep it under 45 "
+                            "seconds of speaking time. No markdown or formatting."
+                        ),
+                    },
+                    {"role": "user", "content": f"Pipeline data: {json.dumps(summary)}"},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Briefing generation failed: %s", e)
+    return (
+        f"You have {summary['total_deals']} deals worth "
+        f"${summary['total_value']:,.0f} total. "
+        f"{summary['closing_this_week']} closing this week. "
+        f"{summary['stale_deals']} stale deals need attention."
+    )
+
+
+@app.route("/briefing", methods=["POST"])
+def trigger_briefing():
+    """Trigger a pipeline briefing call."""
+    data = request.get_json() or {}
+    phone = data.get("phone")
+    rep_name = data.get("rep_name", "")
+    owner_id = data.get("owner_id")
+    if not phone:
+        return jsonify({"error": "phone required"}), 400
+    # Pull pipeline from CRM
+    params = {"page_size": 100}
+    if owner_id:
+        params["owner_id"] = owner_id
+    pipeline = merge_get("/crm/v1/opportunities", params=params)
+    deals = (pipeline or {}).get("results", [])
+    summary = build_pipeline_summary(deals)
+    briefing_text = generate_briefing(summary)
+    brief_id = f"brief-{int(time.time())}"
+    call_sessions[brief_id] = {
+        "rep_name": rep_name,
+        "phone": phone,
+        "summary": summary,
+        "briefing_text": briefing_text,
+        "ts": time.time(),
+    }
+    ttl_cleanup(call_sessions)
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": phone,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"brief_id": brief_id}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("Briefing call failed: %s", e)
+        return jsonify({"error": "briefing call failed"}), 500
+    return jsonify({"status": "calling", "brief_id": brief_id, "pipeline": summary})
+
+
+@app.route("/briefing/preview", methods=["POST"])
+def preview_briefing():
+    """Preview briefing without calling — returns text and summary."""
+    data = request.get_json() or {}
+    owner_id = data.get("owner_id")
+    params = {"page_size": 100}
+    if owner_id:
+        params["owner_id"] = owner_id
+    pipeline = merge_get("/crm/v1/opportunities", params=params)
+    deals = (pipeline or {}).get("results", [])
+    summary = build_pipeline_summary(deals)
+    briefing_text = generate_briefing(summary)
+    return jsonify({"summary": summary, "briefing_text": briefing_text})
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+    brief_id = state.get("brief_id", "")
+    session = call_sessions.get(brief_id, {})
+
+    if event_type == "call.answered":
+        rep = session.get("rep_name", "")
+        greeting = f"Good morning{' ' + rep if rep else ''}. Here is your pipeline briefing. "
+        briefing = session.get("briefing_text", "No pipeline data available.")
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": greeting + briefing + " Would you like me to repeat any part?",
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 15,
+                "client_state": encode_state({"brief_id": brief_id, "step": "followup"}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = (ep.get("speech", {}).get("result", "") or "").lower()
+        if "repeat" in speech or "again" in speech:
+            briefing = session.get("briefing_text", "")
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": briefing + " Anything else?",
+                    "voice": "female",
+                    "language": "en-US",
+                    "input_type": "speech",
+                    "timeout_secs": 15,
+                    "client_state": encode_state({"brief_id": brief_id, "step": "followup"}),
+                },
+            )
+        elif "stale" in speech or "attention" in speech:
+            summary = session.get("summary", {})
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": f"You have {summary.get('stale_deals', 0)} deals with no activity in {STALE_DAYS} days. Check your CRM for details. Have a great day.",
+                    "voice": "female",
+                    "language": "en-US",
+                },
+            )
+        else:
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": "Good luck today. Go close some deals.",
+                    "voice": "female",
+                    "language": "en-US",
+                },
+            )
+
+    elif event_type == "call.speak.ended":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        if session:
+            briefing_log.append({
+                "brief_id": brief_id,
+                "rep": session.get("rep_name"),
+                "deals": session.get("summary", {}).get("total_deals"),
+                "value": session.get("summary", {}).get("total_value"),
+                "ts": time.time(),
+            })
+            if len(briefing_log) > MAX_ENTRIES:
+                briefing_log[:] = briefing_log[-MAX_ENTRIES:]
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/briefings", methods=["GET"])
+def list_briefings():
+    """List briefing history."""
+    return jsonify({"briefings": briefing_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-pipeline-briefing", "total_briefings": len(briefing_log)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-pipeline-briefing-python/requirements.txt
+++ b/merge-pipeline-briefing-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-recruitment-hotline-python/.env.example
+++ b/merge-recruitment-hotline-python/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=

--- a/merge-recruitment-hotline-python/API.md
+++ b/merge-recruitment-hotline-python/API.md
@@ -1,0 +1,103 @@
+# API Reference -- Merge Recruitment Hotline
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/jobs` | Jobs |
+| `GET` | `/applications` | Applications |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.initiated` | New inbound or outbound call detected |
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /jobs`
+
+Jobs.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/jobs
+```
+
+---
+
+## `GET /applications`
+
+Applications.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/applications
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-recruitment-hotline-python/GUIDE.md
+++ b/merge-recruitment-hotline-python/GUIDE.md
@@ -1,0 +1,215 @@
+# Build a Merge Recruitment Hotline
+
+Job seekers call. AI asks what role they want, searches open positions in ATS via Merge, describes top matches conversationally, and submits applications on their behalf with SMS confirmation.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** -- send and receive SMS programmatically
+
+## API Endpoints
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-recruitment-hotline-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (365 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`merge_post()`** -- Merge Post.
+
+```python
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+```
+
+**`search_jobs()`** -- Search Jobs.
+
+```python
+def search_jobs(query):
+    """Search open jobs in ATS."""
+    result = merge_get("/ats/v1/jobs", params={"status": "OPEN", "page_size": 20})
+    if not result:
+        return []
+    jobs = result.get("results", [])
+    if not query:
+        return jobs[:5]
+    query_lower = query.lower()
+    scored = []
+    for job in jobs:
+        name = (job.get("name") or "").lower()
+```
+
+**`describe_jobs()`** -- Describe Jobs.
+
+```python
+def describe_jobs(jobs):
+    """Use AI to create spoken description of matching jobs."""
+    job_list = []
+    for i, j in enumerate(jobs, 1):
+        name = j.get("name", "Untitled")
+        dept = ""
+        if isinstance(j.get("departments"), list) and j["departments"]:
+            d = j["departments"][0]
+            dept = d.get("name", "") if isinstance(d, dict) else str(d)
+        loc = ""
+        if isinstance(j.get("offices"), list) and j["offices"]:
+            o = j["offices"][0]
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+```
+
+**`list_jobs()`** -- List Jobs.
+
+```python
+def list_jobs():
+    """List open positions from ATS."""
+    result = merge_get("/ats/v1/jobs", params={"status": "OPEN", "page_size": 20})
+    return jsonify(result or {"results": []})
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/jobs` | Jobs |
+| `GET` | `/applications` | Applications |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-recruitment-hotline"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-recruitment-hotline-python/README.md
+++ b/merge-recruitment-hotline-python/README.md
@@ -1,0 +1,178 @@
+---
+name: merge-recruitment-hotline
+title: "Merge Recruitment Hotline"
+description: "Job seekers call."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference, Messaging]
+integrations: [Merge ATS]
+channel: [voice, sms]
+---
+
+# Merge Recruitment Hotline
+
+> Also known as: recruitment phone line, job application by phone, ATS voice interface.
+
+Job seekers call. AI asks what role they want, searches open positions in ATS via Merge, describes top matches conversationally, and submits applications on their behalf with SMS confirmation.
+
+## Why Telnyx
+
+Telnyx is the AI Communications Infrastructure that runs voice, messaging, and AI inference on one owned, private global network — so the call audio, the TTS, the LLM that describes job matches, and the confirmation SMS all live behind a single API and key. This example uses Telnyx Call Control for the inbound phone leg, the Telnyx AI Inference endpoint for conversational job descriptions, and the Messaging API for the confirmation text, with no third-party telecom or model providers to stitch together. Keeping it on one low-latency backbone means faster spoken responses and one bill, one SLA, and one support team for the whole hotline.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` -- [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Send Message (SMS)**: `POST /v2/messages` -- [API reference](https://developers.telnyx.com/api/messaging/send-message)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-recruitment-hotline-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `GET /jobs`
+
+Jobs.
+
+```bash
+curl http://localhost:5000/jobs
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-recruitment-hotline"}
+```
+
+### `GET /applications`
+
+Applications.
+
+```bash
+curl http://localhost:5000/applications
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-recruitment-hotline"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-recruitment-hotline"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.initiated` -- New inbound or outbound call detected
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/jobs` | Jobs |
+| `GET` | `/applications` | Applications |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Webhook returns `401 invalid signature` | `TELNYX_PUBLIC_KEY` is missing or wrong, so Ed25519 verification fails (and is disabled when unset) | Set `TELNYX_PUBLIC_KEY` to the base64 public key from [Portal -> Keys & Credentials](https://portal.telnyx.com/keys); confirm it matches the Call Control application sending the webhook. |
+| Call connects but no greeting plays | Webhook URL not reachable, or a required env var (`TELNYX_API_KEY` / `TELNYX_CONNECTION_ID`) is unset | Verify the ngrok tunnel is up and the Portal webhook URL points at `https://<id>.ngrok.io/webhooks/voice`; check the API key and connection ID are loaded from `.env`. |
+| "I could not find matching positions" for every search | Merge credentials wrong or no `OPEN` jobs in the linked ATS | Confirm `MERGE_API_KEY` and `MERGE_ACCOUNT_TOKEN`, then `curl http://localhost:5000/jobs` to see what the ATS returns. |
+| Application submits but no confirmation SMS arrives | `TELNYX_PHONE_NUMBER` unset, or the number is not SMS-enabled / not on the connection | Set `TELNYX_PHONE_NUMBER` to a messaging-enabled Telnyx number and check the app logs for `Confirmation SMS failed`. |
+
+## Related Examples
+
+- [merge-interview-pipeline-python](../merge-interview-pipeline-python/) — voice-driven interview pipeline updates against a Merge ATS.
+- [edge-merge-reference-checker-python](../edge-merge-reference-checker-python/) — automated reference checks over Merge for hiring workflows.
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) — route inbound Call Control calls into a Telnyx AI voice agent.
+- [ai-phone-story-hotline-python](../ai-phone-story-hotline-python/) — another inbound voice hotline using gather-using-speak and AI inference.
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-recruitment-hotline-python/app.py
+++ b/merge-recruitment-hotline-python/app.py
@@ -1,0 +1,402 @@
+"""Merge Recruitment Hotline — job seekers call. AI asks what role they want,
+pulls matching open positions from ATS via Merge, describes top matches
+conversationally, and submits applications on the callers behalf."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+
+call_sessions = {}
+application_log = []
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def merge_post(path, data):
+    try:
+        resp = requests.post(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge POST %s failed: %s", path, e)
+    return None
+
+
+def search_jobs(query):
+    """Search open jobs in ATS."""
+    result = merge_get("/ats/v1/jobs", params={"status": "OPEN", "page_size": 20})
+    if not result:
+        return []
+    jobs = result.get("results", [])
+    if not query:
+        return jobs[:5]
+    query_lower = query.lower()
+    scored = []
+    for job in jobs:
+        name = (job.get("name") or "").lower()
+        dept = ""
+        if isinstance(job.get("departments"), list):
+            dept = " ".join(str(d.get("name", "")) for d in job["departments"] if isinstance(d, dict)).lower()
+        score = 0
+        for word in query_lower.split():
+            if word in name:
+                score += 2
+            if word in dept:
+                score += 1
+        if score > 0:
+            scored.append((score, job))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [j for _, j in scored[:5]] if scored else jobs[:3]
+
+
+def describe_jobs(jobs):
+    """Use AI to create spoken description of matching jobs."""
+    job_list = []
+    for i, j in enumerate(jobs, 1):
+        name = j.get("name", "Untitled")
+        dept = ""
+        if isinstance(j.get("departments"), list) and j["departments"]:
+            d = j["departments"][0]
+            dept = d.get("name", "") if isinstance(d, dict) else str(d)
+        loc = ""
+        if isinstance(j.get("offices"), list) and j["offices"]:
+            o = j["offices"][0]
+            loc = o.get("name", "") if isinstance(o, dict) else str(o)
+        job_list.append(f"{i}. {name}" + (f" in {dept}" if dept else "") + (f", {loc}" if loc else ""))
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a recruitment assistant on a phone call. Briefly describe "
+                            "these open positions to the caller. Be conversational. List by "
+                            "number so they can pick one. Keep it under 30 seconds of speaking."
+                        ),
+                    },
+                    {"role": "user", "content": "\n".join(job_list)},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Job description failed: %s", e)
+    return ". ".join(job_list)
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+
+    if event_type == "call.initiated" and ep.get("direction") == "incoming":
+        caller = ep.get("from", "")
+        call_sessions[cc_id] = {"caller": caller, "ts": time.time()}
+        ttl_cleanup(call_sessions)
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/answer",
+            headers=HEADERS,
+            timeout=10,
+            json={"client_state": encode_state({"step": "greeting"})},
+        )
+
+    elif event_type == "call.answered":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": "Welcome to our recruitment hotline. What type of role are you looking for?",
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 30,
+                "client_state": encode_state({"step": "search"}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = ep.get("speech", {}).get("result", "")
+        step = state.get("step", "")
+        session = call_sessions.get(cc_id, {})
+
+        if step == "search" and speech:
+            jobs = search_jobs(speech)
+            if not jobs:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "I could not find matching positions right now. Would you like to try a different search?",
+                        "voice": "female",
+                        "language": "en-US",
+                        "input_type": "speech",
+                        "timeout_secs": 15,
+                        "client_state": encode_state({"step": "search"}),
+                    },
+                )
+            else:
+                session["matching_jobs"] = jobs
+                description = describe_jobs(jobs)
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": f"{description} Which number interests you? Or say none to end.",
+                        "voice": "female",
+                        "language": "en-US",
+                        "input_type": "speech",
+                        "timeout_secs": 20,
+                        "client_state": encode_state({"step": "select"}),
+                    },
+                )
+
+        elif step == "select" and speech:
+            lower = speech.lower()
+            if "none" in lower or "no" in lower:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "No problem. Check our careers page for new openings. Thank you for calling. Goodbye.",
+                        "voice": "female",
+                        "language": "en-US",
+                    },
+                )
+            else:
+                # Try to extract number
+                jobs = session.get("matching_jobs", [])
+                selected_idx = None
+                for i in range(1, len(jobs) + 1):
+                    if str(i) in speech or ["one", "two", "three", "four", "five"][i - 1] in lower:
+                        selected_idx = i - 1
+                        break
+                if selected_idx is not None and selected_idx < len(jobs):
+                    selected_job = jobs[selected_idx]
+                    session["selected_job"] = selected_job
+                    requests.post(
+                        f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                        headers=HEADERS,
+                        timeout=10,
+                        json={
+                            "payload": f"Great choice. I can submit your application for {selected_job.get('name', 'that role')}. Please tell me your full name.",
+                            "voice": "female",
+                            "language": "en-US",
+                            "input_type": "speech",
+                            "timeout_secs": 15,
+                            "client_state": encode_state({"step": "get_name", "job_id": selected_job.get("id")}),
+                        },
+                    )
+                else:
+                    requests.post(
+                        f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+                        headers=HEADERS,
+                        timeout=10,
+                        json={
+                            "payload": "I did not catch which position. Could you say the number?",
+                            "voice": "female",
+                            "language": "en-US",
+                            "input_type": "speech",
+                            "timeout_secs": 15,
+                            "client_state": encode_state({"step": "select"}),
+                        },
+                    )
+
+        elif step == "get_name" and speech:
+            parts = speech.strip().split()
+            first_name = parts[0] if parts else ""
+            last_name = " ".join(parts[1:]) if len(parts) > 1 else ""
+            caller = session.get("caller", "")
+            job_id = state.get("job_id")
+            # Create candidate in ATS
+            candidate = merge_post("/ats/v1/candidates", {
+                "first_name": first_name,
+                "last_name": last_name,
+                "phone_numbers": [{"value": caller, "phone_number_type": "MOBILE"}],
+            })
+            cand_id = None
+            if candidate:
+                cand_id = candidate.get("model", {}).get("id")
+            # Submit application
+            if cand_id and job_id:
+                app_result = merge_post("/ats/v1/applications", {
+                    "candidate": cand_id,
+                    "job": job_id,
+                    "source": "Phone Hotline",
+                })
+                if app_result:
+                    application_log.append({
+                        "candidate": f"{first_name} {last_name}".strip(),
+                        "job_id": job_id,
+                        "phone": caller,
+                        "ts": time.time(),
+                    })
+                    if len(application_log) > MAX_ENTRIES:
+                        application_log[:] = application_log[-MAX_ENTRIES:]
+            # Send confirmation SMS
+            if caller and TELNYX_PHONE:
+                job_name = session.get("selected_job", {}).get("name", "the position")
+                try:
+                    requests.post(
+                        "https://api.telnyx.com/v2/messages",
+                        headers=HEADERS,
+                        timeout=10,
+                        json={
+                            "from": TELNYX_PHONE,
+                            "to": caller,
+                            "text": f"Hi {first_name}, your application for {job_name} has been submitted! Our team will be in touch.",
+                        },
+                    )
+                except Exception as e:
+                    app.logger.error("Confirmation SMS failed: %s", e)
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": f"Done, {first_name}. Your application has been submitted and a confirmation text is on the way. Good luck!",
+                    "voice": "female",
+                    "language": "en-US",
+                },
+            )
+
+    elif event_type == "call.speak.ended":
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        call_sessions.pop(cc_id, None)
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/jobs", methods=["GET"])
+def list_jobs():
+    """List open positions from ATS."""
+    result = merge_get("/ats/v1/jobs", params={"status": "OPEN", "page_size": 20})
+    return jsonify(result or {"results": []})
+
+
+@app.route("/applications", methods=["GET"])
+def list_applications():
+    """List applications submitted via hotline."""
+    return jsonify({"applications": application_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-recruitment-hotline", "total_applications": len(application_log)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-recruitment-hotline-python/requirements.txt
+++ b/merge-recruitment-hotline-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/merge-ticket-escalation-python/.env.example
+++ b/merge-ticket-escalation-python/.env.example
@@ -1,0 +1,4 @@
+# Telnyx API key — https://portal.telnyx.com/api-keys
+TELNYX_API_KEY=
+# Webhook signature verification (Ed25519 public key) — https://portal.telnyx.com/api-keys
+TELNYX_PUBLIC_KEY=

--- a/merge-ticket-escalation-python/API.md
+++ b/merge-ticket-escalation-python/API.md
@@ -1,0 +1,151 @@
+# API Reference -- Merge Ticket Escalation
+
+Base URL: `http://localhost:5000`
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ticket` | Ticket |
+| `POST` | `/escalate` | Escalate |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/tickets` | Tickets |
+| `GET` | `/escalations` | Escalations |
+| `GET` | `/health` | Health |
+
+---
+
+## `POST /webhooks/ticket`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `POST /escalate`
+
+Escalate.
+
+### Request
+
+```json
+{"example": "value"}
+```
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/escalate \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+---
+
+## `POST /webhooks/voice`
+
+Telnyx webhook handler.
+
+### Events Handled
+
+| Event | Description |
+|-------|-------------|
+| `call.answered` | Call connected, app begins interaction with greeting |
+| `call.gather.ended` | Caller input received (speech or DTMF), app processes response |
+| `call.speak.ended` | TTS playback finished, transitions to next action |
+| `call.hangup` | Call ended, cleans up session state and logs outcome |
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## `GET /tickets`
+
+Tickets.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/tickets
+```
+
+---
+
+## `GET /escalations`
+
+Escalations.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/escalations
+```
+
+---
+
+## `GET /health`
+
+Health.
+
+### Response `200`
+
+```json
+{"status": "ok"}
+```
+
+### Try it
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Error Handling
+
+```json
+{"error": "Description of what went wrong"}
+```
+
+| Status | Meaning |
+|--------|--------|
+| `200` | Success |
+| `400` | Bad request |
+| `404` | Not found |
+| `500` | Server error |

--- a/merge-ticket-escalation-python/GUIDE.md
+++ b/merge-ticket-escalation-python/GUIDE.md
@@ -1,0 +1,223 @@
+# Build a Merge Ticket Escalation
+
+Critical ticket fires a webhook from Merge Ticketing. Calls the on-call engineer with AI-generated context briefing. Engineer says connect me to bridge directly with the customer. Updates ticket status.
+
+## Telnyx Products Used
+
+- **Voice** -- programmatic call control with webhooks for every call state change
+- **AI Inference** -- LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+
+## API Endpoints
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Webhook Events
+
+Telnyx uses webhooks for call control. You do not poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
+- [Call Control Application](https://portal.telnyx.com/call-control/applications)
+- [Merge.dev account](https://app.merge.dev) with linked integration
+- [ngrok](https://ngrok.com) for local webhook testing
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-ticket-escalation-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (325 lines). Here is what each piece does.
+
+
+**`merge_get()`** -- Merge Get.
+
+```python
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+```
+
+**`merge_patch()`** -- Merge Patch.
+
+```python
+def merge_patch(path, data):
+    try:
+        resp = requests.patch(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge PATCH %s failed: %s", path, e)
+    return None
+```
+
+**`call_inference()`** -- Call Inference.
+
+```python
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+```
+
+**`handle_ticket_webhook()`** -- Handle Ticket Webhook.
+
+```python
+def handle_ticket_webhook():
+    """Merge Ticketing webhook — critical ticket triggers on-call phone alert."""
+    data = request.get_json() or {}
+    ticket_id = data.get("id", "")
+    ticket = merge_get(f"/ticketing/v1/tickets/{ticket_id}") if ticket_id else data
+    if not ticket:
+        return jsonify({"error": "Ticket not found"}), 404
+    priority = (ticket.get("priority") or "").upper()
+    if priority not in CRITICAL_PRIORITIES:
+        return jsonify({"status": "skipped", "reason": f"Priority {priority} below threshold"})
+    if not ONCALL_NUMBER:
+        return jsonify({"error": "ONCALL_NUMBER not configured"}), 500
+```
+
+**`manual_escalate()`** -- Manual Escalate.
+
+```python
+def manual_escalate():
+    """Manually trigger an escalation for testing."""
+    data = request.get_json() or {}
+    subject = data.get("subject", "Test Critical Ticket")
+    description = data.get("description", "Production database connection failures.")
+    if not ONCALL_NUMBER:
+        return jsonify({"error": "ONCALL_NUMBER not configured"}), 500
+    esc_id = f"esc-{int(time.time())}"
+    ticket_context = {"subject": subject, "priority": "CRITICAL", "description": description}
+    call_sessions[esc_id] = {"ticket": ticket_context, "outcome": "pending", "ts": time.time()}
+    ttl_cleanup(call_sessions)
+    try:
+```
+
+**`handle_voice()`** -- Handle Voice.
+
+```python
+def handle_voice():
+    payload = request.get_json()
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+```
+
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ticket` | Ticket |
+| `POST` | `/escalate` | Escalate |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/tickets` | Tickets |
+| `GET` | `/escalations` | Escalations |
+| `GET` | `/health` | Health |
+
+## Step 3: Run It
+
+```bash
+python app.py
+```
+
+Server starts on `http://localhost:5000`. Expose for webhooks:
+
+```bash
+ngrok http 5000
+```
+
+## Step 4: Test It
+
+```bash
+curl http://localhost:5000/health
+```
+
+```json
+{"status": "ok", "service": "merge-ticket-escalation"}
+```
+
+## Going to Production
+
+- Replace in-memory state with Redis or a database
+- Add authentication to API endpoints
+- Set up monitoring and alerting
+- Use a process manager: `gunicorn -w 4 app:app`
+- Configure failover webhook URLs in Telnyx Portal
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Production Checklist
+
+### Authentication and Security
+- [ ] API key in environment variable, never in code
+- [ ] HTTPS for all webhook endpoints
+- [ ] Input validation on all endpoints
+- [ ] Webhook signature verification
+
+### Webhook Reliability
+- [ ] Return 200 within 5 seconds
+- [ ] Idempotent webhook handling
+- [ ] Failover URL configured
+
+### Error Handling
+- [ ] Timeout on all outbound requests
+- [ ] Retry with backoff for transient failures
+- [ ] Graceful degradation when AI unavailable
+
+### Observability
+- [ ] Structured logging with call IDs
+- [ ] Health check endpoint
+- [ ] Latency tracking

--- a/merge-ticket-escalation-python/README.md
+++ b/merge-ticket-escalation-python/README.md
@@ -1,0 +1,196 @@
+---
+name: merge-ticket-escalation
+title: "Merge Ticket Escalation"
+description: "Critical ticket fires a webhook from Merge Ticketing."
+language: python
+framework: flask
+telnyx_products: [Voice, AI Inference]
+integrations: [Merge Ticketing]
+channel: [voice]
+---
+
+# Merge Ticket Escalation
+
+> Also known as: ticket escalation, on-call alerts, incident response, support escalation.
+
+Critical ticket fires a webhook from Merge Ticketing. Calls the on-call engineer with AI-generated context briefing. Engineer says connect me to bridge directly with the customer. Updates ticket status.
+
+## Why Telnyx
+
+Telnyx is AI Communications Infrastructure: programmable voice, AI inference, and messaging run on one private global network, so a critical ticket can trigger an outbound call and an AI-generated incident briefing without stitching together separate vendors. This example uses Call Control to place the on-call alert and bridge the customer, plus Telnyx AI Inference to summarize the ticket in real time -- all behind a single API key and one billing relationship. Owning the network end to end keeps escalation latency low and call quality consistent when an incident can't wait.
+
+## Telnyx API Endpoints Used
+
+- **Call Control: Gather Using Speak**: `POST /v2/calls/{id}/actions/gather_using_speak` -- [API reference](https://developers.telnyx.com/api/call-control/gather-using-speak)
+- **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` -- [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **Call Control: Transfer**: `POST /v2/calls/{id}/actions/transfer` -- [API reference](https://developers.telnyx.com/api/call-control/transfer-call)
+- **Call Control: Hangup**: `POST /v2/calls/{id}/actions/hangup` -- [API reference](https://developers.telnyx.com/api/call-control/hangup)
+- **AI Inference**: `POST /v2/ai/chat/completions` -- [API reference](https://developers.telnyx.com/api/inference/chat-completions)
+- **Create Outbound Call**: `POST /v2/calls` -- [API reference](https://developers.telnyx.com/api/call-control/create-call)
+
+## Telnyx Webhook Events
+
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PHONE_NUMBER` | `string` | `+18005551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers/my-numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `149440475714` | **yes** | Call Control app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
+| `MERGE_API_KEY` | `string` | `your-key` | **yes** | Merge.dev API key | [Merge](https://app.merge.dev/keys) |
+| `MERGE_ACCOUNT_TOKEN` | `string` | `your-token` | **yes** | Merge linked account token | [Merge](https://app.merge.dev) |
+| `ONCALL_NUMBER` | `string` | `+12125551234` | **yes** | On-call engineer phone | -- |
+| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `PORT` | `integer` | `5000` | no | Server port | -- |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/merge-ticket-escalation-python
+cp .env.example .env
+pip install -r requirements.txt
+python app.py
+```
+
+### Webhook Configuration
+
+1. Expose your local server: `ngrok http 5000`
+2. Configure in [Telnyx Portal](https://portal.telnyx.com/call-control/applications):
+   - Call Control Application -> Webhook URL -> `https://<id>.ngrok.io/webhooks/voice`
+
+## API Reference
+
+### `POST /escalate`
+
+Escalate.
+
+```bash
+curl -X POST http://localhost:5000/escalate \
+  -H "Content-Type: application/json" \
+  -d '{"example": "value"}'
+```
+
+**Response:**
+
+```json
+{"status": "ok"}
+```
+
+### `GET /tickets`
+
+Tickets.
+
+```bash
+curl http://localhost:5000/tickets
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-ticket-escalation"}
+```
+
+### `GET /escalations`
+
+Escalations.
+
+```bash
+curl http://localhost:5000/escalations
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-ticket-escalation"}
+```
+
+### `GET /health`
+
+Health.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{"status": "ok", "service": "merge-ticket-escalation"}
+```
+
+
+## Webhook Endpoints
+
+### `POST /webhooks/voice`
+
+Telnyx sends call events here. Your app processes them and responds with the next action.
+
+**Events handled:**
+
+- `call.answered` -- Call connected, app begins interaction with greeting
+- `call.gather.ended` -- Caller input received (speech or DTMF), app processes response
+- `call.speak.ended` -- TTS playback finished, transitions to next action
+- `call.hangup` -- Call ended, cleans up session state and logs outcome
+
+**Example payload:**
+
+```json
+{
+  "data": {
+    "event_type": "call.initiated",
+    "id": "evt_123",
+    "payload": {
+      "call_control_id": "v3:abc123",
+      "direction": "incoming",
+      "from": "+12125551234",
+      "to": "+18005559876"
+    }
+  }
+}
+```
+
+## All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhooks/ticket` | Ticket |
+| `POST` | `/escalate` | Escalate |
+| `POST` | `/webhooks/voice` | Voice |
+| `GET` | `/tickets` | Tickets |
+| `GET` | `/escalations` | Escalations |
+| `GET` | `/health` | Health |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `401 invalid signature` on `/webhooks/voice` | `TELNYX_PUBLIC_KEY` missing or wrong | Set `TELNYX_PUBLIC_KEY` to the base64 Ed25519 key from [Portal > Account > Keys & Credentials](https://portal.telnyx.com); the value must match the Call Control app sending the events. |
+| `500 ONCALL_NUMBER not configured` | `ONCALL_NUMBER` env var is empty | Set `ONCALL_NUMBER` in `.env` to the on-call engineer's number in E.164 format (e.g. `+12125551234`). |
+| On-call alert never rings / no webhooks arrive | Webhook URL not reachable or not configured | Confirm `ngrok http 5000` is running and the public URL is set as the Call Control app's Webhook URL ending in `/webhooks/voice`. |
+| Ticket webhook returns `skipped` | Ticket priority below threshold | Only `CRITICAL`, `URGENT`, or `HIGH` priority tickets escalate; lower priorities are intentionally ignored. |
+| Briefing falls back to generic message | AI Inference call failed | Verify `TELNYX_API_KEY` is valid and `AI_MODEL` is a supported [model](https://developers.telnyx.com/docs/inference/models); check logs for the inference error. |
+
+## Related Examples
+
+- [call-sentiment-live-escalation-python](../call-sentiment-live-escalation-python/) -- escalate a live call based on detected sentiment
+- [route-phone-calls-to-ai-agent-python](../route-phone-calls-to-ai-agent-python/) -- route inbound calls to an AI voice agent with Call Control
+- [iot-fleet-alert-escalation-python](../iot-fleet-alert-escalation-python/) -- on-call phone escalation triggered by fleet alerts
+- [merge-employee-hotline-python](../merge-employee-hotline-python/) -- another Merge-integrated voice workflow
+
+## Resources
+
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Call Control quickstart](https://developers.telnyx.com/docs/voice/call-control)
+- [AI Inference docs](https://developers.telnyx.com/docs/inference)
+- [Merge.dev API docs](https://docs.merge.dev)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/merge-ticket-escalation-python/app.py
+++ b/merge-ticket-escalation-python/app.py
@@ -1,0 +1,363 @@
+"""Merge Ticket Escalation — critical ticket fires a webhook from Merge Ticketing.
+App calls the on-call engineer with AI-generated context briefing (whisper).
+Engineer says "connect me" to bridge with the customer who filed the ticket.
+Logs escalation outcomes."""
+import os, json, time, base64, logging
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import requests
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+load_dotenv()
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
+TELNYX_PHONE = os.getenv("TELNYX_PHONE_NUMBER")
+CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID", "")
+INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
+AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+MERGE_API_KEY = os.getenv("MERGE_API_KEY")
+MERGE_ACCOUNT_TOKEN = os.getenv("MERGE_ACCOUNT_TOKEN")
+ONCALL_NUMBER = os.getenv("ONCALL_NUMBER")
+HOST = os.getenv("HOST", "127.0.0.1")
+HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
+MERGE_HEADERS = {
+    "Authorization": f"Bearer {MERGE_API_KEY}",
+    "X-Account-Token": MERGE_ACCOUNT_TOKEN or "",
+    "Content-Type": "application/json",
+}
+MERGE_BASE = "https://api.merge.dev/api"
+CRITICAL_PRIORITIES = {"CRITICAL", "URGENT", "HIGH"}
+
+call_sessions = {}
+escalation_log = []
+MAX_ENTRIES = 10000
+
+
+def ttl_cleanup(store, max_size=MAX_ENTRIES):
+    if len(store) > max_size:
+        oldest = sorted(store, key=lambda k: store[k].get("ts", 0))
+        for k in oldest[: len(store) - max_size]:
+            del store[k]
+
+
+def encode_state(data):
+    return base64.b64encode(json.dumps(data).encode()).decode()
+
+
+def decode_state(b64):
+    try:
+        return json.loads(base64.b64decode(b64).decode())
+    except Exception:
+        return {}
+
+
+# Telnyx public key (Portal > Keys & Credentials) is a base64-encoded 32-byte Ed25519 key.
+_TELNYX_VERIFY_KEY = None
+if TELNYX_PUBLIC_KEY:
+    try:
+        _TELNYX_VERIFY_KEY = Ed25519PublicKey.from_public_bytes(base64.b64decode(TELNYX_PUBLIC_KEY))
+    except Exception as e:
+        app.logger.error("Invalid TELNYX_PUBLIC_KEY, webhook verification disabled: %s", e)
+
+MAX_SKEW_SECONDS = 300
+
+
+def verify_telnyx_signature(raw_body, headers):
+    """Verify the Telnyx Ed25519 signature over ``<timestamp>|<raw body>`` before
+    trusting the webhook. Headers are telnyx-signature-ed25519 (base64) and
+    telnyx-timestamp. Rejects signatures older than MAX_SKEW_SECONDS (replay)."""
+    if _TELNYX_VERIFY_KEY is None:
+        return False
+    signature = headers.get("telnyx-signature-ed25519", "")
+    timestamp = headers.get("telnyx-timestamp", "")
+    if not signature or not timestamp:
+        return False
+    try:
+        if abs(time.time() - int(timestamp)) > MAX_SKEW_SECONDS:
+            return False
+        signed = f"{timestamp}|".encode() + raw_body
+        _TELNYX_VERIFY_KEY.verify(base64.b64decode(signature), signed)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+def merge_get(path, params=None):
+    try:
+        resp = requests.get(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, params=params
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge GET %s failed: %s", path, e)
+    return None
+
+
+def merge_patch(path, data):
+    try:
+        resp = requests.patch(
+            f"{MERGE_BASE}{path}", headers=MERGE_HEADERS, timeout=10, json={"model": data}
+        )
+        if resp.ok:
+            return resp.json()
+    except Exception as e:
+        app.logger.error("Merge PATCH %s failed: %s", path, e)
+    return None
+
+
+def call_inference(prompt, context):
+    try:
+        resp = requests.post(
+            INFERENCE_URL,
+            headers=HEADERS,
+            timeout=15,
+            json={
+                "model": AI_MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are an incident response assistant briefing an on-call "
+                            "engineer. Be concise: what is broken, who reported it, severity, "
+                            "and recommended first action. 2-3 sentences max.\n\n"
+                            f"Ticket data: {json.dumps(context)}"
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+        )
+        if resp.ok:
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        app.logger.error("Inference failed: %s", e)
+    return "A critical ticket needs your attention. Please check the ticket queue."
+
+
+@app.route("/webhooks/ticket", methods=["POST"])
+def handle_ticket_webhook():
+    """Merge Ticketing webhook — critical ticket triggers on-call phone alert."""
+    data = request.get_json() or {}
+    ticket_id = data.get("id", "")
+    ticket = merge_get(f"/ticketing/v1/tickets/{ticket_id}") if ticket_id else data
+    if not ticket:
+        return jsonify({"error": "Ticket not found"}), 404
+    priority = (ticket.get("priority") or "").upper()
+    if priority not in CRITICAL_PRIORITIES:
+        return jsonify({"status": "skipped", "reason": f"Priority {priority} below threshold"})
+    if not ONCALL_NUMBER:
+        return jsonify({"error": "ONCALL_NUMBER not configured"}), 500
+    ticket_context = {
+        "subject": ticket.get("name", ticket.get("subject", "Unknown")),
+        "priority": priority,
+        "description": (ticket.get("description") or "")[:300],
+        "creator": ticket.get("creator", {}).get("name", "Unknown") if isinstance(ticket.get("creator"), dict) else str(ticket.get("creator", "Unknown")),
+        "ticket_id": ticket_id,
+        "created_at": ticket.get("created_at", ""),
+    }
+    reporter_phone = None
+    creator = ticket.get("creator") or ticket.get("contact")
+    if isinstance(creator, dict):
+        for pn in creator.get("phone_numbers", []):
+            if pn.get("value") or pn.get("number"):
+                reporter_phone = pn.get("value") or pn.get("number")
+                break
+    esc_id = f"esc-{int(time.time())}"
+    call_sessions[esc_id] = {
+        "ticket": ticket_context,
+        "reporter_phone": reporter_phone,
+        "outcome": "pending",
+        "ts": time.time(),
+    }
+    ttl_cleanup(call_sessions)
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": ONCALL_NUMBER,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"esc_id": esc_id}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("On-call phone alert failed: %s", e)
+        return jsonify({"error": "Failed to place on-call alert"}), 500
+    return jsonify({"status": "escalating", "esc_id": esc_id, "ticket": ticket_context["subject"]})
+
+
+@app.route("/escalate", methods=["POST"])
+def manual_escalate():
+    """Manually trigger an escalation for testing."""
+    data = request.get_json() or {}
+    subject = data.get("subject", "Test Critical Ticket")
+    description = data.get("description", "Production database connection failures.")
+    if not ONCALL_NUMBER:
+        return jsonify({"error": "ONCALL_NUMBER not configured"}), 500
+    esc_id = f"esc-{int(time.time())}"
+    ticket_context = {"subject": subject, "priority": "CRITICAL", "description": description}
+    call_sessions[esc_id] = {"ticket": ticket_context, "outcome": "pending", "ts": time.time()}
+    ttl_cleanup(call_sessions)
+    try:
+        requests.post(
+            "https://api.telnyx.com/v2/calls",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "connection_id": CONNECTION_ID,
+                "to": ONCALL_NUMBER,
+                "from": TELNYX_PHONE,
+                "webhook_url": request.url_root.rstrip("/") + "/webhooks/voice",
+                "client_state": encode_state({"esc_id": esc_id}),
+            },
+        )
+    except Exception as e:
+        app.logger.error("Manual escalation call failed: %s", e)
+        return jsonify({"error": "Failed to place escalation call"}), 500
+    return jsonify({"status": "calling", "esc_id": esc_id})
+
+
+@app.route("/webhooks/voice", methods=["POST"])
+def handle_voice():
+    # Verify the Telnyx Ed25519 signature against the RAW body before trusting anything.
+    raw_body = request.get_data()
+    if not verify_telnyx_signature(raw_body, request.headers):
+        return jsonify({"error": "invalid signature"}), 401
+    payload = request.get_json(silent=True)
+    if not payload:
+        return jsonify({"error": "No payload"}), 400
+    event = payload.get("data", {})
+    event_type = event.get("event_type", "")
+    ep = event.get("payload", {})
+    cc_id = ep.get("call_control_id")
+    if not cc_id:
+        return jsonify({"error": "Missing call_control_id"}), 400
+
+    state = decode_state(ep.get("client_state", ""))
+    esc_id = state.get("esc_id", "")
+    session = call_sessions.get(esc_id, {})
+    ticket = session.get("ticket", {})
+
+    if event_type == "call.answered":
+        briefing = call_inference("Brief me on this incident.", ticket)
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/gather_using_speak",
+            headers=HEADERS,
+            timeout=10,
+            json={
+                "payload": (
+                    f"Critical ticket alert. {briefing} "
+                    f"Say connect me to bridge with the reporter, or acknowledge to dismiss."
+                ),
+                "voice": "female",
+                "language": "en-US",
+                "input_type": "speech",
+                "timeout_secs": 15,
+                "client_state": encode_state({"esc_id": esc_id, "step": "awaiting"}),
+            },
+        )
+
+    elif event_type == "call.gather.ended":
+        speech = (ep.get("speech", {}).get("result", "") or "").lower()
+        if "connect" in speech or "bridge" in speech:
+            reporter_phone = session.get("reporter_phone")
+            if reporter_phone:
+                session["outcome"] = "connected"
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "Connecting you to the reporter now.",
+                        "voice": "female",
+                        "language": "en-US",
+                        "client_state": encode_state({"esc_id": esc_id, "step": "transferring", "target": reporter_phone}),
+                    },
+                )
+            else:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={
+                        "payload": "No phone number on file for the reporter. Check the ticket for contact details. Goodbye.",
+                        "voice": "female",
+                        "language": "en-US",
+                    },
+                )
+        else:
+            session["outcome"] = "acknowledged"
+            ticket_id = ticket.get("ticket_id")
+            if ticket_id:
+                merge_patch(f"/ticketing/v1/tickets/{ticket_id}", {"status": "IN_PROGRESS"})
+            requests.post(
+                f"https://api.telnyx.com/v2/calls/{cc_id}/actions/speak",
+                headers=HEADERS,
+                timeout=10,
+                json={
+                    "payload": "Acknowledged. Ticket marked in progress. Good luck.",
+                    "voice": "female",
+                    "language": "en-US",
+                },
+            )
+
+    elif event_type == "call.speak.ended":
+        if state.get("step") == "transferring":
+            target = state.get("target")
+            if target:
+                requests.post(
+                    f"https://api.telnyx.com/v2/calls/{cc_id}/actions/transfer",
+                    headers=HEADERS,
+                    timeout=10,
+                    json={"to": target},
+                )
+                return jsonify({"status": "ok"})
+        requests.post(
+            f"https://api.telnyx.com/v2/calls/{cc_id}/actions/hangup",
+            headers=HEADERS,
+            timeout=10,
+        )
+
+    elif event_type == "call.hangup":
+        if session:
+            escalation_log.append({
+                "esc_id": esc_id,
+                "ticket": ticket.get("subject"),
+                "priority": ticket.get("priority"),
+                "outcome": session.get("outcome", "no_answer"),
+                "ts": time.time(),
+            })
+            if len(escalation_log) > MAX_ENTRIES:
+                escalation_log[:] = escalation_log[-MAX_ENTRIES:]
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/tickets", methods=["GET"])
+def list_tickets():
+    """List critical tickets from Merge Ticketing."""
+    result = merge_get("/ticketing/v1/tickets", params={"priority": "URGENT", "page_size": 20})
+    return jsonify(result or {"results": []})
+
+
+@app.route("/escalations", methods=["GET"])
+def list_escalations():
+    """List escalation history."""
+    return jsonify({"escalations": escalation_log[-50:]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "service": "merge-ticket-escalation", "pending": len(call_sessions)})
+
+
+if __name__ == "__main__":
+    app.run(host=HOST, port=int(os.getenv("PORT", "5000")), debug=False)

--- a/merge-ticket-escalation-python/requirements.txt
+++ b/merge-ticket-escalation-python/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0
+python-dotenv>=1.0
+requests>=2.31
+cryptography>=42.0

--- a/scripts/examples_mapping.yaml
+++ b/scripts/examples_mapping.yaml
@@ -1659,3 +1659,98 @@ examples:
     framework: flask
     folder: wireguard-private-voice-network-python
 
+  - product: voice
+    use_case: edge-compliance-monitor
+    language: python
+    framework: flask
+    folder: edge-compliance-monitor-python
+  - product: voice
+    use_case: edge-fraud-firewall
+    language: python
+    framework: flask
+    folder: edge-fraud-firewall-python
+  - product: voice
+    use_case: edge-geo-smart-router
+    language: python
+    framework: flask
+    folder: edge-geo-smart-router-python
+  - product: voice
+    use_case: edge-ivr-ab-tester
+    language: python
+    framework: flask
+    folder: edge-ivr-ab-tester-python
+  - product: voice
+    use_case: edge-merge-ai-receptionist
+    language: python
+    framework: flask
+    folder: edge-merge-ai-receptionist-python
+  - product: voice
+    use_case: edge-merge-reference-checker
+    language: python
+    framework: flask
+    folder: edge-merge-reference-checker-python
+  - product: voice
+    use_case: edge-merge-shift-coverage
+    language: python
+    framework: flask
+    folder: edge-merge-shift-coverage-python
+  - product: voice
+    use_case: edge-number-masking
+    language: python
+    framework: flask
+    folder: edge-number-masking-python
+  - product: voice
+    use_case: edge-voicemail-to-action
+    language: python
+    framework: flask
+    folder: edge-voicemail-to-action-python
+  - product: voice
+    use_case: edge-webhook-aggregator
+    language: python
+    framework: flask
+    folder: edge-webhook-aggregator-python
+  - product: voice
+    use_case: merge-deal-desk-alerts
+    language: python
+    framework: flask
+    folder: merge-deal-desk-alerts-python
+  - product: voice
+    use_case: merge-employee-hotline
+    language: python
+    framework: flask
+    folder: merge-employee-hotline-python
+  - product: sms
+    use_case: merge-employee-onboarding
+    language: python
+    framework: flask
+    folder: merge-employee-onboarding-python
+  - product: voice
+    use_case: merge-expense-by-phone
+    language: python
+    framework: flask
+    folder: merge-expense-by-phone-python
+  - product: voice
+    use_case: merge-interview-pipeline
+    language: python
+    framework: flask
+    folder: merge-interview-pipeline-python
+  - product: voice
+    use_case: merge-invoice-collector
+    language: python
+    framework: flask
+    folder: merge-invoice-collector-python
+  - product: voice
+    use_case: merge-pipeline-briefing
+    language: python
+    framework: flask
+    folder: merge-pipeline-briefing-python
+  - product: voice
+    use_case: merge-recruitment-hotline
+    language: python
+    framework: flask
+    folder: merge-recruitment-hotline-python
+  - product: voice
+    use_case: merge-ticket-escalation
+    language: python
+    framework: flask
+    folder: merge-ticket-escalation-python


### PR DESCRIPTION
Supersedes the **new contribution** in #10. #10 conflicts with `main` and mostly duplicates examples already merged there — its 207 "shared" folders are *older, divergent copies* that would regress prior fixes (e.g. it re-introduces SSRF/leakage in `compliance-call-recorder`, `cloud-storage-*` that main already fixed). Its genuinely new work is **19 `edge-*`/`merge-*` Python examples**; this PR adds those on top of current `main`, hardened — **main's existing 207 stand unchanged.**

## Hardening applied to the 19
- **Webhook signature verification** added wherever the app receives Telnyx webhooks (native Ed25519 over `"<timestamp>|<raw body>"`, or `client.webhooks.unwrap`), reading event fields from `data.payload`. Also fixed a **header-casing bug** (`dict(request.headers)` Title-cases keys → would reject every real webhook with 401).
- **SSRF fixed** — `edge-geo-smart-router`, `edge-number-masking` and others fetched URLs derived from webhook input with the API key attached; now validated against Telnyx hosts (the `is_telnyx_url` guard pattern).
- **Error leakage removed** (no `str(e)`/stack traces in responses; logged server-side).
- **No clear-text secret logging.**
- Registered all 19 in `examples_mapping.yaml` + root README.

## Verification
- `python scripts/verify.py` → **267/267, 0 errors**
- All 19 `py_compile` clean; deps already pinned; structure already standard
- Each example independently adversarially verified; resolves the CodeQL criticals located in these new folders

## Note
The other CodeQL criticals from #10's check (in `compliance-call-recorder`, `cloud-storage-*`, etc.) are in **main's** shared folders, plus there are ~19 pre-existing code-scanning alerts on `main` — a separate backlog, not part of this new-examples PR.