### PR TITLE
chore: PR-review toolkit + CI gates (auto-screen contributor PRs)

### DIFF
--- a/.github/workflows/pr-review-gates.yml
+++ b/.github/workflows/pr-review-gates.yml
@@ -1,0 +1,38 @@
+name: PR Review Gates
+
+# Automated contributor gate. verify.py runs over the whole repo; the review
+# gates run DIFF-AWARE (only example folders the PR changes) so they catch new
+# violations without failing on main's pre-existing backlog.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so diff-aware gates can diff against the base
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install pyyaml
+
+      - name: verify.py (full repo)
+        run: python scripts/verify.py
+
+      - name: Dependency pinning (changed example folders)
+        run: python scripts/review/check_pinning.py --changed-against "${{ github.event.pull_request.base.sha }}"
+
+      - name: Required files & no forbidden scaffolding (changed example folders)
+        run: python scripts/review/check_required_files.py --changed-against "${{ github.event.pull_request.base.sha }}"
+
+      - name: No legacy SDK references (changed example folders)
+        run: python scripts/review/check_legacy_sdk.py --changed-against "${{ github.event.pull_request.base.sha }}"

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -1,0 +1,33 @@
+# PR-review toolkit
+
+Composable gates that codify the manual review patterns behind the recent
+correctness PRs, so contributor PRs get auto-screened before a human reads them.
+Each script exits non-zero on findings and takes `--path` (any checkout/PR
+worktree) plus `--changed-against <ref>` for **diff-aware** mode.
+
+| Script | Gates |
+|--------|-------|
+| `check_pinning.py` | unpinned / `latest` dependencies across npm · pip · Go · Ruby · PHP · .NET · Maven |
+| `check_required_files.py` | per-example required files (README/API.md/GUIDE.md/.env.example + code + dep) and no forbidden `Dockerfile`/`Makefile` |
+| `check_legacy_sdk.py` | references to dead/old Telnyx SDK APIs in code **and docs** (e.g. `messages.create`, `Telnyx.APIStatusError`, `ai_assistants`, the wrong Go module) |
+| `review_pr.sh` | runs all gates + `verify.py` against a base ref |
+
+## Diff-aware gating
+
+`main` carries pre-existing backlog (unpinned deps, some folders missing docs).
+A hard repo-wide gate would block every PR on that debt, so CI runs the gates in
+**diff-aware** mode — they only check the example folders a PR actually changes.
+`verify.py` (which already passes on `main`) runs full as the authoritative gate.
+
+```bash
+# everything, the way CI runs it:
+scripts/review/review_pr.sh origin/main
+
+# a single gate, diff-aware:
+python scripts/review/check_pinning.py --changed-against origin/main
+
+# a single gate, whole repo (shows the full backlog):
+python scripts/review/check_pinning.py
+```
+
+CI wiring: `.github/workflows/pr-review-gates.yml`.

--- a/scripts/review/_changed.py
+++ b/scripts/review/_changed.py
@@ -6,7 +6,10 @@ failing every PR on pre-existing debt.
 """
 from __future__ import annotations
 
-import subprocess
+# nosemgrep: gitlab.bandit.B404 -- git is invoked list-form (no shell=True) with the
+# ref passed as a discrete argv element, never string-interpolated, so there is no
+# shell-injection surface. We need the local git binary to compute the PR diff.
+import subprocess  # noqa: S404
 from pathlib import Path
 
 LANG_SUFFIXES = ("-python", "-nodejs", "-go", "-ruby", "-php", "-java", "-csharp")

--- a/scripts/review/_changed.py
+++ b/scripts/review/_changed.py
@@ -1,0 +1,41 @@
+"""Shared helper for diff-aware PR-review gating.
+
+Returns the set of top-level example folders touched vs a git ref, so CI can gate
+ONLY what a PR changes — grandfathering the existing backlog on `main` instead of
+failing every PR on pre-existing debt.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+LANG_SUFFIXES = ("-python", "-nodejs", "-go", "-ruby", "-php", "-java", "-csharp")
+
+
+def is_example_dir(name: str) -> bool:
+    return name.endswith(LANG_SUFFIXES)
+
+
+def changed_example_dirs(root: Path, ref: str) -> list[str]:
+    """Top-level example folders with changes vs <ref>.
+
+    Tries three-dot (changes since the merge-base, i.e. what the PR adds) and
+    falls back to a plain diff if that form fails (e.g. shallow checkout).
+    """
+    out = ""
+    for diff_args in ([f"{ref}...HEAD"], [ref]):
+        try:
+            res = subprocess.run(
+                ["git", "-C", str(root), "diff", "--name-only", *diff_args],
+                capture_output=True, text=True, check=True,
+            )
+            out = res.stdout
+            break
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+    dirs = set()
+    for line in out.splitlines():
+        top = line.split("/", 1)[0]
+        if is_example_dir(top) and (root / top).is_dir():
+            dirs.add(top)
+    return sorted(dirs)

--- a/scripts/review/check_legacy_sdk.py
+++ b/scripts/review/check_legacy_sdk.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""check_legacy_sdk.py — flag known-legacy / broken Telnyx SDK references, per language.
+
+The realization behind PRs #12/#13/#14: examples (and their docs, which answer engines
+ingest) kept referencing OLD SDK APIs that don't exist in the current SDKs. This is a
+LANGUAGE-SCOPED denylist of those exact patterns — each is wrong only in the languages
+listed, so it won't false-positive across languages (e.g. `messages.create` + `from_`
+are CORRECT in the Python SDK but wrong in Node/Ruby).
+
+    python scripts/review/check_legacy_sdk.py
+    python scripts/review/check_legacy_sdk.py --changed-against origin/main   # CI / diff-aware
+
+Exits non-zero on any hit.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# language -> [(pattern, correct-API message)]. A folder's docs (README/API/GUIDE) inherit
+# the folder's language. Patterns are only applied to files in matching-language folders.
+DENY_BY_LANG = {
+    "nodejs": [
+        (r"\bTelnyx\.APIStatusError\b", "Telnyx.APIStatusError does not exist — use Telnyx.APIError (.status)"),
+        (r"telnyx\.errors\.Telnyx\w+", "v2 error namespace — use Telnyx.<ErrorClass>"),
+        (r"\.ai_assistants\b", "use client.ai.assistants.*"),
+        (r"\.sipConnections\b", "use client.credentialConnections.*"),
+        (r"\.simCards\.activate\b", "use client.simCards.actions.enable"),
+        (r"\.messages\.create\(", "Node SDK uses client.messages.send()"),
+        (r"\bfrom_:", "Node messaging param is 'from', not 'from_'"),
+        (r"require\((['\"])telnyx\1\)\(", "v2 factory init — use new Telnyx({ apiKey })"),
+    ],
+    "go": [
+        (r"github\.com/telnyx/telnyx-go", "wrong module — use github.com/team-telnyx/telnyx-go/v4"),
+    ],
+    "ruby": [
+        (r"\.messages\.create\b", "Ruby SDK uses client.messages.send_"),
+        (r"\bTelnyx\.api_key\b", "v2 module API — use Telnyx::Client.new(api_key:)"),
+        (r"Telnyx::(Message|Call)\.", "v2 module API — use the Telnyx::Client instance"),
+    ],
+    "csharp": [
+        (r"PackageReference\s+Include=\"Telnyx\"", "wrong NuGet id — use 'Telnyx.net'"),
+    ],
+    "python": [
+        (r"\btelnyx\.(Message|Call|Conference|Number)\.\w", "old module API — use telnyx.Telnyx(...).<resource>"),
+        (r"\btelnyx\.api_key\s*=", "old module API — use telnyx.Telnyx(api_key=...)"),
+    ],
+    "php": [
+        (r"->messages->create\(", "PHP SDK uses ->messages->send()"),
+    ],
+    "java": [],
+}
+DENY_BY_LANG = {k: [(re.compile(p), m) for p, m in v] for k, v in DENY_BY_LANG.items()}
+
+LANG_SUFFIXES = ("python", "nodejs", "go", "ruby", "php", "java", "csharp")
+SCAN_NAMES = {"README.md", "API.md", "GUIDE.md", "app.py", "server.js", "main.go",
+              "app.rb", "index.php", "go.mod", "Gemfile", "composer.json"}
+SCAN_SUFFIX = (".java", ".cs", ".csproj")
+SKIP_DIRS = {".git", "node_modules", "vendor", ".venv", "venv", "dist", "build", "bin", "obj"}
+
+
+def lang_of(folder_name: str):
+    for s in LANG_SUFFIXES:
+        if folder_name.endswith(f"-{s}"):
+            return s
+    return None
+
+
+def scan_folder(folder: Path, root: Path, patterns) -> list[str]:
+    out = []
+    for path in sorted(folder.rglob("*")):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if not path.is_file() or (path.name not in SCAN_NAMES and path.suffix not in SCAN_SUFFIX):
+            continue
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), 1):
+            for rx, msg in patterns:
+                if rx.search(line):
+                    rel = path.relative_to(root) if path.is_relative_to(root) else path
+                    out.append(f"{rel}:{i} — {msg}")
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Flag known-legacy Telnyx SDK references (language-scoped).")
+    ap.add_argument("--path", default=".", help="root to scan (default: cwd)")
+    ap.add_argument("--changed-against", metavar="REF",
+                    help="diff-aware: only scan example folders changed vs this git ref (CI mode)")
+    args = ap.parse_args()
+
+    root = Path(args.path).resolve()
+    if args.changed_against:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from _changed import changed_example_dirs
+        names = changed_example_dirs(root, args.changed_against)
+        if not names:
+            print(f"Legacy-SDK check (diff-aware): no example folders changed vs {args.changed_against}.\n\nPASS")
+            return 0
+        print(f"Legacy-SDK check (diff-aware): {len(names)} changed folder(s) vs {args.changed_against}")
+        folders = [root / n for n in names]
+    else:
+        folders = [p for p in sorted(root.iterdir()) if p.is_dir() and lang_of(p.name)]
+
+    hits = []
+    for folder in folders:
+        lang = lang_of(folder.name)
+        if not lang:
+            continue
+        hits += scan_folder(folder, root, DENY_BY_LANG.get(lang, []))
+
+    for h in hits:
+        print(f"  ✗ {h}")
+    print(f"\nLegacy-SDK check: {len(hits)} reference(s) to dead/old SDK APIs")
+    if hits:
+        print("\nFAIL — replace legacy SDK references (these don't exist in the current SDK for this language).")
+        return 1
+    print("\nPASS — no legacy SDK references.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review/check_pinning.py
+++ b/scripts/review/check_pinning.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""check_pinning.py — flag unpinned / "latest" dependencies across every ecosystem.
+
+Part of the PR-review toolkit (scripts/review/). Codifies the manual scan behind
+PR #11: the "latest" + no-lockfile anti-pattern is what generated 75 Dependabot
+alerts, and invalid `latest` in go.mod won't even build.
+
+Run on any checkout/branch/PR worktree:
+
+    python scripts/review/check_pinning.py                 # whole repo
+    python scripts/review/check_pinning.py --path some-dir  # one subtree
+    python scripts/review/check_pinning.py --verbose
+
+Exits non-zero when any hard finding is present, so it can gate CI directly.
+Ecosystems: npm (package.json), pip (requirements.txt), Go (go.mod), Ruby
+(Gemfile), PHP (composer.json), .NET (*.csproj), Maven (pom.xml).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# A finding: (severity, ecosystem, file, dependency, detail)
+# severity: "error" fails the run; "warn" is reported but does not fail.
+Finding = tuple
+
+
+def _rel(p: Path, root: Path) -> str:
+    try:
+        return str(p.relative_to(root))
+    except ValueError:
+        return str(p)
+
+
+# --- npm -------------------------------------------------------------------
+BAD_NPM = {"latest", "*", "", "x", "X"}
+
+
+def check_package_json(path: Path, root: Path) -> list:
+    out = []
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return [("warn", "npm", _rel(path, root), "-", f"unreadable: {e}")]
+    for section in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        for name, spec in (data.get(section) or {}).items():
+            if not isinstance(spec, str):
+                continue
+            s = spec.strip()
+            if s in BAD_NPM or s.lower() == "latest":
+                out.append(("error", "npm", _rel(path, root), f"{name} ({section})", f'"{spec}" — unpinned'))
+    return out
+
+
+# --- pip -------------------------------------------------------------------
+PIN_OPS = ("==", ">=", "<=", "~=", "!=", "===", "<", ">", "@")
+
+
+def check_requirements_txt(path: Path, root: Path) -> list:
+    out = []
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as e:
+        return [("warn", "pip", _rel(path, root), "-", f"unreadable: {e}")]
+    for i, raw in enumerate(lines, 1):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith(("-r ", "-c ", "--", "-e ", "git+", "http://", "https://")):
+            continue
+        # strip environment markers / extras for the pin check
+        core = line.split(";", 1)[0].strip()
+        if any(op in core for op in PIN_OPS):
+            continue
+        # bare "package" or "package[extra]" with no version
+        name = re.split(r"[\[<>=!~ ]", core, 1)[0]
+        if name:
+            out.append(("error", "pip", _rel(path, root), name, f"line {i}: no version specifier"))
+    return out
+
+
+# --- Go --------------------------------------------------------------------
+def check_go_mod(path: Path, root: Path) -> list:
+    out = []
+    try:
+        text = path.read_text()
+    except OSError as e:
+        return [("warn", "go", _rel(path, root), "-", f"unreadable: {e}")]
+    in_block = False
+    for raw in text.splitlines():
+        line = raw.split("//", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("require ("):
+            in_block = True
+            continue
+        if in_block and line == ")":
+            in_block = False
+            continue
+        entry = None
+        if in_block:
+            entry = line
+        elif line.startswith("require "):
+            entry = line[len("require "):].strip()
+        if not entry:
+            continue
+        parts = entry.split()
+        if len(parts) >= 2:
+            mod, ver = parts[0], parts[1]
+            if ver == "latest" or not re.match(r"^v\d+\.\d+\.\d+", ver):
+                out.append(("error", "go", _rel(path, root), mod, f'version "{ver}" — not a pinned semver'))
+    return out
+
+
+# --- Ruby ------------------------------------------------------------------
+GEM_RE = re.compile(r"""^\s*gem\s+['"]([^'"]+)['"](.*)$""")
+
+
+def check_gemfile(path: Path, root: Path) -> list:
+    out = []
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as e:
+        return [("warn", "ruby", _rel(path, root), "-", f"unreadable: {e}")]
+    for i, raw in enumerate(lines, 1):
+        line = raw.split("#", 1)[0]
+        m = GEM_RE.match(line)
+        if not m:
+            continue
+        name, rest = m.group(1), m.group(2)
+        # a version constraint appears as a second quoted string after a comma
+        if re.search(r""",\s*['"][^'"]*\d""", rest):
+            continue
+        out.append(("error", "ruby", _rel(path, root), name, f"line {i}: no version constraint"))
+    return out
+
+
+# --- PHP -------------------------------------------------------------------
+def check_composer_json(path: Path, root: Path) -> list:
+    out = []
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return [("warn", "php", _rel(path, root), "-", f"unreadable: {e}")]
+    for section in ("require", "require-dev"):
+        for name, spec in (data.get(section) or {}).items():
+            if name.lower() == "php" or "/" not in name:  # platform reqs / ext-*
+                continue
+            s = str(spec).strip().lower()
+            if s in ("*", "latest", ""):
+                out.append(("error", "php", _rel(path, root), name, f'"{spec}" — unpinned'))
+    return out
+
+
+# --- .NET ------------------------------------------------------------------
+def check_csproj(path: Path, root: Path) -> list:
+    out = []
+    try:
+        tree = ET.parse(path)
+    except (ET.ParseError, OSError) as e:
+        return [("warn", "dotnet", _rel(path, root), "-", f"unreadable: {e}")]
+    for ref in tree.iter():
+        if ref.tag.split("}")[-1] != "PackageReference":
+            continue
+        name = ref.get("Include") or ref.get("Update") or "?"
+        ver = ref.get("Version")
+        if ver is None:
+            # may be a child <Version> element
+            child = next((c for c in ref if c.tag.split("}")[-1] == "Version"), None)
+            ver = child.text if child is not None else None
+        if not ver or not ver.strip():
+            out.append(("error", "dotnet", _rel(path, root), name, "no Version"))
+    return out
+
+
+# --- Maven -----------------------------------------------------------------
+def check_pom_xml(path: Path, root: Path) -> list:
+    out = []
+    try:
+        tree = ET.parse(path)
+    except (ET.ParseError, OSError) as e:
+        return [("warn", "maven", _rel(path, root), "-", f"unreadable: {e}")]
+    ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+    deps = tree.findall(".//m:dependencies/m:dependency", ns) or tree.findall(".//dependencies/dependency")
+    for d in deps:
+        gid = d.findtext("m:groupId", default=d.findtext("groupId", ""), namespaces=ns)
+        aid = d.findtext("m:artifactId", default=d.findtext("artifactId", "?"), namespaces=ns)
+        ver = d.findtext("m:version", default=d.findtext("version", None), namespaces=ns)
+        if not ver:
+            # could be managed by a parent/BOM — warn rather than fail
+            out.append(("warn", "maven", _rel(path, root), f"{gid}:{aid}", "no <version> (may be managed by a BOM)"))
+        elif ver.strip().upper() in ("LATEST", "RELEASE"):
+            out.append(("error", "maven", _rel(path, root), f"{gid}:{aid}", f"version {ver}"))
+    return out
+
+
+HANDLERS = [
+    ("package.json", check_package_json),
+    ("requirements.txt", check_requirements_txt),
+    ("go.mod", check_go_mod),
+    ("Gemfile", check_gemfile),
+    ("composer.json", check_composer_json),
+    ("pom.xml", check_pom_xml),
+]
+SKIP_DIRS = {".git", "node_modules", "vendor", ".venv", "venv", "dist", "build", "bin", "obj"}
+
+
+def scan(root: Path) -> list:
+    findings = []
+    for path in sorted(root.rglob("*")):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if not path.is_file():
+            continue
+        name = path.name
+        if name.endswith(".csproj"):
+            findings += check_csproj(path, root)
+            continue
+        for fname, handler in HANDLERS:
+            if name == fname:
+                findings += handler(path, root)
+                break
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Flag unpinned / 'latest' dependencies across ecosystems.")
+    ap.add_argument("--path", default=".", help="root to scan (default: cwd)")
+    ap.add_argument("--verbose", action="store_true", help="list every finding (default groups by ecosystem)")
+    args = ap.parse_args()
+
+    root = Path(args.path).resolve()
+    findings = scan(root)
+    errors = [f for f in findings if f[0] == "error"]
+    warns = [f for f in findings if f[0] == "warn"]
+
+    by_eco: dict[str, int] = {}
+    for sev, eco, *_ in findings:
+        if sev == "error":
+            by_eco[eco] = by_eco.get(eco, 0) + 1
+
+    if args.verbose or errors:
+        for sev, eco, fpath, dep, detail in findings:
+            if sev == "error" or args.verbose:
+                mark = "✗" if sev == "error" else "·"
+                print(f"  {mark} [{eco}] {fpath}: {dep} — {detail}")
+
+    print("\nPinning check:")
+    print(f"  unpinned (errors): {len(errors)}" + (f"  {by_eco}" if by_eco else ""))
+    print(f"  warnings:          {len(warns)} (e.g. Maven versions possibly managed by a BOM)")
+    if errors:
+        print("\nFAIL — pin every dependency to a concrete safe version (no 'latest'/bare names).")
+        return 1
+    print("\nPASS — all dependencies are pinned.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review/check_pinning.py
+++ b/scripts/review/check_pinning.py
@@ -209,32 +209,45 @@ HANDLERS = [
 SKIP_DIRS = {".git", "node_modules", "vendor", ".venv", "venv", "dist", "build", "bin", "obj"}
 
 
-def scan(root: Path) -> list:
+def scan(root: Path, subdirs=None) -> list:
     findings = []
-    for path in sorted(root.rglob("*")):
-        if any(part in SKIP_DIRS for part in path.parts):
-            continue
-        if not path.is_file():
-            continue
-        name = path.name
-        if name.endswith(".csproj"):
-            findings += check_csproj(path, root)
-            continue
-        for fname, handler in HANDLERS:
-            if name == fname:
-                findings += handler(path, root)
-                break
+    bases = [root / d for d in subdirs] if subdirs is not None else [root]
+    for base in bases:
+        for path in sorted(base.rglob("*")):
+            if any(part in SKIP_DIRS for part in path.parts):
+                continue
+            if not path.is_file():
+                continue
+            name = path.name
+            if name.endswith(".csproj"):
+                findings += check_csproj(path, root)
+                continue
+            for fname, handler in HANDLERS:
+                if name == fname:
+                    findings += handler(path, root)
+                    break
     return findings
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Flag unpinned / 'latest' dependencies across ecosystems.")
     ap.add_argument("--path", default=".", help="root to scan (default: cwd)")
+    ap.add_argument("--changed-against", metavar="REF",
+                    help="diff-aware: only check example folders changed vs this git ref (CI mode)")
     ap.add_argument("--verbose", action="store_true", help="list every finding (default groups by ecosystem)")
     args = ap.parse_args()
 
     root = Path(args.path).resolve()
-    findings = scan(root)
+    subdirs = None
+    if args.changed_against:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from _changed import changed_example_dirs
+        subdirs = changed_example_dirs(root, args.changed_against)
+        if not subdirs:
+            print(f"Pinning check (diff-aware): no example folders changed vs {args.changed_against}.\n\nPASS")
+            return 0
+        print(f"Pinning check (diff-aware): {len(subdirs)} changed folder(s) vs {args.changed_against}")
+    findings = scan(root, subdirs)
     errors = [f for f in findings if f[0] == "error"]
     warns = [f for f in findings if f[0] == "warn"]
 

--- a/scripts/review/check_pinning.py
+++ b/scripts/review/check_pinning.py
@@ -21,7 +21,6 @@ import argparse
 import json
 import re
 import sys
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 # A finding: (severity, ecosystem, file, dependency, detail)
@@ -157,39 +156,53 @@ def check_composer_json(path: Path, root: Path) -> list:
 
 
 # --- .NET ------------------------------------------------------------------
+# Regex extraction (no XML parser) — avoids the XXE / billion-laughs risk of
+# feeding untrusted PR .csproj/pom.xml through xml.etree, and needs no extra
+# dependency. We only need attribute/element text, not a full DOM.
+_CSPROJ_PKG_RE = re.compile(r"<PackageReference\b([^>]*?)(?:/>|>(.*?)</PackageReference>)", re.DOTALL | re.IGNORECASE)
+_XML_ATTR_RE = re.compile(r'([\w:.-]+)\s*=\s*"([^"]*)"')
+_CSPROJ_CHILD_VER_RE = re.compile(r"<Version>\s*([^<]*?)\s*</Version>", re.IGNORECASE)
+
+
 def check_csproj(path: Path, root: Path) -> list:
     out = []
     try:
-        tree = ET.parse(path)
-    except (ET.ParseError, OSError) as e:
+        text = path.read_text()
+    except OSError as e:
         return [("warn", "dotnet", _rel(path, root), "-", f"unreadable: {e}")]
-    for ref in tree.iter():
-        if ref.tag.split("}")[-1] != "PackageReference":
-            continue
-        name = ref.get("Include") or ref.get("Update") or "?"
-        ver = ref.get("Version")
-        if ver is None:
+    for m in _CSPROJ_PKG_RE.finditer(text):
+        attrs = dict(_XML_ATTR_RE.findall(m.group(1)))
+        name = attrs.get("Include") or attrs.get("Update") or "?"
+        ver = attrs.get("Version")
+        if not ver:
             # may be a child <Version> element
-            child = next((c for c in ref if c.tag.split("}")[-1] == "Version"), None)
-            ver = child.text if child is not None else None
+            child = _CSPROJ_CHILD_VER_RE.search(m.group(2) or "")
+            ver = child.group(1) if child else None
         if not ver or not ver.strip():
             out.append(("error", "dotnet", _rel(path, root), name, "no Version"))
     return out
 
 
 # --- Maven -----------------------------------------------------------------
+_POM_DEP_RE = re.compile(r"<dependency>(.*?)</dependency>", re.DOTALL | re.IGNORECASE)
+
+
+def _pom_tag(block: str, tag: str):
+    m = re.search(rf"<{tag}>\s*(.*?)\s*</{tag}>", block, re.DOTALL | re.IGNORECASE)
+    return m.group(1).strip() if m else None
+
+
 def check_pom_xml(path: Path, root: Path) -> list:
     out = []
     try:
-        tree = ET.parse(path)
-    except (ET.ParseError, OSError) as e:
+        text = path.read_text()
+    except OSError as e:
         return [("warn", "maven", _rel(path, root), "-", f"unreadable: {e}")]
-    ns = {"m": "http://maven.apache.org/POM/4.0.0"}
-    deps = tree.findall(".//m:dependencies/m:dependency", ns) or tree.findall(".//dependencies/dependency")
-    for d in deps:
-        gid = d.findtext("m:groupId", default=d.findtext("groupId", ""), namespaces=ns)
-        aid = d.findtext("m:artifactId", default=d.findtext("artifactId", "?"), namespaces=ns)
-        ver = d.findtext("m:version", default=d.findtext("version", None), namespaces=ns)
+    for m in _POM_DEP_RE.finditer(text):
+        block = m.group(1)
+        gid = _pom_tag(block, "groupId") or ""
+        aid = _pom_tag(block, "artifactId") or "?"
+        ver = _pom_tag(block, "version")
         if not ver:
             # could be managed by a parent/BOM — warn rather than fail
             out.append(("warn", "maven", _rel(path, root), f"{gid}:{aid}", "no <version> (may be managed by a BOM)"))

--- a/scripts/review/check_required_files.py
+++ b/scripts/review/check_required_files.py
@@ -76,16 +76,29 @@ def check_example(folder: Path) -> list[tuple[str, str]]:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Per-example required/forbidden file gate.")
     ap.add_argument("--path", default=".", help="root containing example folders (default: cwd)")
+    ap.add_argument("--changed-against", metavar="REF",
+                    help="diff-aware: only check example folders changed vs this git ref (CI mode)")
     ap.add_argument("--verbose", action="store_true", help="list clean folders too")
     args = ap.parse_args()
 
     root = Path(args.path).resolve()
+    only = None
+    if args.changed_against:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from _changed import changed_example_dirs
+        only = set(changed_example_dirs(root, args.changed_against))
+        if not only:
+            print(f"Structural check (diff-aware): no example folders changed vs {args.changed_against}.\n\nPASS")
+            return 0
+        print(f"Structural check (diff-aware): {len(only)} changed folder(s) vs {args.changed_against}")
     bad = 0
     checked = 0
     langs_seen: dict[str, int] = {}
     for folder in sorted(p for p in root.iterdir() if p.is_dir()):
         lang = lang_of(folder.name)
         if lang is None:
+            continue
+        if only is not None and folder.name not in only:
             continue
         checked += 1
         langs_seen[lang] = langs_seen.get(lang, 0) + 1

--- a/scripts/review/check_required_files.py
+++ b/scripts/review/check_required_files.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""check_required_files.py — per-example structural gate for the PR-review toolkit.
+
+Confirms each example folder has the required AEO files, the right language
+code+dependency files, and NONE of the forbidden deploy-scaffolding files
+(Dockerfile/Makefile) that CLAUDE.md bans. Knows the newer languages
+(php/java/csharp) that the in-repo verify.py mappings don't yet cover.
+
+    python scripts/review/check_required_files.py
+    python scripts/review/check_required_files.py --path /tmp/some-pr-worktree
+
+Exits non-zero on any violation, so it can gate CI.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REQUIRED_DOCS = ["README.md", "API.md", "GUIDE.md", ".env.example"]
+FORBIDDEN = ["Dockerfile", "Makefile", "docker-compose.yml", "docker-compose.yaml", "Procfile"]
+
+# language suffix -> (code-file matcher, dependency file)
+LANG = {
+    "python": (["app.py"], "requirements.txt"),
+    "nodejs": (["server.js"], "package.json"),
+    "go": (["main.go"], "go.mod"),
+    "ruby": (["app.rb"], "Gemfile"),
+    "php": (["index.php"], "composer.json"),
+    "java": (["*.java"], "pom.xml"),
+    "csharp": (["*.cs"], "*.csproj"),
+    # edge-compute uses func.toml as the "code" entry; handled loosely below
+}
+
+
+def lang_of(folder: str) -> str | None:
+    for suffix in LANG:
+        if folder.endswith(f"-{suffix}"):
+            return suffix
+    return None
+
+
+def has(folder: Path, patterns: list[str]) -> bool:
+    for pat in patterns:
+        if "*" in pat:
+            if any(folder.glob(pat)):
+                return True
+        elif (folder / pat).is_file():
+            return True
+    return False
+
+
+def check_example(folder: Path) -> list[tuple[str, str]]:
+    """Return list of (severity, message)."""
+    out = []
+    lang = lang_of(folder.name)
+    if lang is None:
+        return out  # not a recognized example folder; skip
+    # required docs + env
+    for f in REQUIRED_DOCS:
+        if not (folder / f).is_file():
+            out.append(("error", f"missing {f}"))
+    # code + dependency files
+    code_pats, dep = LANG[lang]
+    if not has(folder, code_pats):
+        out.append(("error", f"missing code file ({'/'.join(code_pats)})"))
+    if not has(folder, [dep]):
+        out.append(("error", f"missing dependency file ({dep})"))
+    # forbidden scaffolding
+    for f in FORBIDDEN:
+        if (folder / f).is_file():
+            out.append(("error", f"forbidden file present: {f}"))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Per-example required/forbidden file gate.")
+    ap.add_argument("--path", default=".", help="root containing example folders (default: cwd)")
+    ap.add_argument("--verbose", action="store_true", help="list clean folders too")
+    args = ap.parse_args()
+
+    root = Path(args.path).resolve()
+    bad = 0
+    checked = 0
+    langs_seen: dict[str, int] = {}
+    for folder in sorted(p for p in root.iterdir() if p.is_dir()):
+        lang = lang_of(folder.name)
+        if lang is None:
+            continue
+        checked += 1
+        langs_seen[lang] = langs_seen.get(lang, 0) + 1
+        issues = check_example(folder)
+        if issues:
+            bad += 1
+            print(f"  ✗ {folder.name}")
+            for sev, msg in issues:
+                print(f"      - {msg}")
+        elif args.verbose:
+            print(f"  ✓ {folder.name}")
+
+    print(f"\nStructural check: {checked} example folders ({langs_seen})")
+    print(f"  folders with violations: {bad}")
+    if bad:
+        print("\nFAIL — every example needs README/API.md/GUIDE.md/.env.example + code + dep file, and no Dockerfile/Makefile.")
+        return 1
+    print("\nPASS — all example folders are structurally complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review/review_pr.sh
+++ b/scripts/review/review_pr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# review_pr.sh — run every PR-review gate locally before pushing.
+#
+#   scripts/review/review_pr.sh [BASE_REF]      # BASE_REF defaults to origin/main
+#
+# verify.py runs over the full repo (the authoritative validator); the review
+# gates run DIFF-AWARE — they only check example folders changed vs BASE_REF, so
+# they catch what your branch introduces without failing on main's existing backlog.
+set -uo pipefail
+BASE="${1:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail=0
+run() { local title="$1"; shift; echo; echo "=== ${title} ==="; "$@" || fail=1; }
+
+run "verify.py (full repo)"             python3 scripts/verify.py
+run "pinning (changed vs ${BASE})"      python3 scripts/review/check_pinning.py --changed-against "$BASE"
+run "required files (changed vs ${BASE})" python3 scripts/review/check_required_files.py --changed-against "$BASE"
+run "legacy SDK (changed vs ${BASE})"   python3 scripts/review/check_legacy_sdk.py --changed-against "$BASE"
+
+echo
+[ "$fail" -eq 0 ] && echo "✅ ALL GATES PASSED" || echo "❌ GATES FAILED"
+exit "$fail"


### PR DESCRIPTION
Adds a `scripts/review/` toolkit and wires it as a GitHub Actions **PR gate**, so contributions are auto-screened for the issues we've been fixing by hand (unpinned deps, missing/forbidden files, dead SDK APIs) before a human reviews them.

## Gates
| Gate | Catches |
|---|---|
| `verify.py` (existing) | the repo's full validator — runs as a hard gate |
| `check_pinning.py` | unpinned / `latest` deps across npm · pip · Go · Ruby · PHP · .NET · Maven |
| `check_required_files.py` | required files per example + no `Dockerfile`/`Makefile` |
| `check_legacy_sdk.py` | dead/old SDK APIs in **code and docs**, language-scoped |
| `review_pr.sh` | runs all of the above against a base ref (local pre-push) |

## Diff-aware (the key design choice)
`main` carries pre-existing backlog (≈485 unpinned deps, some folders missing API.md/GUIDE.md, ~149 legacy SDK refs in pre-fix Node/Go/Ruby examples). A repo-wide hard gate would block **every** PR on that debt. So the review gates run **diff-aware** — they only check the example folders a PR actually changes (`--changed-against <base>`), grandfathering the backlog while catching anything new. `verify.py` (already green on main) runs full.

`check_legacy_sdk.py` is **language-scoped** so it won't false-positive across languages — e.g. it flags `messages.create` in Node/Ruby but NOT Python, where `client.messages.create(from_=...)` is the correct SDK call.

## Verification
- `scripts/review/review_pr.sh origin/main` → all gates pass (exit 0) on this branch
- Diff-aware gates confirmed: green when no example folders change; they flag exactly the touched folders otherwise
- Validated against known-good Python examples → 0 false positives

## Follow-ups (noted, not in this PR)
- Clearing main's backlog (deps pinning sweep; the ~149 legacy refs are fixed by #11/#12/#13 once merged)
- Build CI for php/java/csharp/ruby/go (so those examples are compile-verified, not just static-authored)