### PR TITLE
[codex] Add Telnyx inference cookbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ pip install -r requirements.txt && python app.py
 
 Each example's README has a Quick Start with the exact install/run commands for its language, an `API.md` typed endpoint reference, and a `GUIDE.md` walkthrough.
 
+## Cookbooks
+
+Notebook-based walkthroughs for Telnyx AI workflows.
+
+| Cookbook collection | Language | Description |
+|---------------------|----------|-------------|
+| [Telnyx Inference Cookbooks](cookbooks/inference/README.md) | Python / Colab | Chat completions, structured JSON extraction, RAG, transcription, and translation with Telnyx AI. |
+
 ---
 
 ## Voice AI

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Notebook-based walkthroughs for Telnyx AI workflows.
 
 | Cookbook collection | Language | Description |
 |---------------------|----------|-------------|
-| [Telnyx Inference Cookbooks](cookbooks/inference/README.md) | Python / Colab | Chat completions, structured JSON extraction, RAG, transcription, and translation with Telnyx AI. |
+| [Telnyx Inference Cookbooks](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/cookbooks/inference/README.md) | Python / Colab | Chat completions, structured JSON extraction, RAG, transcription, and translation with Telnyx AI. |
 
 ---
 

--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -1,0 +1,7 @@
+# Telnyx Cookbooks
+
+Runnable notebook-based examples for building with Telnyx APIs.
+
+| Cookbook collection | What it covers |
+| --- | --- |
+| [Inference Cookbooks](./inference/README.md) | Colab notebooks for chat completions, structured JSON extraction, RAG, transcription, and translation with Telnyx AI. |

--- a/cookbooks/inference/01_Chat_completion_telnyx_inference.ipynb
+++ b/cookbooks/inference/01_Chat_completion_telnyx_inference.ipynb
@@ -1,0 +1,250 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/01_Chat_completion_telnyx_inference.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# First Chat Completion with Telnyx Inference\n",
+        "\n",
+        "In this notebook, you’ll send your first chat completion request to a Telnyx-hosted model using the OpenAI Python SDK.\n",
+        "\n",
+        "Telnyx Inference is OpenAI-compatible, so if you already use the OpenAI SDK, you can point it at Telnyx by changing the `base_url` and using your Telnyx API key.\n"
+      ],
+      "metadata": {
+        "id": "MWbwX1Kregwd"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Install SDK"
+      ],
+      "metadata": {
+        "id": "_UYlQY4BMhF8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install openai"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "vz9FxZpxejTs"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Add Telnyx API key"
+      ],
+      "metadata": {
+        "id": "1PqmnraTMpwe"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from getpass import getpass\n",
+        "\n",
+        "TELNYX_API_KEY = getpass(\"Enter your Telnyx API key: \")\n"
+      ],
+      "metadata": {
+        "id": "Sjp4r2igejdH"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Create Client\n",
+        "Telnyx Inference is OpenAI-compatible. This notebook uses the OpenAI Python SDK and points it at Telnyx with the `base_url` below."
+      ],
+      "metadata": {
+        "id": "u0vf_ERQM4jX"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from openai import OpenAI\n",
+        "\n",
+        "client = OpenAI(\n",
+        "    api_key=TELNYX_API_KEY,\n",
+        "    base_url=\"https://api.telnyx.com/v2/ai/openai\"\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "9T0a53Z3ejgx"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## First Chat Completion"
+      ],
+      "metadata": {
+        "id": "6w-t2G-LPWpW"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "response = client.chat.completions.create(\n",
+        "    model=\"moonshotai/Kimi-K2.6\",\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": \"You are a helpful assistant.\"\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": \"Explain Telnyx Inference in one short paragraph.\"\n",
+        "        }\n",
+        "    ],\n",
+        "    temperature=0.2,\n",
+        ")\n",
+        "\n",
+        "print(response.choices[0].message.content)"
+      ],
+      "metadata": {
+        "id": "3GBOLB3iejjv"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Try Your Own Prompt\n",
+        "\n",
+        "Change the prompt below and run the cell again.\n"
+      ],
+      "metadata": {
+        "id": "F2QoroDfKdLo"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "user_prompt = \"Give me three example use cases for low-latency LLM inference.\"\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=\"moonshotai/Kimi-K2.6\",\n",
+        "    messages=[\n",
+        "        {\"role\": \"system\", \"content\": \"You are a concise technical assistant.\"},\n",
+        "        {\"role\": \"user\", \"content\": user_prompt}\n",
+        "    ],\n",
+        "    temperature=0.2,\n",
+        ")\n",
+        "\n",
+        "print(response.choices[0].message.content)"
+      ],
+      "metadata": {
+        "id": "3BEXAMyhKZww"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Common Errors\n",
+        "\n",
+        "Here are a few common issues you may run into when making your first request.\n"
+      ],
+      "metadata": {
+        "id": "4cwnEB2p0VxI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from openai import AuthenticationError, NotFoundError, RateLimitError, APIError\n",
+        "\n",
+        "try:\n",
+        "    response = client.chat.completions.create(\n",
+        "        model=\"moonshotai/Kimi-K2.6\",\n",
+        "        messages=[\n",
+        "            {\"role\": \"user\", \"content\": \"Say hello in one sentence.\"}\n",
+        "        ],\n",
+        "        temperature=0.2,\n",
+        "    )\n",
+        "\n",
+        "    print(response.choices[0].message.content)\n",
+        "\n",
+        "except AuthenticationError:\n",
+        "    print(\"Authentication failed. Check that your Telnyx API key is correct.\")\n",
+        "\n",
+        "except NotFoundError:\n",
+        "    print(\"Model not found. Check that the model name is spelled correctly.\")\n",
+        "\n",
+        "except RateLimitError:\n",
+        "    print(\"Rate limit hit. Wait a moment and try again.\")\n",
+        "\n",
+        "except APIError as e:\n",
+        "    print(f\"API error: {e}\")\n"
+      ],
+      "metadata": {
+        "id": "bTNT7CjK0aoM"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Next Steps\n",
+        "\n",
+        "Now that you’ve sent your first request, try:\n",
+        "\n",
+        "- Changing the model\n",
+        "- Changing the prompt\n",
+        "- Adjusting `temperature`\n",
+        "- Streaming the response token-by-token\n",
+        "- Returning structured JSON\n"
+      ],
+      "metadata": {
+        "id": "VzUtRZBiKz_J"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "iaf3WAXjK3NZ"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/cookbooks/inference/02_Structured_JSON_Extraction.ipynb
+++ b/cookbooks/inference/02_Structured_JSON_Extraction.ipynb
@@ -1,0 +1,446 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "authorship_tag": "ABX9TyPIlGiNx6v6wOXdOieSvZGu",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/02_Structured_JSON_Extraction.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Structured JSON Extraction with Telnyx Inference\n",
+        "\n",
+        "In this notebook, you’ll use Telnyx Inference to extract structured JSON from messy, unstructured text.\n",
+        "\n",
+        "This is useful for workflows like:\n",
+        "\n",
+        "- Support ticket triage\n",
+        "- Email parsing\n",
+        "- Lead qualification\n",
+        "- Contract or document extraction\n",
+        "- Incident report summarization\n",
+        "\n",
+        "We’ll use the OpenAI Python SDK with Telnyx’s OpenAI-compatible endpoint.\n"
+      ],
+      "metadata": {
+        "id": "002NKYOpGfX5"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Install SDK"
+      ],
+      "metadata": {
+        "id": "M3d3MBAbG2pR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cg9Q9cpPKsTN"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install openai"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from getpass import getpass\n",
+        "\n",
+        "TELNYX_API_KEY = getpass(\"Enter your Telnyx API key: \")\n"
+      ],
+      "metadata": {
+        "id": "JvS5oSmdLIcy"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This notebook uses the OpenAI Python SDK because Telnyx Inference supports OpenAI-compatible APIs.\n"
+      ],
+      "metadata": {
+        "id": "HSJicH3298be"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Create Telnyx Client"
+      ],
+      "metadata": {
+        "id": "QWefQYMwHCvY"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from openai import OpenAI\n",
+        "\n",
+        "client = OpenAI(\n",
+        "    api_key=TELNYX_API_KEY,\n",
+        "    base_url=\"https://api.telnyx.com/v2/ai/openai\"\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "QWTORmKJLLUx"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This example uses `moonshotai/Kimi-K2.6` for JSON extraction. You can swap in another Telnyx-hosted chat model, but output quality and formatting may vary by model.\n"
+      ],
+      "metadata": {
+        "id": "W2ta9XgX_DWk"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Define Messy Input Text"
+      ],
+      "metadata": {
+        "id": "dIVRUYRtHGUI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ticket = \"\"\"\n",
+        "Subject: URGENT - checkout failures after key rotation??\n",
+        "\n",
+        "Hey support,\n",
+        "\n",
+        "We rotated our Telnyx API key yesterday around 6:15pm ET as part of a security cleanup.\n",
+        "Since then, some of our backend jobs are failing when they try to send verification messages.\n",
+        "\n",
+        "The weird part: our staging environment works fine, but production is throwing 401s.\n",
+        "We also saw a few 429s earlier this morning, but those might be from our retry loop going crazy.\n",
+        "\n",
+        "Impact: new users can't complete signup because they never receive the verification code.\n",
+        "This started around 9:30am ET today and is affecting our US traffic only as far as we can tell.\n",
+        "\n",
+        "Can someone check whether our old key is still cached somewhere, or if we missed a permission\n",
+        "on the new key? Happy to jump on a call. This is pretty urgent because paid acquisition is live today.\n",
+        "\n",
+        "Account: Acme Health\n",
+        "Request ID examples: req_7K2... and req_9Q1...\n",
+        "\"\"\"\n"
+      ],
+      "metadata": {
+        "id": "OmUqJG5gNCOq"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Define the JSON Schema"
+      ],
+      "metadata": {
+        "id": "FghDDpquHKaw"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ticket_schema = {\n",
+        "    \"type\": \"object\",\n",
+        "    \"additionalProperties\": False,\n",
+        "    \"properties\": {\n",
+        "        \"company\": {\"type\": \"string\"},\n",
+        "        \"category\": {\n",
+        "            \"type\": \"string\",\n",
+        "            \"enum\": [\"authentication\", \"rate_limit\", \"billing\", \"bug\", \"feature_request\", \"general\"]\n",
+        "        },\n",
+        "        \"priority\": {\n",
+        "            \"type\": \"string\",\n",
+        "            \"enum\": [\"low\", \"medium\", \"high\", \"urgent\"]\n",
+        "        },\n",
+        "        \"summary\": {\"type\": \"string\"},\n",
+        "        \"affected_environment\": {\"type\": \"string\"},\n",
+        "        \"affected_region\": {\"type\": \"string\"},\n",
+        "        \"customer_impact\": {\"type\": \"string\"},\n",
+        "        \"error_codes\": {\n",
+        "            \"type\": \"array\",\n",
+        "            \"items\": {\"type\": \"string\"}\n",
+        "        },\n",
+        "        \"suspected_cause\": {\"type\": \"string\"},\n",
+        "        \"requested_action\": {\"type\": \"string\"}\n",
+        "    },\n",
+        "    \"required\": [\n",
+        "        \"company\",\n",
+        "        \"category\",\n",
+        "        \"priority\",\n",
+        "        \"summary\",\n",
+        "        \"affected_environment\",\n",
+        "        \"affected_region\",\n",
+        "        \"customer_impact\",\n",
+        "        \"error_codes\",\n",
+        "        \"suspected_cause\",\n",
+        "        \"requested_action\"\n",
+        "    ]\n",
+        "}"
+      ],
+      "metadata": {
+        "id": "UCB2YNq1HMlI"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Extract Structured JSON"
+      ],
+      "metadata": {
+        "id": "SUUSbFuvHRXu"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "response = client.chat.completions.create(\n",
+        "    model=\"moonshotai/Kimi-K2.6\", # Telnyx-hosted chat model used in this example\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": \"\"\"\n",
+        "You extract structured information from support tickets.\n",
+        "\n",
+        "Return only valid JSON.\n",
+        "Do not use Markdown.\n",
+        "Do not include extra fields.\n",
+        "\n",
+        "Use exactly this JSON shape:\n",
+        "\n",
+        "{\n",
+        "  \"company\": \"string\",\n",
+        "  \"category\": \"authentication | rate_limit | billing | bug | feature_request | general\",\n",
+        "  \"priority\": \"low | medium | high | urgent\",\n",
+        "  \"summary\": \"string\",\n",
+        "  \"affected_environment\": \"string\",\n",
+        "  \"affected_region\": \"string\",\n",
+        "  \"customer_impact\": \"string\",\n",
+        "  \"error_codes\": [\"string\"],\n",
+        "  \"suspected_cause\": \"string\",\n",
+        "  \"requested_action\": \"string\"\n",
+        "}\n",
+        "\"\"\"\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": ticket\n",
+        "        }\n",
+        "    ],\n",
+        "    temperature=0.0,\n",
+        "    response_format={\"type\": \"json_object\"},\n",
+        ")\n",
+        "\n",
+        "raw_output = response.choices[0].message.content\n",
+        "print(raw_output)\n"
+      ],
+      "metadata": {
+        "id": "pExjzEgBHdSh"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Parse the JSON\n"
+      ],
+      "metadata": {
+        "id": "2kHqgQi3Hk85"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import json\n",
+        "from pprint import pprint\n",
+        "\n",
+        "structured_ticket = json.loads(raw_output)\n",
+        "\n",
+        "pprint(structured_ticket)"
+      ],
+      "metadata": {
+        "id": "moyeTM3oHmmj"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Example Output\n",
+        "\n",
+        "You should see a JSON object with the same fields as the requested shape:\n",
+        "\n",
+        "```json\n",
+        "{\n",
+        "  \"company\": \"Acme Health\",\n",
+        "  \"category\": \"authentication\",\n",
+        "  \"priority\": \"urgent\",\n",
+        "  \"summary\": \"Production webhook jobs are failing after an API key rotation.\",\n",
+        "  \"affected_environment\": \"production\",\n",
+        "  \"affected_region\": \"US\",\n",
+        "  \"customer_impact\": \"New users cannot complete signup because verification codes are not being sent.\",\n",
+        "  \"error_codes\": [\"401\", \"429\"],\n",
+        "  \"suspected_cause\": \"The new API key may be missing permissions, or the old key may still be cached somewhere.\",\n",
+        "  \"requested_action\": \"Check authentication configuration and help debug the API key rotation issue.\"\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "Your exact wording may vary, but the field names should match this structure."
+      ],
+      "metadata": {
+        "id": "HQ_KgRXQHtEZ"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Try Your Own Text\n",
+        "\n",
+        "Replace the text below with another support ticket, email, or customer message.\n"
+      ],
+      "metadata": {
+        "id": "ZCWHcceAH1lM"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import re\n",
+        "custom_text = \"\"\"\n",
+        "Subject: Billing question - duplicate charge\n",
+        "\n",
+        "Hi, I noticed two charges from Telnyx on my card this month.\n",
+        "One was on May 2 and another was on May 4 for the same amount.\n",
+        "\n",
+        "Our finance team is asking whether this is expected or if one charge was accidental.\n",
+        "Nothing is broken right now, but we'd like to resolve it before our books close this week.\n",
+        "\n",
+        "Company: Northstar Logistics\n",
+        "\"\"\"\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=\"moonshotai/Kimi-K2.6\",\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": (\n",
+        "                \"Extract structured information from the user's message. \"\n",
+        "                \"Return only a valid JSON object. Do not wrap it in Markdown. \"\n",
+        "                \"Do not include explanations, comments, or code fences.\"\n",
+        "            )\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": custom_text\n",
+        "        }\n",
+        "    ],\n",
+        "    temperature=0.0,\n",
+        "    extra_body={\n",
+        "        \"guided_json\": ticket_schema\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "raw_output = response.choices[0].message.content.strip()\n",
+        "raw_output = re.sub(r\"^```(?:json)?\\s*\", \"\", raw_output)\n",
+        "raw_output = re.sub(r\"\\s*```$\", \"\", raw_output)\n",
+        "\n",
+        "structured_result = json.loads(raw_output)\n",
+        "\n",
+        "pprint(structured_result)"
+      ],
+      "metadata": {
+        "id": "wjjsmzttHu8a"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Troubleshooting"
+      ],
+      "metadata": {
+        "id": "-W_jTgyDP2YT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(repr(response.choices[0].message.content))\n"
+      ],
+      "metadata": {
+        "id": "qNUeueXOP4Vj"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Common causes:\n",
+        "\n",
+        "- The response was wrapped in Markdown code fences.\n",
+        "- The response included extra text before or after the JSON.\n",
+        "- The schema was changed in a way that makes generation harder.\n",
+        "\n",
+        "The parsing cells above remove basic Markdown code fences before calling `json.loads()`.\n"
+      ],
+      "metadata": {
+        "id": "SfCSZRDDP9wl"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Explore More\n",
+        "\n",
+        "Want to build more with Telnyx Inference?\n",
+        "\n",
+        "- Browse Telnyx Inference docs: https://developers.telnyx.com/docs/inference\n",
+        "- Explore Telnyx examples on GitHub: https://github.com/team-telnyx/telnyx-code-examples\n",
+        "- Try the Telnyx Mission Control Portal: https://portal.telnyx.com/"
+      ],
+      "metadata": {
+        "id": "G3qh8DtLLKdR"
+      }
+    }
+  ]
+}

--- a/cookbooks/inference/03_RAG_Telnyx_Inference.ipynb
+++ b/cookbooks/inference/03_RAG_Telnyx_Inference.ipynb
@@ -1,0 +1,496 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "authorship_tag": "ABX9TyPyomatDuqQi4JwddJ+AQ6O",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/03_RAG_Telnyx_Inference.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# RAG with Telnyx Inference\n",
+        "\n",
+        "In this notebook, you’ll build a simple Retrieval-Augmented Generation (RAG) workflow with Telnyx Inference.\n",
+        "\n",
+        "You’ll:\n",
+        "\n",
+        "1. Create a small knowledge base\n",
+        "2. Generate embeddings with Telnyx Inference\n",
+        "3. Retrieve the most relevant documents for a user question\n",
+        "4. Use a Telnyx-hosted chat model to answer using only the retrieved context\n",
+        "\n",
+        "We’ll use the OpenAI Python SDK with Telnyx’s OpenAI-compatible endpoint. This notebook uses a simple in-memory retriever for learning purposes. Production RAG systems typically use a vector database or search backend.\n"
+      ],
+      "metadata": {
+        "id": "LeWimwcZI_Vv"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Install SDK and Required Libraries"
+      ],
+      "metadata": {
+        "id": "8rQ9m4MlKGYd"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q openai numpy"
+      ],
+      "metadata": {
+        "id": "hLS3WSovI9tk"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Add Telnyx API Key"
+      ],
+      "metadata": {
+        "id": "gTBLeOMjKMfG"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from getpass import getpass\n",
+        "\n",
+        "TELNYX_API_KEY = getpass(\"Enter your Telnyx API key: \")"
+      ],
+      "metadata": {
+        "id": "FS-aHTpVKQoL"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Create Telnyx Client"
+      ],
+      "metadata": {
+        "id": "scKD2ATMKTvN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from openai import OpenAI\n",
+        "\n",
+        "client = OpenAI(\n",
+        "    api_key=TELNYX_API_KEY,\n",
+        "    base_url=\"https://api.telnyx.com/v2/ai/openai\",\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "StdEKbhHKVdU"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Create a Small Knowledge Base\n",
+        "\n",
+        "For this example, we’ll use a few short support documents.\n",
+        "\n",
+        "In a real application, these could come from help center articles, product docs, PDFs, tickets, or internal runbooks."
+      ],
+      "metadata": {
+        "id": "rK903g7CKfW6"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "documents = [\n",
+        "    {\n",
+        "        \"title\": \"API Key Authentication\",\n",
+        "        \"text\": \"\"\"\n",
+        "Telnyx API requests require a valid API key. If a request returns a 401 error,\n",
+        "check that the API key is active, correctly copied, and has the required permissions.\n",
+        "After rotating an API key, make sure production services are using the new key and\n",
+        "that no old key is cached in environment variables or deployment secrets.\n",
+        "\"\"\"\n",
+        "    },\n",
+        "    {\n",
+        "        \"title\": \"Rate Limits\",\n",
+        "        \"text\": \"\"\"\n",
+        "A 429 error means too many requests were sent in a short period of time.\n",
+        "Applications should use exponential backoff and avoid retry loops that immediately\n",
+        "resend failed requests. If retries are too aggressive, they can increase traffic and\n",
+        "make rate limit errors worse.\n",
+        "\"\"\"\n",
+        "    },\n",
+        "    {\n",
+        "        \"title\": \"Webhook Troubleshooting\",\n",
+        "        \"text\": \"\"\"\n",
+        "Webhook delivery issues can happen when endpoint URLs are incorrect, authentication\n",
+        "headers are missing, or downstream services reject requests. Check request logs,\n",
+        "response codes, and recent configuration changes when debugging webhook failures.\n",
+        "\"\"\"\n",
+        "    },\n",
+        "    {\n",
+        "        \"title\": \"Verification Message Delivery\",\n",
+        "        \"text\": \"\"\"\n",
+        "If users are not receiving verification messages, check message delivery logs,\n",
+        "provider response codes, destination formatting, and whether the signup flow depends\n",
+        "on a backend job that may be failing.\n",
+        "\"\"\"\n",
+        "    },\n",
+        "    {\n",
+        "        \"title\": \"Billing Support\",\n",
+        "        \"text\": \"\"\"\n",
+        "For duplicate charges or invoice questions, collect the account name, invoice IDs,\n",
+        "charge dates, charge amounts, and billing contact. Billing issues are usually not\n",
+        "urgent unless they block account access or service usage.\n",
+        "\"\"\"\n",
+        "    },\n",
+        "]"
+      ],
+      "metadata": {
+        "id": "pW7lX_ncKggb"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Generate Embeddings\n",
+        "\n",
+        "Embeddings turn text into vectors. Similar pieces of text have similar vectors.\n",
+        "\n",
+        "We’ll create one embedding per document using Telnyx’s embedding model."
+      ],
+      "metadata": {
+        "id": "uorBuOYSKln7"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Embedding model: turns documents and questions into vectors for retrieval.\n",
+        "embedding_model = \"thenlper/gte-large\"\n",
+        "\n",
+        "texts = [doc[\"text\"] for doc in documents]\n",
+        "\n",
+        "embedding_response = client.embeddings.create(\n",
+        "    model=embedding_model,\n",
+        "    input=texts,\n",
+        ")\n",
+        "\n",
+        "for doc, item in zip(documents, embedding_response.data):\n",
+        "    doc[\"embedding\"] = item.embedding\n",
+        "\n",
+        "print(f\"Created embeddings for {len(documents)} documents.\")\n",
+        "print(f\"Embedding dimensions: {len(documents[0]['embedding'])}\")\n"
+      ],
+      "metadata": {
+        "id": "uqqWT8a3Knx4"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Build a Sample Retriever\n",
+        "\n",
+        "For this demo, we’ll use NumPy to compare embeddings in memory.\n",
+        "\n",
+        "This keeps the notebook simple and easy to run in Colab. In production, you would usually store and search embeddings with a vector database or search system such as pgvector, ApertureData, Weaviate, Qdrant, Elasticsearch, or another retrieval layer.\n"
+      ],
+      "metadata": {
+        "id": "P_h3JszkKv_q"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "def cosine_similarity(a, b):\n",
+        "    a = np.array(a)\n",
+        "    b = np.array(b)\n",
+        "    return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))\n",
+        "\n",
+        "def retrieve(query, top_k=3):\n",
+        "    query_embedding = client.embeddings.create(\n",
+        "        model=embedding_model,\n",
+        "        input=query,\n",
+        "    ).data[0].embedding\n",
+        "\n",
+        "    scored_docs = []\n",
+        "\n",
+        "    for doc in documents:\n",
+        "        score = cosine_similarity(query_embedding, doc[\"embedding\"])\n",
+        "        scored_docs.append({\n",
+        "            \"title\": doc[\"title\"],\n",
+        "            \"text\": doc[\"text\"],\n",
+        "            \"score\": score,\n",
+        "        })\n",
+        "\n",
+        "    scored_docs = sorted(scored_docs, key=lambda x: x[\"score\"], reverse=True)\n",
+        "\n",
+        "    return scored_docs[:top_k]\n"
+      ],
+      "metadata": {
+        "id": "65QCtBf_Kxqw"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Ask a Question"
+      ],
+      "metadata": {
+        "id": "_NPrZnPgWD7S"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "question = \"\"\"\n",
+        "Our production signup flow broke after rotating an API key.\n",
+        "Users are not receiving verification codes, and logs show 401 errors.\n",
+        "What should we check first?\n",
+        "\"\"\"\n",
+        "\n",
+        "retrieved_docs = retrieve(question, top_k=3)\n",
+        "\n",
+        "for i, doc in enumerate(retrieved_docs, start=1):\n",
+        "    print(f\"{i}. {doc['title']} — score: {doc['score']:.3f}\")"
+      ],
+      "metadata": {
+        "id": "9wXlCnjEWFrY"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Build Context for the Model"
+      ],
+      "metadata": {
+        "id": "-cCXYft2WLvr"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "context = \"\\n\\n\".join(\n",
+        "    f\"Source: {doc['title']}\\n{doc['text']}\"\n",
+        "    for doc in retrieved_docs\n",
+        ")\n",
+        "\n",
+        "print(context)"
+      ],
+      "metadata": {
+        "id": "hZnpz7sQWOPo"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Generate a RAG Answer"
+      ],
+      "metadata": {
+        "id": "daMuaLgvWPbJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Chat model: generates the final answer using the retrieved context.\n",
+        "chat_model = \"moonshotai/Kimi-K2.6\"\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=chat_model,\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": (\n",
+        "                \"You are a helpful support assistant. \"\n",
+        "                \"Answer the user's question using only the provided context. \"\n",
+        "                \"If the context does not contain the answer, say you don't know.\"\n",
+        "            )\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": f\"\"\"\n",
+        "Context:\n",
+        "{context}\n",
+        "\n",
+        "Question:\n",
+        "{question}\n",
+        "\n",
+        "Answer with:\n",
+        "1. A short answer\n",
+        "2. The most relevant sources\n",
+        "\"\"\"\n",
+        "        }\n",
+        "    ],\n",
+        "    temperature=0.2,\n",
+        ")\n",
+        "\n",
+        "print(response.choices[0].message.content)"
+      ],
+      "metadata": {
+        "id": "U6pTcENBWS-X"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Try Your Own Question\n",
+        "\n",
+        "Change the question below and run the next cells again.\n"
+      ],
+      "metadata": {
+        "id": "3D28iw9zWdch"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "question = \"A customer says they were charged twice this month. What information should we collect?\"\n",
+        "\n",
+        "retrieved_docs = retrieve(question, top_k=3)\n",
+        "\n",
+        "context = \"\\n\\n\".join(\n",
+        "    f\"Source: {doc['title']}\\n{doc['text']}\"\n",
+        "    for doc in retrieved_docs\n",
+        ")\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=chat_model,\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": (\n",
+        "                \"You are a helpful support assistant. \"\n",
+        "                \"Answer the user's question using only the provided context. \"\n",
+        "                \"If the context does not contain the answer, say you don't know.\"\n",
+        "            )\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": f\"\"\"\n",
+        "Context:\n",
+        "{context}\n",
+        "\n",
+        "Question:\n",
+        "{question}\n",
+        "\n",
+        "Answer with:\n",
+        "1. A short answer\n",
+        "2. The most relevant sources\n",
+        "\"\"\"\n",
+        "        }\n",
+        "    ],\n",
+        "    temperature=0.2,\n",
+        ")\n",
+        "\n",
+        "print(\"Retrieved sources:\")\n",
+        "for doc in retrieved_docs:\n",
+        "    print(\"-\", doc[\"title\"])\n",
+        "\n",
+        "print(\"\\nAnswer:\")\n",
+        "print(response.choices[0].message.content)\n"
+      ],
+      "metadata": {
+        "id": "Wsqx0r_VWfqT"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## What Just Happened?\n",
+        "\n",
+        "You built a simple RAG pipeline:\n",
+        "\n",
+        "1. Embedded each document with Telnyx Inference\n",
+        "2. Embedded the user's question\n",
+        "3. Compared the question embedding to each document embedding\n",
+        "4. Retrieved the most relevant documents\n",
+        "5. Passed those documents into a Telnyx chat model as context\n",
+        "6. Generated an answer grounded in the retrieved sources\n",
+        "\n",
+        "This example stores vectors in memory. In production, you would usually store embeddings in a vector database or search system."
+      ],
+      "metadata": {
+        "id": "8NnyB5fJWmve"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Next Steps\n",
+        "\n",
+        "Try extending this notebook by:\n",
+        "\n",
+        "- Adding more documents\n",
+        "- Splitting long documents into chunks\n",
+        "- Returning more or fewer retrieved sources\n",
+        "- Showing source citations in the final answer\n",
+        "- Storing embeddings in a vector database\n",
+        "- Using your own docs, tickets, or knowledge base content"
+      ],
+      "metadata": {
+        "id": "NTfGdW8OWsfL"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Explore More\n",
+        "\n",
+        "Want to build more with Telnyx Inference?\n",
+        "\n",
+        "- Browse the Telnyx Inference docs: https://developers.telnyx.com/docs/inference\n",
+        "- Learn about Telnyx Inference getting started: https://developers.telnyx.com/docs/inference/getting-started\n",
+        "- Explore Telnyx on GitHub: https://github.com/team-telnyx\n",
+        "- Try the Telnyx Mission Control Portal: https://portal.telnyx.com/"
+      ],
+      "metadata": {
+        "id": "61I6aoahWvh9"
+      }
+    }
+  ]
+}

--- a/cookbooks/inference/04_Transcription_Translation.ipynb
+++ b/cookbooks/inference/04_Transcription_Translation.ipynb
@@ -1,0 +1,385 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "authorship_tag": "ABX9TyP1iiol+LW9hZ3HnmPoAAcR",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/04_Transcription_Translation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Build a Transcription and Translation Pipeline with Telnyx AI"
+      ],
+      "metadata": {
+        "id": "JR7brw__NDCF"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In this cookbook, you'll build a simple pipeline that takes an audio file, transcribes it with Telnyx Speech-to-Text, and translates the transcript to English with Telnyx Inference.\n",
+        "\n",
+        "This notebook uses:\n",
+        "\n",
+        "- Speech-to-Text model: `openai/whisper-large-v3-turbo`\n",
+        "- Translation model: `moonshotai/Kimi-K2.5`\n",
+        "- Transcription API: `https://developers.telnyx.com/docs/voice/stt/rest-api`\n",
+        "- Transcription models: `https://developers.telnyx.com/docs/voice/stt/models`\n",
+        "- Chat completions endpoint: `https://api.telnyx.com/v2/ai/chat/completions`"
+      ],
+      "metadata": {
+        "id": "FnxAiECfNJh5"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BHS52RlMLHee"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install requests"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Set up API Key"
+      ],
+      "metadata": {
+        "id": "i6hl0O9sNrMr"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "from getpass import getpass\n",
+        "\n",
+        "os.environ[\"TELNYX_API_KEY\"] = getpass(\"Enter your Telnyx API key: \")"
+      ],
+      "metadata": {
+        "id": "3-VL7AXrNtPp"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Set Model Names"
+      ],
+      "metadata": {
+        "id": "0R9zCnF7N2W8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "STT_MODEL = \"openai/whisper-large-v3-turbo\"\n",
+        "TRANSLATION_MODEL = \"moonshotai/Kimi-K2.5\"\n",
+        "# For this transcription + translation cookbook, if we use direct requests calls, use:\n",
+        "TELNYX_API_BASE = \"https://api.telnyx.com\""
+      ],
+      "metadata": {
+        "id": "rakBI8HWN5jF"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Upload an audio file\n",
+        "\n",
+        "Upload an audio file that contains speech you want to transcribe and translate.\n",
+        "\n",
+        "Supported formats include `.mp3`, `.mp4`, `.m4a`, `.wav`, `.flac`, `.ogg`, and `.webm`."
+      ],
+      "metadata": {
+        "id": "t4ty57HGeToB"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import files\n",
+        "from pathlib import Path\n",
+        "from IPython.display import Audio, display\n",
+        "\n",
+        "uploaded = files.upload()\n",
+        "\n",
+        "uploaded_audio_path = Path(next(iter(uploaded.keys())))\n",
+        "\n",
+        "print(f\"Uploaded file: {uploaded_audio_path}\")\n",
+        "print(f\"File size: {uploaded_audio_path.stat().st_size:,} bytes\")\n",
+        "\n",
+        "display(Audio(str(uploaded_audio_path)))"
+      ],
+      "metadata": {
+        "id": "LL44yVWJeqys"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "audio_path = uploaded_audio_path"
+      ],
+      "metadata": {
+        "id": "q3aYDB9RB8YH"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Transcribe the audio\n",
+        "\n",
+        "Send the audio file to the Telnyx Speech-to-Text API.\n",
+        "\n",
+        "This example uses `openai/whisper-large-v3-turbo` for multilingual transcription."
+      ],
+      "metadata": {
+        "id": "1yWQaH51hOvh"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "import requests\n",
+        "import mimetypes\n",
+        "from pprint import pprint\n",
+        "\n",
+        "TRANSCRIPTION_URL = f\"{TELNYX_API_BASE}/v2/ai/audio/transcriptions\"\n",
+        "\n",
+        "headers = {\n",
+        "    \"Authorization\": f\"Bearer {os.environ['TELNYX_API_KEY']}\"\n",
+        "}\n",
+        "\n",
+        "mime_type = mimetypes.guess_type(audio_path.name)[0] or \"application/octet-stream\"\n",
+        "\n",
+        "with open(audio_path, \"rb\") as audio_file:\n",
+        "    files_payload = {\n",
+        "        \"file\": (audio_path.name, audio_file, mime_type)\n",
+        "    }\n",
+        "\n",
+        "    data = {\n",
+        "        \"model\": STT_MODEL,\n",
+        "        \"response_format\": \"verbose_json\"\n",
+        "    }\n",
+        "\n",
+        "    transcription_response = requests.post(\n",
+        "        TRANSCRIPTION_URL,\n",
+        "        headers=headers,\n",
+        "        files=files_payload,\n",
+        "        data=data,\n",
+        "        timeout=300,\n",
+        "    )\n",
+        "\n",
+        "print(\"Status:\", transcription_response.status_code)\n",
+        "print(\"Response:\", transcription_response.text)\n",
+        "\n",
+        "transcription_response.raise_for_status()\n",
+        "transcription = transcription_response.json()\n",
+        "\n",
+        "print(\"Full transcription response:\")\n",
+        "pprint(transcription)"
+      ],
+      "metadata": {
+        "id": "bbTs5dksgQN_"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(\"Transcript text:\")\n",
+        "transcript_text = transcription.get(\"text\") or transcription.get(\"transcript\")\n",
+        "\n",
+        "print(transcript_text)"
+      ],
+      "metadata": {
+        "id": "N2dTgUUahwuA"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Translate the transcript\n",
+        "\n",
+        "Now send the transcript to a Telnyx-hosted LLM and ask it to translate the text into English.\n",
+        "\n",
+        "This example uses `moonshotai/Kimi-K2.5` for translation."
+      ],
+      "metadata": {
+        "id": "hi2M_HbTiPIH"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "CHAT_COMPLETIONS_URL = f\"{TELNYX_API_BASE}/v2/ai/chat/completions\"\n",
+        "\n",
+        "translation_payload = {\n",
+        "    \"model\": TRANSLATION_MODEL,\n",
+        "    \"messages\": [\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": (\n",
+        "                \"Translate the provided transcript faithfully into English. \"\n",
+        "                \"Do not summarize, omit, redact, or add commentary.\"\n",
+        "            ),\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": transcript_text,\n",
+        "        },\n",
+        "    ],\n",
+        "    \"temperature\": 0,\n",
+        "}\n",
+        "\n",
+        "translation_response = requests.post(\n",
+        "    CHAT_COMPLETIONS_URL,\n",
+        "    headers={\n",
+        "        \"Authorization\": f\"Bearer {os.environ['TELNYX_API_KEY']}\",\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "    },\n",
+        "    json=translation_payload,\n",
+        "    timeout=300,\n",
+        ")\n",
+        "\n",
+        "print(\"Status:\", translation_response.status_code)\n",
+        "print(\"Response:\", translation_response.text)\n",
+        "\n",
+        "translation_response.raise_for_status()\n",
+        "translation = translation_response.json()"
+      ],
+      "metadata": {
+        "id": "XyDzcUUDiQ0h"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "translated_text = translation[\"choices\"][0][\"message\"][\"content\"]\n",
+        "\n",
+        "print(translated_text)"
+      ],
+      "metadata": {
+        "id": "SiAl3ghPiUj8"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Save the transcript and translation\n",
+        "\n",
+        "The reference pipeline writes separate files for the source transcript, English translation, and metadata.\n",
+        "\n",
+        "This notebook saves the same three outputs locally in Colab."
+      ],
+      "metadata": {
+        "id": "xjFygd8aifcO"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import json\n",
+        "from datetime import datetime, timezone\n",
+        "\n",
+        "source_output_path = Path(\"telnyx-spanish-support-sample.source.txt\")\n",
+        "english_output_path = Path(\"telnyx-spanish-support-sample.en.txt\")\n",
+        "metadata_output_path = Path(\"telnyx-spanish-support-sample.meta.json\")\n",
+        "\n",
+        "metadata = {\n",
+        "    \"source_audio_file\": str(audio_path),\n",
+        "    \"source_transcript_file\": str(source_output_path),\n",
+        "    \"english_translation_file\": str(english_output_path),\n",
+        "    \"stt_model\": STT_MODEL,\n",
+        "    \"translation_model\": TRANSLATION_MODEL,\n",
+        "    \"completed_at\": datetime.now(timezone.utc).isoformat(),\n",
+        "}\n",
+        "\n",
+        "source_output_path.write_text(transcript_text, encoding=\"utf-8\")\n",
+        "english_output_path.write_text(translated_text, encoding=\"utf-8\")\n",
+        "metadata_output_path.write_text(\n",
+        "    json.dumps(metadata, indent=2, ensure_ascii=False),\n",
+        "    encoding=\"utf-8\",\n",
+        ")\n",
+        "\n",
+        "print(\"Saved files:\")\n",
+        "print(source_output_path)\n",
+        "print(english_output_path)\n",
+        "print(metadata_output_path)"
+      ],
+      "metadata": {
+        "id": "I6MThwpjigC9"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Optionally you can download these files from Google colab as follows\":\n",
+        "from google.colab import files\n",
+        "\n",
+        "files.download(source_output_path)\n",
+        "files.download(english_output_path)\n",
+        "files.download(metadata_output_path)"
+      ],
+      "metadata": {
+        "id": "ntIynNKLikNQ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Explore More\n",
+        "*   Want to build more with Telnyx Inference? Try the Telnyx Mission Control Portal: https://portal.telnyx.com/\n",
+        "*   Browse Telnyx Inference docs: https://developers.telnyx.com/docs/inference\n",
+        "*   Explore Telnyx examples on GitHub: https://github.com/team-telnyx/telnyx-code-examples\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "eFqAVskCE5Ak"
+      }
+    }
+  ]
+}

--- a/cookbooks/inference/README.md
+++ b/cookbooks/inference/README.md
@@ -1,0 +1,25 @@
+# Telnyx Inference Cookbooks
+
+Hands-on Colab notebooks for building with Telnyx Inference and related Telnyx AI APIs. These cookbooks show how to call Telnyx-hosted models through OpenAI-compatible clients, extract structured data, build retrieval-augmented generation flows, and combine speech-to-text with translation.
+
+## Cookbooks
+
+| Cookbook | What it covers | Launch |
+| --- | --- | --- |
+| [First Chat Completion with Telnyx Inference](./01_Chat_completion_telnyx_inference.ipynb) | Install the OpenAI SDK, configure a Telnyx-backed client, and send a first chat completion request. | [Open in Colab](https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/01_Chat_completion_telnyx_inference.ipynb) |
+| [Structured JSON Extraction with Telnyx Inference](./02_Structured_JSON_Extraction.ipynb) | Extract structured JSON from messy tickets, emails, leads, contracts, or incident reports. | [Open in Colab](https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/02_Structured_JSON_Extraction.ipynb) |
+| [RAG with Telnyx Inference](./03_RAG_Telnyx_Inference.ipynb) | Build a lightweight retrieval-augmented generation workflow using embeddings and chat completions. | [Open in Colab](https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/03_RAG_Telnyx_Inference.ipynb) |
+| [Transcription and Translation Pipeline with Telnyx AI](./04_Transcription_Translation.ipynb) | Transcribe audio with Telnyx Speech-to-Text, then translate the transcript with Telnyx Inference. | [Open in Colab](https://colab.research.google.com/github/team-telnyx/telnyx-code-examples/blob/main/cookbooks/inference/04_Transcription_Translation.ipynb) |
+
+## Requirements
+
+- A Telnyx API key
+- Google Colab or another Python notebook environment
+- The `openai` Python SDK
+
+## Getting Started
+
+1. Open a cookbook in GitHub or Colab.
+2. Add your Telnyx API key when prompted.
+3. Run the cells from top to bottom.
+4. Modify the prompts, models, or generation settings for your own workflow.


### PR DESCRIPTION
## Summary

Moves the Telnyx Inference cookbook notebooks from the external staging repo into `team-telnyx/telnyx-code-examples` under `cookbooks/inference/`.

## Changes

- Adds `cookbooks/README.md` and `cookbooks/inference/README.md` so the notebooks are discoverable from the repo.
- Links the root `README.md` to the new cookbook directory.
- Adds four Colab notebooks:
  - `01_Chat_completion_telnyx_inference.ipynb`
  - `02_Structured_JSON_Extraction.ipynb`
  - `03_RAG_Telnyx_Inference.ipynb`
  - `04_Transcription_Translation.ipynb`
- Updates all Colab badges to the canonical `team-telnyx/telnyx-code-examples` path.
- Standardizes notebook 04 STT guidance and code on `openai/whisper-large-v3-turbo`.
- Strips saved notebook outputs and execution counts for consistent notebook hygiene.

## Validation

- Parsed all four notebooks as JSON.
- Confirmed notebooks have zero saved outputs and zero non-null execution counts.
- Confirmed no remaining references to `sonamg-droid/telnyx-inference`, `team-telnyx/ai`, `deepgram/flux-multilingual`, or `deepgram/nova-3` in the cookbook files.
