### PR TITLE
Switch default AI model to Llama-3.3-70B-Instruct in 3 Week 4 examples

### DIFF
--- a/ai-negotiation-practice-phone-python/app.py
+++ b/ai-negotiation-practice-phone-python/app.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"), public_key=os.getenv("TELNYX_PUBLIC_KEY"))
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
-AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+AI_MODEL = os.getenv("AI_MODEL", "meta-llama/Llama-3.3-70B-Instruct")
 PRACTICE_NUMBER = os.getenv("PRACTICE_NUMBER")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 active_calls = {}

--- a/ai-phone-story-hotline-python/.env.example
+++ b/ai-phone-story-hotline-python/.env.example
@@ -1,5 +1,5 @@
 TELNYX_API_KEY=your_telnyx_api_key
-AI_MODEL=moonshotai/Kimi-K2.6
+AI_MODEL=meta-llama/Llama-3.3-70B-Instruct
 STORY_NUMBER=+1xxxxxxxxxx
 TELNYX_PUBLIC_KEY=your_telnyx_public_key
 HOST=127.0.0.1

--- a/ai-phone-story-hotline-python/README.md
+++ b/ai-phone-story-hotline-python/README.md
@@ -60,7 +60,7 @@ Copy `.env.example` to `.env` and fill in:
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
 | `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
-| `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
+| `AI_MODEL` | `string` | `meta-llama/Llama-3.3-70B-Instruct` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
 | `STORY_NUMBER` | `string` | `your_value` | **yes** | Story number | - |
 | `PORT` | `integer` | `5000` | no | HTTP server port | - |
 

--- a/ai-phone-story-hotline-python/app.py
+++ b/ai-phone-story-hotline-python/app.py
@@ -31,11 +31,8 @@ _start_ttl_cleanup(active_calls)
 GENRES = {"1": "mystery", "2": "sci-fi", "3": "fantasy", "4": "horror", "5": "romance"}
 
 def call_inference(messages, max_tokens=250):
-    try:
-        resp = requests.post(INFERENCE_URL, headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
+    resp = requests.post(INFERENCE_URL, headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
         json={"model": AI_MODEL, "messages": messages, "max_tokens": max_tokens, "temperature": 0.9}, timeout=20)
-    except Exception as e:
-        app.logger.error("Request failed: %s", e)
     resp.raise_for_status()
     return resp.json()["choices"][0]["message"]["content"]
 

--- a/ai-phone-story-hotline-python/app.py
+++ b/ai-phone-story-hotline-python/app.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"), public_key=os.getenv("TELNYX_PUBLIC_KEY"))
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
-AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+AI_MODEL = os.getenv("AI_MODEL", "meta-llama/Llama-3.3-70B-Instruct")
 STORY_NUMBER = os.getenv("STORY_NUMBER")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 active_calls = {}

--- a/ai-price-quote-phone-agent-python/app.py
+++ b/ai-price-quote-phone-agent-python/app.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"), public_key=os.getenv("TELNYX_PUBLIC_KEY"))
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
-AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+AI_MODEL = os.getenv("AI_MODEL", "meta-llama/Llama-3.3-70B-Instruct")
 QUOTE_NUMBER = os.getenv("QUOTE_NUMBER")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 active_calls = {}


### PR DESCRIPTION
## Changes

Switched the default  from  to  in 3 Week 4 code samples:

- 
- 
- 

## Why

Kimi-K2.6 returns  at 200 tokens. Llama-3.3-70B-Instruct works reliably with Telnyx AI Inference. Same fix applied to `edge-mcp-server-deploy-python` in PR #44.