### PR TITLE
Fix lead enrichment for reasoning models + correct Number Lookup field mapping

### DIFF
--- a/number-lookup-lead-enrichment-python/.env.example
+++ b/number-lookup-lead-enrichment-python/.env.example
@@ -1,3 +1,3 @@
 TELNYX_API_KEY=your_telnyx_api_key
-AI_MODEL=moonshotai/Kimi-K2.6
+AI_MODEL=MiniMaxAI/MiniMax-M3-MXFP8
 HOST=127.0.0.1

--- a/number-lookup-lead-enrichment-python/README.md
+++ b/number-lookup-lead-enrichment-python/README.md
@@ -44,7 +44,7 @@ Copy `.env.example` to `.env` and fill in:
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
 | `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
-| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
+| `AI_MODEL` | `string` | `MiniMaxAI/MiniMax-M3-MXFP8` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
 | `PORT` | `integer` | `5000` | no | HTTP server port | - |
 
 ## Setup

--- a/number-lookup-lead-enrichment-python/app.py
+++ b/number-lookup-lead-enrichment-python/app.py
@@ -6,9 +6,30 @@ from flask import Flask, request, jsonify
 load_dotenv()
 app = Flask(__name__)
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
-AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+AI_MODEL = os.getenv("AI_MODEL", "MiniMaxAI/MiniMax-M3-MXFP8")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 enriched_leads = []
+
+def _extract_json(text):
+    if not text:
+        return None
+    s = text.strip()
+    if s.startswith("```"):
+        s = s.split("```", 2)[1]
+        if s.startswith("json"):
+            s = s[4:]
+        s = s.strip()
+    start = s.find("{")
+    end = s.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        s = s[start:end + 1]
+    return s
+
+def parse_json_response(result):
+    payload = _extract_json(result)
+    if not payload:
+        return None
+    return json.loads(payload)
 
 def lookup_number(phone):
     try:
@@ -19,7 +40,7 @@ def lookup_number(phone):
         pass
     return {}
 
-def call_inference(messages, max_tokens=200):
+def call_inference(messages, max_tokens=1500):
     resp = requests.post(INFERENCE_URL, headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
         json={"model": AI_MODEL, "messages": messages, "max_tokens": max_tokens, "temperature": 0.3}, timeout=15)
     resp.raise_for_status()
@@ -34,14 +55,24 @@ def enrich_lead():
     if not phone:
         return jsonify({"error": "phone_number required"}), 400
     lookup = lookup_number(phone)
-    carrier = lookup.get("carrier", {})
-    cnam = lookup.get("caller_name", {})
-    enrichment = {"phone": phone, "carrier_name": carrier.get("name"), "carrier_type": carrier.get("type"), "caller_name": cnam.get("caller_name"), "line_type": lookup.get("phone_number", {}).get("type"), "country": lookup.get("country_code")}
-    msgs = [{"role": "system", "content": "Score this lead based on phone data. Return JSON: lead_quality (hot/warm/cold), reasoning (string), is_mobile (boolean), is_voip (boolean), recommended_channel (sms/voice/email)."},
+    carrier = lookup.get("carrier") or {}
+    cnam = lookup.get("caller_name") or {}
+    portability = lookup.get("portability") or {}
+    enrichment = {
+        "phone": phone,
+        "carrier_name": carrier.get("name"),
+        "carrier_type": carrier.get("type"),
+        "caller_name": cnam.get("caller_name"),
+        "line_type": portability.get("line_type") or carrier.get("type"),
+        "country": lookup.get("country_code"),
+        "valid_number": lookup.get("valid_number"),
+    }
+    msgs = [{"role": "system", "content": "Score this lead based on phone data. Return only JSON, no prose, no markdown fences: lead_quality (hot/warm/cold), reasoning (string), is_mobile (boolean), is_voip (boolean), recommended_channel (sms/voice/email)."},
         {"role": "user", "content": json.dumps(enrichment)}]
     try:
-        score = json.loads(call_inference(msgs))
-        enrichment["score"] = score
+        score = parse_json_response(call_inference(msgs))
+        if score:
+            enrichment["score"] = score
     except Exception:
         pass
     enriched_leads.append(enrichment)
@@ -56,7 +87,15 @@ def enrich_bulk():
     results = []
     for phone in numbers[:50]:
         lookup = lookup_number(phone)
-        results.append({"phone": phone, "carrier": lookup.get("carrier", {}).get("name"), "type": lookup.get("phone_number", {}).get("type")})
+        carrier = lookup.get("carrier") or {}
+        portability = lookup.get("portability") or {}
+        results.append({
+            "phone": phone,
+            "carrier": carrier.get("name"),
+            "type": portability.get("line_type") or carrier.get("type"),
+            "country": lookup.get("country_code"),
+            "valid": lookup.get("valid_number"),
+        })
     return jsonify({"results": results, "total": len(results)}), 200
 
 @app.route("/health", methods=["GET"])


### PR DESCRIPTION
## What & why

This example was broken end-to-end for two reasons:

### 1. Reasoning model compatibility
Default `moonshotai/Kimi-K2.6` returns `content: null` when `max_tokens` is too small (was 200) because the reasoning step consumes the token budget before any content is emitted. When content is returned, models often wrap JSON in ````json``` fences, so `json.loads` fails.

### 2. Number Lookup response field bug
`lookup.get("phone_number", {}).get("type")` crashed with `AttributeError` because `phone_number` is a string (the E.164 number), not a dict. `line_type` actually lives at `data.portability.line_type`.

## Changes (`number-lookup-lead-enrichment-python/`)
- **app.py**: switch default model to `MiniMaxAI/MiniMax-M3-MXFP8`, raise `max_tokens` 200 -> 1500, add `_extract_json`/`parse_json_response` helpers, tighten system prompt to request JSON-only output, fix `line_type` to read from `portability.line_type`, null-safe carrier/cnam/portability access, add `valid_number` to enrichment and bulk results.
- **.env.example**: `AI_MODEL` example updated to `MiniMaxAI/MiniMax-M3-MXFP8`.
- **README.md**: environment variable table example value updated to match.

## Verified
Tested locally against Telnyx Number Lookup + AI Inference (MiniMax M3):
- `POST /enrich` returns carrier, line_type, country, valid_number, and AI score (lead_quality, is_mobile, is_voip, recommended_channel)
- `POST /enrich/bulk` returns 4 numbers with carrier/type/country/valid
- `GET /health` returns status and enriched count

Also tested with `zai-org/GLM-5.2` as an alternative reasoning model.

## Compatibility
No breaking changes to request/response shape. Non-reasoning models (e.g. `meta-llama/Llama-3.3-70B-Instruct`) also work — the fence-stripper is a no-op when the model already returns bare JSON.