### PR TITLE
Fix RAG embeddings endpoint handling

### DIFF
--- a/build-rag-with-telnyx-inference-python/README.md
+++ b/build-rag-with-telnyx-inference-python/README.md
@@ -13,7 +13,7 @@ Build a retrieval-augmented generation API with Telnyx embeddings and chat compl
 
 ## Telnyx API Endpoints Used
 
-- **Embeddings**: `POST /v2/ai/embeddings` - create vectors for documents and questions
+- **Embeddings**: `POST /v2/ai/openai/embeddings` - create vectors for documents and questions
 - **AI Inference**: `POST /v2/ai/chat/completions` - [API reference](https://developers.telnyx.com/api/inference/chat-completions)
 
 ## Architecture

--- a/build-rag-with-telnyx-inference-python/app.py
+++ b/build-rag-with-telnyx-inference-python/app.py
@@ -79,14 +79,28 @@ def _headers() -> dict:
 
 def create_embeddings(inputs: str | list[str]) -> list[list[float]]:
     _require_api_key()
+    input_values = [inputs] if isinstance(inputs, str) else inputs
     response = requests.post(
-        f"{API_BASE}/embeddings",
+        f"{API_BASE}/openai/embeddings",
         headers=_headers(),
-        json={"model": EMBEDDING_MODEL, "input": inputs},
+        json={
+            "model": EMBEDDING_MODEL,
+            "input": input_values,
+        },
         timeout=60,
     )
     response.raise_for_status()
-    return [item["embedding"] for item in response.json()["data"]]
+    payload = response.json()
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise RuntimeError("Unexpected embeddings response shape.")
+
+    embeddings = []
+    for item in data:
+        if not isinstance(item, dict) or not isinstance(item.get("embedding"), list):
+            raise RuntimeError("Unexpected embeddings response shape.")
+        embeddings.append(item["embedding"])
+    return embeddings
 
 
 def cosine_similarity(left: Iterable[float], right: Iterable[float]) -> float:
@@ -183,6 +197,8 @@ def rag_ask():
         }), 200
     except requests.HTTPError as exc:
         status = exc.response.status_code if exc.response is not None else 502
+        if exc.response is not None:
+            app.logger.warning("Telnyx AI Inference request failed with status %s", status)
         return jsonify({"error": "Telnyx AI Inference request failed.", "status": status}), status
     except RuntimeError as exc:
         app.logger.exception("Runtime error while processing /rag/ask request")


### PR DESCRIPTION
## Summary

- Use the OpenAI-compatible embeddings endpoint for the RAG example: `/v2/ai/openai/embeddings`
- Normalize single-string embedding input into a list before sending the request
- Validate the embeddings response shape before reading vectors
- Keep client-facing HTTP errors generic while logging the failed upstream status server-side
- Update the README endpoint list to match the code

## Verification

- Ran `python3 -m py_compile build-rag-with-telnyx-inference-python/app.py` locally

## Notes

- This PR intentionally avoids returning upstream API response details in the Flask error response.