### PR TITLE
Fix reputation monitor for reasoning models (MiniMax M3, GLM-5.2)

### DIFF
--- a/number-reputation-monitor-auto-rotate-python/.env.example
+++ b/number-reputation-monitor-auto-rotate-python/.env.example
@@ -1,4 +1,4 @@
 TELNYX_API_KEY=your_telnyx_api_key
-AI_MODEL=moonshotai/Kimi-K2.6
+AI_MODEL=MiniMaxAI/MiniMax-M3-MXFP8
 ALERT_NUMBER=+1xxxxxxxxxx
 HOST=127.0.0.1

--- a/number-reputation-monitor-auto-rotate-python/README.md
+++ b/number-reputation-monitor-auto-rotate-python/README.md
@@ -42,7 +42,7 @@ Copy `.env.example` to `.env` and fill in:
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
 | `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
-| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
+| `AI_MODEL` | `string` | `MiniMaxAI/MiniMax-M3-MXFP8` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
 | `ALERT_NUMBER` | `string` | `your_value` | **yes** | Alert number | - |
 | `PORT` | `integer` | `5000` | no | HTTP server port | - |
 

--- a/number-reputation-monitor-auto-rotate-python/app.py
+++ b/number-reputation-monitor-auto-rotate-python/app.py
@@ -7,10 +7,31 @@ import threading, time as _ttl_time
 load_dotenv()
 app = Flask(__name__)
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
-AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+AI_MODEL = os.getenv("AI_MODEL", "MiniMaxAI/MiniMax-M3-MXFP8")
 ALERT_NUMBER = os.getenv("ALERT_NUMBER")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 number_health = {}  # number -> {calls, complaints, answer_rate, flagged}
+
+def _extract_json(text):
+    if not text:
+        return None
+    s = text.strip()
+    if s.startswith("```"):
+        s = s.split("```", 2)[1]
+        if s.startswith("json"):
+            s = s[4:]
+        s = s.strip()
+    start = s.find("{")
+    end = s.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        s = s[start:end + 1]
+    return s
+
+def parse_json_response(result):
+    payload = _extract_json(result)
+    if not payload:
+        return None
+    return json.loads(payload)
 
 def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
     def _cleanup():
@@ -38,10 +59,10 @@ def get_numbers():
     return []
 
 def analyze_health(number_data):
-    messages = [{"role": "system", "content": "Analyze phone number health metrics. Return JSON: risk_level (healthy/warning/critical), recommendation (keep/rotate/retire), reasoning (string)."},
+    messages = [{"role": "system", "content": "Analyze phone number health metrics. Return only JSON, no prose, no markdown fences: risk_level (healthy/warning/critical), recommendation (keep/rotate/retire), reasoning (string)."},
         {"role": "user", "content": json.dumps(number_data)}]
     resp = requests.post(INFERENCE_URL, headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
-        json={"model": AI_MODEL, "messages": messages, "max_tokens": 150, "temperature": 0.2}, timeout=15)
+        json={"model": AI_MODEL, "messages": messages, "max_tokens": 800, "temperature": 0.2}, timeout=15)
     resp.raise_for_status()
     return resp.json()["choices"][0]["message"]["content"]
 
@@ -53,7 +74,10 @@ def scan_numbers():
         phone = num.get("phone_number", "")
         health = number_health.get(phone, {"calls": 0, "complaints": 0, "answer_rate": 0.5})
         try:
-            analysis = json.loads(analyze_health({**health, "number": phone}))
+            analysis = parse_json_response(analyze_health({**health, "number": phone}))
+            if analysis is None:
+                results.append({"number": phone, "analysis": {"risk_level": "unknown"}})
+                continue
             number_health[phone] = {**health, "analysis": analysis, "last_scan": time.time()}
             if analysis.get("recommendation") == "rotate":
                 rotation_log.append({"number": phone, "reason": analysis.get("reasoning", "flagged"), "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ")})


### PR DESCRIPTION
## What & why

Same class of bug as PRs #31 and #33: the default reasoning model (`moonshotai/Kimi-K2.6`) returned `content: null` when `max_tokens` was too small (was 150) because reasoning consumes the token budget before any content is emitted. When content was returned, models often wrapped JSON in ````json``` fences, so `json.loads` failed.

## Changes (`number-reputation-monitor-auto-rotate-python/`)
- **app.py**: switch default model to `MiniMaxAI/MiniMax-M3-MXFP8`, raise `max_tokens` 150 -> 800, add `_extract_json`/`parse_json_response` helpers, tighten system prompt to request JSON-only output, null-safe analysis when `parse_json_response` returns `None`.
- **.env.example**: `AI_MODEL` example updated to `MiniMaxAI/MiniMax-M3-MXFP8`.
- **README.md**: environment variable table example value updated to match.

## Verified
Tested locally against Telnyx Number Management + AI Inference (MiniMax M3):
- `POST /scan` pulls real numbers from the account and returns per-number `risk_level` + `recommendation` (keep/rotate/retire)
- `GET /health-report` returns tracked numbers and rotation log
- `GET /health` returns counts

Also tested with `zai-org/GLM-5.2` as an alternative reasoning model.

## Compatibility
No breaking changes to request/response shape. Non-reasoning models (e.g. `meta-llama/Llama-3.3-70B-Instruct`) also work — the fence-stripper is a no-op when the model already returns bare JSON.