### PR TITLE
fix(review): structural gate recognizes edge-compute func.toml layout

### DIFF
--- a/scripts/review/check_required_files.py
+++ b/scripts/review/check_required_files.py
@@ -62,6 +62,11 @@ def check_example(folder: Path) -> list[tuple[str, str]]:
             out.append(("error", f"missing {f}"))
     # code + dependency files
     code_pats, dep = LANG[lang]
+    # Edge Compute examples ship func.toml + a function/ package instead of a
+    # single app.py — verify.py treats func.toml as the code file, so mirror that
+    # here to avoid false-positives on those folders.
+    if (folder / "func.toml").is_file():
+        code_pats = ["func.toml"]
     if not has(folder, code_pats):
         out.append(("error", f"missing code file ({'/'.join(code_pats)})"))
     if not has(folder, [dep]):


### PR DESCRIPTION
## What

The PR-review toolkit's `check_required_files.py` gate flagged two examples as missing `app.py`:

- `edge-compute-webhook-proxy-python`
- `edge-mcp-server-deploy-python`

These are **false positives**. Edge Compute examples ship a `func.toml` + `function/` package instead of a single `app.py`. The authoritative `verify.py` already treats `func.toml` as the code file for these (see `verify.py:81-85`); the gate didn't, so it disagreed with `verify.py` and would wrongly block any PR touching an edge-compute example.

## Fix

Mirror `verify.py`: when `func.toml` is present, treat it as the code file.

## Verification

- `python scripts/review/check_required_files.py` → **291/291 PASS** (was 2 false-positive violations)
- `python scripts/verify.py` → 291/291 PASS (unchanged)

Found during the post-#15 final green sweep of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)