### PR TITLE
Fix call-whisper-monitoring: recording start, webhook paths, Telnyx STT+Inference, web dashboard

### DIFF
--- a/call-whisper-monitoring-python/.env.example
+++ b/call-whisper-monitoring-python/.env.example
@@ -1,5 +1,4 @@
 TELNYX_API_KEY=your_telnyx_api_key
-OPENAI_API_KEY=your_openai_api_key
 TELNYX_PHONE_NUMBER=+1xxxxxxxxxx
 TELNYX_CONNECTION_ID=your_connection_id
 TELNYX_PUBLIC_KEY=your_telnyx_public_key

--- a/call-whisper-monitoring-python/README.md
+++ b/call-whisper-monitoring-python/README.md
@@ -7,14 +7,17 @@ framework: flask
 telnyx_products: [AI Assistants, SMS/MMS, Voice, Call Recording]
 ---
 
-# Production-ready Flask application for Whisper-based call prompts via Telnyx.
+# Post-Call Monitoring with Telnyx STT, Inference, and Call Control
 
-Voice application. Built with Telnyx AI Assistants, Migration, Number Porting, SMS/MMS.
+Post-call analysis application. Triggers an outbound call, records the audio, transcribes it with Telnyx Speech-to-Text, generates an AI response with Telnyx Inference, and displays everything in a web dashboard. Built with Telnyx AI Assistants, Call Control, Call Recording, and AI Inference — no external AI provider required.
 
 ## Telnyx API Endpoints Used
 
-- **Call Control: Answer**: `POST /v2/calls/{id}/actions/answer` - [API reference](https://developers.telnyx.com/api/call-control/answer-call)
+- **Call Control: Dial**: `POST /v2/calls` - [API reference](https://developers.telnyx.com/api/call-control/create-call)
+- **Call Control: Start Recording**: `POST /v2/calls/{id}/actions/start_recording` - [API reference](https://developers.telnyx.com/api/call-control/start-recording)
 - **Call Control: Speak (TTS)**: `POST /v2/calls/{id}/actions/speak` - [API reference](https://developers.telnyx.com/api/call-control/speak)
+- **AI Speech-to-Text**: `POST /v2/ai/audio/transcriptions` - [API reference](https://developers.telnyx.com/docs/ai/speech-to-text)
+- **AI Inference (Chat)**: `POST /v2/ai/openai/chat/completions` - [API reference](https://developers.telnyx.com/docs/ai/inference)
 
 ## Telnyx Webhook Events
 
@@ -27,20 +30,32 @@ This app handles these webhook events ([Call Control docs](https://developers.te
 ## Architecture
 
 ```
-  Inbound Phone Call
+  POST /calls/initiate
         │
         ▼
-  ┌──────────────────┐
-  │ Call Control      │
-  └────────┬─────────┘
-           │
-           ├──► TTS
-           ├──► STT
-           ├──► Call Recording
-           │
-           ▼
-     Voice response
+  ┌──────────────────────┐
+  │  Telnyx Call Control  │  ──► outbound call rings
+  └──────────┬───────────┘
+             │  call.answered → start recording
+             │  call.hangup
+             ▼
+  ┌──────────────────────┐
+  │  Flask app            │
+  │  in-memory call_state │
+  └──────────┬───────────┘
+             │  call.recording.saved webhook
+             ▼
+  ┌──────────────────────┐
+  │  download audio       │
+  │  → Telnyx STT         │
+  │  → Telnyx Inference   │
+  │  → Telnyx TTS (speak) │
+  └──────────────────────┘
+             │
+             └──► dashboard shows transcript + AI response
 ```
+
+This is **post-call analysis**: the transcript and AI response appear in the web dashboard seconds after the call ends. TTS is attempted on the live call but gracefully skipped if the call has already hung up (the recording webhook arrives ~5 seconds after hangup).
 
 ## Environment Variables
 
@@ -49,10 +64,9 @@ Copy `.env.example` to `.env` and fill in:
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
 | `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
-| `OPENAI_API_KEY` | `string` | `your_value` | **yes** | Openai api key | - |
-| `TELNYX_PHONE_NUMBER` | `string` | `your_value` | **yes** | Telnyx phone number | - |
-| `TELNYX_CONNECTION_ID` | `string` | `your_value` | **yes** | Telnyx connection id | - |
-| `FLASK_DEBUG` | `string` | `false` | no | Flask debug | - |
+| `TELNYX_PHONE_NUMBER` | `string` | `+13125551234` | **yes** | Telnyx phone number | [Portal](https://portal.telnyx.com/numbers) |
+| `TELNYX_CONNECTION_ID` | `string` | `2771215234625439469` | **yes** | Call Control Application ID | [Portal](https://portal.telnyx.com/call-control) |
+| `TELNYX_PUBLIC_KEY` | `string` | `URQCA17ti...` | **yes** | Telnyx public key (for webhook signature verification) | [Portal](https://portal.telnyx.com/api-keys) |
 
 ## Setup
 
@@ -74,7 +88,16 @@ python app.py           # starts on http://localhost:5000
 
 2. Copy the HTTPS URL and configure in [Telnyx Portal](https://portal.telnyx.com):
 
-   - **Call Control Application** → Webhook URL → `https://<id>.ngrok.io/webhooks/voice`
+   - **Call Control Application** → Webhook URL → `https://<id>.ngrok.io/webhooks/call`
+
+### Web Dashboard
+
+Open `http://localhost:5000` in your browser after starting the server. The dashboard lets you:
+
+- Enter a phone number and trigger a call with one click
+- Watch a live event timeline as webhooks arrive (call initiated → answered → recording → hangup → transcript → AI response)
+- View the transcript and AI response in cards after the call ends
+- Phone numbers are masked in the UI for privacy
 
 ## API Reference
 
@@ -103,7 +126,7 @@ curl -X POST http://localhost:5000/calls/initiate \
 
 ### `GET /calls/<call_control_id>/status`
 
-Retrieve call status and transcript.
+Retrieve call status, transcript, and AI response.
 
 ```bash
 curl http://localhost:5000/calls/example-id/status
@@ -113,15 +136,12 @@ curl http://localhost:5000/calls/example-id/status
 
 ```json
 {
-  "calls": [
-    {
-      "call_id": "v3:uMi2qMWHT-mLFGkEm4t9tA",
-      "from": "+18005551234",
-      "to": "+12125559876",
-      "duration_seconds": 145,
-      "status": "completed"
-    }
-  ]
+  "call_control_id": "v3:uMi2qMWHT-mLFGkEm4t9tA",
+  "is_alive": false,
+  "state": "hangup",
+  "transcript": "Hello, this is Harpreet. Who am I talking to today?",
+  "ai_response": "Good morning, Harpreet. I'm an AI assistant. How can I help you today?",
+  "spoken": false
 }
 ```
 
@@ -168,6 +188,8 @@ Receives [Telnyx Call Control](https://developers.telnyx.com/docs/voice/call-con
 | `401 Unauthorized` | Invalid or missing API key | Verify `TELNYX_API_KEY` in `.env` matches your key in the [Portal](https://portal.telnyx.com/api-keys) |
 | Webhook not received | Local server not publicly reachable | Expose it with a tunnel (e.g. ngrok) and set the webhook URL in the [Telnyx Portal](https://portal.telnyx.com) |
 | `422 Unprocessable Entity` | Missing or malformed request fields | Check the request body against the API Reference above |
+| TTS skipped (`spoken: false`) | Call already hung up before recording was processed | Expected behavior — `call.recording.saved` arrives ~5s after hangup. The transcript and AI response are still captured for post-call analysis. |
+| Recording webhook never fires | Recording not enabled on the Call Control Application | Enable recording on the Call Control Application in the [Portal](https://portal.telnyx.com/call-control), or the app starts recording programmatically on `call.answered` |
 
 ## Related Examples
 
@@ -180,6 +202,11 @@ Receives [Telnyx Call Control](https://developers.telnyx.com/docs/voice/call-con
 ## Resources
 
 - [Call Control Guide](https://developers.telnyx.com/docs/voice/call-control)
+- [Call Recording Webhooks](https://developers.telnyx.com/docs/voice/call-control/recording)
+- [Telnyx Speech-to-Text](https://developers.telnyx.com/docs/ai/speech-to-text)
+- [Telnyx AI Inference](https://developers.telnyx.com/docs/ai/inference)
+- [Telnyx Speak (TTS) API](https://developers.telnyx.com/api-reference/call-commands/speak-text)
+- [Telnyx Python SDK](https://github.com/team-telnyx/telnyx-python)
 - [Telnyx Developer Docs](https://developers.telnyx.com)
 - [Telnyx Portal](https://portal.telnyx.com)
 

--- a/call-whisper-monitoring-python/app.py
+++ b/call-whisper-monitoring-python/app.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Production-ready Flask application for Whisper-based call prompts via Telnyx."""
+"""Production-ready Flask application for Whisper-based call prompts via Telnyx.
+
+Uses Telnyx for call control + recording + TTS, and Telnyx Inference
+(OpenAI-compatible) for transcription (Whisper) and chat (Kimi K2.6).
+No separate OpenAI API key required.
+"""
 
 import os
 import json
@@ -14,10 +19,24 @@ load_dotenv()
 
 app = Flask(__name__)
 
-# Initialize clients with the new SDK pattern
-telnyx_client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"), public_key=os.getenv("TELNYX_PUBLIC_KEY"))
+# Initialize Telnyx client for call control + TTS + webhook verification
+telnyx_client = telnyx.Telnyx(
+    api_key=os.getenv("TELNYX_API_KEY"),
+    public_key=os.getenv("TELNYX_PUBLIC_KEY"),
+)
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
-openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# Telnyx Inference is OpenAI-compatible — same SDK, different base_url + key.
+ai_client = OpenAI(
+    api_key=os.getenv("TELNYX_API_KEY"),
+    base_url="https://api.telnyx.com/v2/ai/openai",
+)
+stt_client = OpenAI(
+    api_key=os.getenv("TELNYX_API_KEY"),
+    base_url="https://api.telnyx.com/v2/ai",
+)
+STT_MODEL = "openai/whisper-large-v3-turbo"
+CHAT_MODEL = "moonshotai/Kimi-K2.6"
 
 # In-memory store for call state (use Redis in production)
 call_state = {}
@@ -74,15 +93,13 @@ def initiate_call(to_number: str) -> dict:
 
 
 def transcribe_audio(audio_url: str) -> str:
-    """Download audio from URL and transcribe using OpenAI Whisper."""
+    """Download audio from URL and transcribe using Telnyx STT (Whisper)."""
     try:
-        # Download audio file from Telnyx
         response = requests.get(audio_url, timeout=10)
         response.raise_for_status()
         
-        # Transcribe using Whisper API
-        transcript_response = openai_client.audio.transcriptions.create(
-            model="whisper-1",
+        transcript_response = stt_client.audio.transcriptions.create(
+            model=STT_MODEL,
             file=("audio.wav", response.content, "audio/wav"),
         )
         
@@ -92,10 +109,10 @@ def transcribe_audio(audio_url: str) -> str:
 
 
 def generate_prompt_response(transcript: str) -> str:
-    """Generate an AI response based on transcribed text."""
+    """Generate an AI response based on transcribed text using Telnyx Inference."""
     try:
-        response = openai_client.chat.completions.create(
-            model="gpt-4",
+        response = ai_client.chat.completions.create(
+            model=CHAT_MODEL,
             messages=[
                 {
                     "role": "system",
@@ -104,6 +121,7 @@ def generate_prompt_response(transcript: str) -> str:
                 {"role": "user", "content": transcript},
             ],
             max_tokens=100,
+            extra_body={"enable_thinking": False},
         )
         return response.choices[0].message.content
     except Exception as e:
@@ -112,16 +130,13 @@ def generate_prompt_response(transcript: str) -> str:
 
 def speak_response(call_control_id: str, text: str) -> dict:
     """Use Telnyx Speak action to play text-to-speech response."""
-    try:
-        response = telnyx_client.calls.actions.speak(
-            call_control_id=call_control_id,
-            payload=text,
-            language="en-US",
-            voice="female",
-        )
-        return {"status": "speaking", "call_control_id": call_control_id}
-    except Exception as e:
-        return {"error": "Internal server error"}
+    response = telnyx_client.calls.actions.speak(
+        call_control_id=call_control_id,
+        payload=text,
+        language="en-US",
+        voice="female",
+    )
+    return {"status": "speaking", "call_control_id": call_control_id}
 
 
 @app.route("/calls/initiate", methods=["POST"])
@@ -171,30 +186,49 @@ def handle_call_webhook():
         return jsonify({"error": "No payload"}), 400
     
     event_type = payload.get("data", {}).get("event_type")
-    call_control_id = payload.get("data", {}).get("call_control_id")
+    call_control_id = payload.get("data", {}).get("payload", {}).get("call_control_id") or payload.get("data", {}).get("call_control_id")
     
-    # Handle call.answered event
+    print(f"[WEBHOOK] event_type={event_type} call_control_id={call_control_id}")
+    
+    # Handle call.answered event — start recording so we get call.recording.saved later
     if event_type == "call.answered":
         if call_control_id in call_state:
             call_state[call_control_id]["status"] = "answered"
+            try:
+                telnyx_client.calls.actions.start_recording(
+                    call_control_id=call_control_id,
+                    format="wav",
+                    channels="single",
+                )
+                print(f"[RECORDING] started for {call_control_id}")
+            except Exception as e:
+                print(f"[RECORDING ERROR] {e}")
         return jsonify({"status": "acknowledged"}), 200
     
     # Handle call.recording.saved event (audio ready for transcription)
     if event_type == "call.recording.saved":
-        recording_url = payload.get("data", {}).get("recording_urls", {}).get("wav")
+        data_payload = payload.get("data", {}).get("payload", payload.get("data", {}))
+        recording_url = data_payload.get("recording_urls", {}).get("wav")
+        print(f"[RECORDING] recording_url={recording_url} in_state={call_control_id in call_state}")
         
         if recording_url and call_control_id in call_state:
             try:
-                # Transcribe the audio
                 transcript = transcribe_audio(recording_url)
                 call_state[call_control_id]["transcript"] = transcript
-                
-                # Generate AI response
+                print(f"[TRANSCRIPT] {transcript[:200]}")
+
                 ai_response = generate_prompt_response(transcript)
-                
-                # Speak the response back to caller
-                speak_result = speak_response(call_control_id, ai_response)
-                
+                call_state[call_control_id]["ai_response"] = ai_response
+                print(f"[AI RESPONSE] {ai_response[:200]}")
+
+                try:
+                    speak_result = speak_response(call_control_id, ai_response)
+                    call_state[call_control_id]["spoken"] = True
+                    print(f"[TTS] {speak_result}")
+                except Exception as tts_err:
+                    call_state[call_control_id]["spoken"] = False
+                    print(f"[TTS] skipped (call no longer live): {tts_err}")
+
                 return jsonify({
                     "status": "processed",
                     "transcript": transcript,
@@ -202,6 +236,7 @@ def handle_call_webhook():
                 }), 200
                 
             except Exception as e:
+                print(f"[ERROR] {e}")
                 return jsonify({"error": "Internal server error"}), 500
     
     # Handle call.hangup event
@@ -228,6 +263,8 @@ def get_call_status(call_control_id):
             "is_alive": response.data.is_alive,
             "state": call_state[call_control_id]["status"],
             "transcript": call_state[call_control_id]["transcript"],
+            "ai_response": call_state[call_control_id].get("ai_response", ""),
+            "spoken": call_state[call_control_id].get("spoken", False),
         }), 200
         
     except telnyx.APIStatusError as e:
@@ -236,6 +273,406 @@ def get_call_status(call_control_id):
         return jsonify({"error": "Network error"}), 503
 
 
+
+@app.route("/", methods=["GET"])
+def index():
+    return """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Call Whisper Monitoring</title>
+<style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  :root{
+    --bg:#0f1117;--bg-elev:#1a1b26;--bg-elev2:#22232e;
+    --border:#2a2d3a;--border-strong:#3a3d4a;
+    --text:#e4e4e7;--text-dim:#a1a1aa;--text-faint:#71717a;
+    --accent:#e91e63;--accent-hover:#d11553;
+    --success:#22c55e;--warning:#f59e0b;--info:#3b82f6;
+  }
+  body{
+    background:var(--bg);color:var(--text);
+    font-family:-apple-system,BlinkMacSystemFont,'SF Pro Text','Segoe UI',system-ui,sans-serif;
+    min-height:100vh;line-height:1.5;
+  }
+  .container{max-width:1100px;margin:0 auto;padding:32px 24px}
+  /* Header */
+  header{display:flex;align-items:center;justify-content:space-between;padding-bottom:24px;border-bottom:1px solid var(--border);margin-bottom:32px}
+  .brand{display:flex;align-items:center;gap:12px}
+  .brand-logo{
+    width:40px;height:40px;border-radius:10px;
+    background:linear-gradient(135deg,var(--accent),#9d174d);
+    display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:18px;color:#fff;
+  }
+  .brand h1{font-size:18px;font-weight:600;color:#fff;letter-spacing:-0.3px}
+  .brand .sub{font-size:12px;color:var(--text-faint);margin-top:2px}
+  .status-pill{
+    display:flex;align-items:center;gap:8px;
+    padding:6px 12px;border-radius:999px;
+    background:rgba(34,197,94,0.1);border:1px solid rgba(34,197,94,0.3);
+    font-size:12px;color:var(--success);font-weight:500;
+  }
+  .pulse{width:8px;height:8px;border-radius:50%;background:var(--success);animation:pulse 2s infinite}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:0.4}}
+  /* Call form */
+  .call-bar{
+    display:flex;gap:12px;align-items:flex-end;
+    background:var(--bg-elev);border:1px solid var(--border);
+    border-radius:12px;padding:20px;margin-bottom:24px;
+  }
+  .field{flex:1;display:flex;flex-direction:column;gap:6px}
+  .field label{font-size:12px;color:var(--text-faint);font-weight:500;text-transform:uppercase;letter-spacing:0.5px}
+  .field input{
+    background:var(--bg);border:1px solid var(--border-strong);border-radius:8px;
+    padding:11px 14px;color:var(--text);font-size:15px;font-family:'SF Mono','Menlo',monospace;
+    outline:none;transition:border-color 0.15s;
+  }
+  .field input:focus{border-color:var(--accent)}
+  .field input::placeholder{color:var(--text-faint)}
+  .btn{
+    padding:11px 20px;border-radius:8px;border:none;cursor:pointer;
+    font-size:14px;font-weight:600;font-family:inherit;
+    transition:all 0.15s;
+  }
+  .btn-primary{background:var(--accent);color:#fff}
+  .btn-primary:hover:not(:disabled){background:var(--accent-hover)}
+  .btn-primary:disabled{background:var(--border-strong);color:var(--text-faint);cursor:not-allowed}
+  .btn-secondary{background:transparent;color:var(--text-dim);border:1px solid var(--border-strong)}
+  .btn-secondary:hover{background:var(--bg-elev2);color:var(--text)}
+  /* Empty state */
+  .empty{
+    background:var(--bg-elev);border:1px solid var(--border);
+    border-radius:12px;padding:60px 24px;text-align:center;
+  }
+  .empty-icon{
+    width:56px;height:56px;border-radius:50%;
+    background:var(--bg-elev2);border:1px solid var(--border);
+    display:flex;align-items:center;justify-content:center;
+    margin:0 auto 16px;color:var(--text-faint);font-size:24px;
+  }
+  .empty h2{font-size:16px;color:var(--text-dim);margin-bottom:6px}
+  .empty p{font-size:13px;color:var(--text-faint)}
+  /* Active call view */
+  .call-view{display:grid;gap:24px}
+  .card{
+    background:var(--bg-elev);border:1px solid var(--border);
+    border-radius:12px;padding:24px;
+  }
+  .card-header{
+    display:flex;align-items:center;justify-content:space-between;
+    margin-bottom:16px;
+  }
+  .card-title{font-size:13px;font-weight:600;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.5px}
+  .badge{
+    padding:4px 10px;border-radius:999px;font-size:11px;font-weight:600;
+    text-transform:uppercase;letter-spacing:0.5px;
+  }
+  .badge-waiting{background:rgba(113,113,122,0.15);color:var(--text-faint)}
+  .badge-active{background:rgba(59,130,246,0.15);color:var(--info)}
+  .badge-processing{background:rgba(245,158,11,0.15);color:var(--warning)}
+  .badge-complete{background:rgba(34,197,94,0.15);color:var(--success)}
+  /* Timeline */
+  .timeline{display:flex;flex-direction:column;gap:2px}
+  .event{
+    display:flex;align-items:flex-start;gap:14px;
+    padding:12px 0;opacity:0.35;transition:opacity 0.3s;
+  }
+  .event.done{opacity:1}
+  .event-dot{
+    width:24px;height:24px;border-radius:50%;
+    background:var(--bg-elev2);border:2px solid var(--border-strong);
+    display:flex;align-items:center;justify-content:center;
+    flex-shrink:0;font-size:11px;color:var(--text-faint);
+  }
+  .event.done .event-dot{background:var(--success);border-color:var(--success);color:#0f1117}
+  .event-body{flex:1;padding-top:2px}
+  .event-title{font-size:14px;color:var(--text);font-weight:500}
+  .event-time{font-size:12px;color:var(--text-faint);margin-top:2px}
+  /* Result cards */
+  .result-card{
+    border-left:3px solid var(--accent);
+    padding:16px 18px;background:var(--bg-elev2);border-radius:0 8px 8px 0;
+    margin-top:8px;
+  }
+  .result-card .label{font-size:11px;color:var(--text-faint);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;font-weight:600}
+  .result-card .value{font-size:15px;color:var(--text);line-height:1.6}
+  .result-card.transcript{border-left-color:var(--info)}
+  .result-card.transcript .label{color:var(--info)}
+  .result-card.ai{border-left-color:var(--accent)}
+  .result-card.ai .label{color:var(--accent)}
+  .result-card.tts{border-left-color:var(--text-faint)}
+  .result-card.tts .value{font-size:13px;color:var(--text-dim)}
+  .result-placeholder{font-size:13px;color:var(--text-faint);font-style:italic;padding:8px 0}
+  .call-meta{display:flex;gap:20px;font-size:12px;color:var(--text-faint);margin-bottom:16px}
+  .call-meta span code{background:var(--bg-elev2);padding:2px 6px;border-radius:4px;font-family:'SF Mono',monospace;color:var(--text-dim)}
+  .actions{display:flex;gap:10px;margin-top:20px}
+</style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <div class="brand">
+      <div class="brand-logo">T</div>
+      <div>
+        <h1>Call Whisper Monitoring</h1>
+        <div class="sub">Post-call transcription and AI analysis</div>
+      </div>
+    </div>
+    <div class="status-pill"><span class="pulse"></span> Server running</div>
+  </header>
+
+  <div class="call-bar">
+    <div class="field">
+      <label for="to">Phone number</label>
+      <input id="to" type="password" placeholder="+1XXXXXXXXXX" autocomplete="off">
+    </div>
+    <button id="startBtn" class="btn btn-primary" onclick="startCall()">Start Call</button>
+    <button id="newBtn" class="btn btn-secondary" onclick="resetUI()" style="display:none">Start New Call</button>
+  </div>
+
+  <div id="emptyState" class="empty">
+    <div class="empty-icon">&#9742;</div>
+    <h2>No active call</h2>
+    <p>Enter a phone number above and click Start Call to begin monitoring.</p>
+  </div>
+
+  <div id="callView" class="call-view" style="display:none">
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title" id="callStateLabel">Call Status</span>
+        <span id="stateBadge" class="badge badge-waiting">Waiting</span>
+      </div>
+      <div class="call-meta">
+        <span>To: <code id="metaTo">—</code></span>
+        <span>Call ID: <code id="metaId">—</code></span>
+      </div>
+      <div class="timeline" id="timeline">
+        <div class="event" id="ev-initiated">
+          <div class="event-dot">1</div>
+          <div class="event-body">
+            <div class="event-title">Call initiated</div>
+            <div class="event-time" id="t-initiated">—</div>
+          </div>
+        </div>
+        <div class="event" id="ev-answered">
+          <div class="event-dot">2</div>
+          <div class="event-body">
+            <div class="event-title">Call answered &amp; recording started</div>
+            <div class="event-time" id="t-answered">—</div>
+          </div>
+        </div>
+        <div class="event" id="ev-hangup">
+          <div class="event-dot">3</div>
+          <div class="event-body">
+            <div class="event-title">Call ended</div>
+            <div class="event-time" id="t-hangup">—</div>
+          </div>
+        </div>
+        <div class="event" id="ev-recording">
+          <div class="event-dot">4</div>
+          <div class="event-body">
+            <div class="event-title">Recording saved &amp; processing</div>
+            <div class="event-time" id="t-recording">—</div>
+          </div>
+        </div>
+        <div class="event" id="ev-stt">
+          <div class="event-dot">5</div>
+          <div class="event-body">
+            <div class="event-title">Transcribed with Telnyx STT</div>
+            <div class="event-time" id="t-stt">—</div>
+          </div>
+        </div>
+        <div class="event" id="ev-ai">
+          <div class="event-dot">6</div>
+          <div class="event-body">
+            <div class="event-title">AI response generated</div>
+            <div class="event-time" id="t-ai">—</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header"><span class="card-title">Results</span></div>
+      <div class="result-card transcript">
+        <div class="label">Caller Transcript</div>
+        <div class="value" id="transcript">
+          <span class="result-placeholder">Transcription will appear here after the call ends…</span>
+        </div>
+      </div>
+      <div class="result-card ai">
+        <div class="label">AI Assistant Response</div>
+        <div class="value" id="aiResponse">
+          <span class="result-placeholder">AI response will appear here after transcription completes…</span>
+        </div>
+      </div>
+      <div class="result-card tts">
+        <div class="label">TTS Playback</div>
+        <div class="value" id="ttsStatus"><span class="result-placeholder">—</span></div>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button class="btn btn-secondary" onclick="resetUI()">Start New Call</button>
+    </div>
+  </div>
+</div>
+
+<script>
+let pollTimer=null;
+let callControlId=null;
+let seenStates=new Set();
+
+function fmtTime(d){return new Date(d).toLocaleTimeString('en-US',{hour12:false})}
+function maskPhone(p){if(!p)return '—';if(p.length<=4)return '****';return p.slice(0,3)+'****'+p.slice(-2)}
+
+function setStateBadge(text,cls){
+  const b=document.getElementById('stateBadge');
+  b.textContent=text;
+  b.className='badge '+cls;
+}
+
+function markEvent(evId,timeStr){
+  const ev=document.getElementById(evId);
+  if(ev && !ev.classList.contains('done')){
+    ev.classList.add('done');
+    const t=document.getElementById('t-'+evId.replace('ev-',''));
+    if(t) t.textContent=timeStr;
+  }
+}
+
+async function startCall(){
+  const to=document.getElementById('to').value.trim();
+  if(!to){alert('Enter a phone number');return;}
+  const btn=document.getElementById('startBtn');
+  btn.disabled=true;btn.textContent='Initiating…';
+  try{
+    const r=await fetch('/calls/initiate',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({to:to})
+    });
+    const data=await r.json();
+    if(!r.ok) throw new Error(data.error||'Failed to start call');
+    callControlId=data.call_control_id;
+    showCallView(to);
+    setStateBadge('Call initiated','badge-active');
+    markEvent('ev-initiated',fmtTime(new Date()));
+    startPolling();
+  }catch(e){
+    alert('Error: '+e.message);
+    btn.disabled=false;btn.textContent='Start Call';
+  }
+}
+
+function showCallView(to){
+  document.getElementById('emptyState').style.display='none';
+  document.getElementById('callView').style.display='grid';
+  document.getElementById('metaTo').textContent=maskPhone(to);
+  document.getElementById('metaId').textContent=callControlId;
+  document.getElementById('startBtn').style.display='none';
+  document.getElementById('newBtn').style.display='inline-block';
+  document.getElementById('newBtn').disabled=true;
+}
+
+function startPolling(){
+  if(pollTimer) clearInterval(pollTimer);
+  pollTimer=setInterval(poll,2000);
+}
+
+async function poll(){
+  if(!callControlId) return;
+  try{
+    const r=await fetch('/calls/'+callControlId+'/status');
+    const data=await r.json();
+    updateUI(data);
+    if(isComplete(data)) stopPolling();
+  }catch(e){console.error('poll error',e)}
+}
+
+function updateUI(data){
+  const now=fmtTime(new Date());
+  const state=data.state;
+  // Map backend state to timeline events
+  if(state==='initiated' && !seenStates.has('initiated')){
+    seenStates.add('initiated');
+    setStateBadge('Ringing','badge-active');
+  }
+  if(state==='answered' && !seenStates.has('answered')){
+    seenStates.add('answered');
+    setStateBadge('In progress','badge-active');
+    markEvent('ev-answered',now);
+  }
+  if(state==='hangup' && !seenStates.has('hangup')){
+    seenStates.add('hangup');
+    setStateBadge('Processing','badge-processing');
+    markEvent('ev-hangup',now);
+    markEvent('ev-recording',now);
+  }
+  if(data.transcript && !seenStates.has('transcript')){
+    seenStates.add('transcript');
+    markEvent('ev-stt',now);
+    document.getElementById('transcript').innerHTML='';
+    document.getElementById('transcript').textContent=data.transcript;
+  }
+  if(data.ai_response && !seenStates.has('ai')){
+    seenStates.add('ai');
+    markEvent('ev-ai',now);
+    document.getElementById('aiResponse').innerHTML='';
+    document.getElementById('aiResponse').textContent=data.ai_response;
+  }
+  // TTS status
+  if(seenStates.has('ai')){
+    const tts=document.getElementById('ttsStatus');
+    if(data.spoken===true){
+      tts.innerHTML='<span style="color:var(--success);font-weight:500">Spoken on call &#10003;</span>';
+    }else if(data.spoken===false){
+      tts.innerHTML='Post-call analysis (call ended before TTS) — transcript &amp; AI response captured for review';
+    }
+  }
+  if(isComplete(data)){
+    setStateBadge('Complete','badge-complete');
+    document.getElementById('newBtn').disabled=false;
+  }
+}
+
+function isComplete(data){
+  return data.state==='hangup' && data.transcript && data.ai_response;
+}
+
+function stopPolling(){
+  if(pollTimer){clearInterval(pollTimer);pollTimer=null;}
+}
+
+function resetUI(){
+  stopPolling();
+  callControlId=null;
+  seenStates.clear();
+  document.getElementById('startBtn').disabled=false;
+  document.getElementById('startBtn').textContent='Start Call';
+  document.getElementById('startBtn').style.display='inline-block';
+  document.getElementById('newBtn').style.display='none';
+  document.getElementById('emptyState').style.display='block';
+  document.getElementById('callView').style.display='none';
+  // reset timeline
+  ['ev-initiated','ev-answered','ev-hangup','ev-recording','ev-stt','ev-ai'].forEach(id=>{
+    document.getElementById(id).classList.remove('done');
+  });
+  ['t-initiated','t-answered','t-hangup','t-recording','t-stt','t-ai'].forEach(id=>{
+    document.getElementById(id).textContent='—';
+  });
+  document.getElementById('transcript').innerHTML='<span class="result-placeholder">Transcription will appear here after the call ends…</span>';
+  document.getElementById('aiResponse').innerHTML='<span class="result-placeholder">AI response will appear here after transcription completes…</span>';
+  document.getElementById('ttsStatus').innerHTML='<span class="result-placeholder">—</span>';
+  setStateBadge('Waiting','badge-waiting');
+  document.getElementById('metaTo').textContent='—';
+  document.getElementById('metaId').textContent='—';
+}
+</script>
+</body>
+</html>"""
 
 @app.route("/health", methods=["GET"])
 def health():


### PR DESCRIPTION
## Summary

The `call-whisper-monitoring-python` example had **3 critical bugs** that made it completely non-functional, plus several significant issues. This PR fixes all of them and adds a web dashboard for the monitoring UI.

## Critical Fixes

### 1. Recording never started → entire pipeline was dead code

The `call.answered` webhook handler only updated in-memory state — it never called `start_recording()`. Without recording, `call.recording.saved` never fires, and the entire STT → chat → TTS pipeline below it is unreachable dead code.

**Fix:** Added `telnyx_client.calls.actions.start_recording()` on `call.answered`.

### 2. Wrong `call_control_id` extraction from webhook payload

```python
# Before (broken): wrong path
call_control_id = payload.get("data", {}).get("call_control_id")
```

Telnyx webhook v2 puts `call_control_id` inside `data.payload`, not `data` directly. So `call_control_id` was always `None`, and every webhook handler that checks `if call_control_id in call_state` silently failed.

**Fix:** `payload.get("data", {}).get("payload", {}).get("call_control_id") or payload.get("data", {}).get("call_control_id")`

### 3. Wrong `recording_url` extraction

```python
# Before (broken): wrong path
recording_url = payload.get("data", {}).get("recording_urls", {}).get("wav")
```

Same issue — `recording_urls` is in `data.payload`. Even with bugs #1 and #2 fixed, `recording_url` would be `None` and the transcription block would never execute.

**Fix:** `data_payload = payload.get("data", {}).get("payload", payload.get("data", {}))` then `data_payload.get("recording_urls", {}).get("wav")`.

## Significant Fixes

### 4. Swap OpenAI → Telnyx STT + Inference

The original code required an `OPENAI_API_KEY` for Whisper + GPT-4. Since Telnyx has built-in STT (`openai/whisper-large-v3-turbo`) and Inference (`moonshotai/Kimi-K2.6`) via OpenAI-compatible endpoints, the example now runs with a single Telnyx account — no external AI provider needed.

Uses two OpenAI SDK client instances with different `base_url` values:
- `stt_client` → `https://api.telnyx.com/v2/ai` (for audio transcriptions)
- `ai_client` → `https://api.telnyx.com/v2/ai/openai` (for chat completions)

### 5. `speak_response` no longer swallows exceptions

The original `catch Exception → return {"error": ...}` pattern prevented the webhook handler from detecting TTS failures. Now re-raises so the handler can gracefully skip TTS.

### 6. TTS gracefully skipped post-hangup

`call.recording.saved` arrives ~5 seconds after `call.hangup`, so the call is already dead when TTS fires. The original code would 500 the webhook. Now TTS is wrapped in its own try/except, marks `spoken=false`, and exposes it in `/status`.

### 7. `enable_thinking: False` for Telnyx Inference

Telnyx Inference with reasoning models (e.g. Kimi K2.6) returns `None` content by default because `enable_thinking=true`. Added `extra_body={"enable_thinking": False}` to get actual content.

## New Features

### 8. Web dashboard at `/`

Replaced the static HTML card with a full monitoring dashboard:
- Phone number input (masked with `type=password`) + Start Call button
- Live event timeline as webhook events arrive (6-step progress)
- Transcript card + AI response card after processing
- TTS status shown ("Spoken on call" vs "Post-call analysis")
- Dark theme matching Telnyx brand, self-contained (no external CDN deps)

### 9. `/status` endpoint enhanced

Now returns `ai_response` and `spoken` fields in addition to `call_control_id`, `is_alive`, `state`, and `transcript`.

## Files Changed

- `app.py` — 3 critical bug fixes, OpenAI→Telnyx swap, web dashboard, graceful TTS
- `.env.example` — removed `OPENAI_API_KEY`, kept 4 Telnyx values
- `README.md` — updated env vars, API endpoints, architecture diagram, status response, troubleshooting, dashboard docs, resources

## Verification

The full pipeline was tested end-to-end:
- `call.initiated` ✓
- `call.answered` ✓ → recording started ✓
- `call.hangup` ✓
- `call.recording.saved` ✓ → recording URL received ✓
- STT: "Hello, this is Harpreet. Who am I talking to today?" ✓
- AI: "Good morning, Harpreet. I'm an AI assistant. How can I help you today?" ✓
- TTS: gracefully skipped (call no longer live) ✓
- `/status` returns transcript + ai_response + spoken=false ✓

Demo video: https://youtu.be/mUmmtY3xXi8