### PR TITLE
Add AI Assistant filler messages demo app

### DIFF
--- a/ai-assistant-filler-messages-demo-python/.env.example
+++ b/ai-assistant-filler-messages-demo-python/.env.example
@@ -1,0 +1,3 @@
+TELNYX_API_KEY=your_telnyx_api_key_here
+WEBHOOK_DELAY_SECONDS=12
+PORT=5000

--- a/ai-assistant-filler-messages-demo-python/API.md
+++ b/ai-assistant-filler-messages-demo-python/API.md
@@ -1,0 +1,124 @@
+## `POST /webhook/order-status`
+
+Sync webhook endpoint that receives tool calls from the AI Assistant, intentionally delays, then returns mock order status. Streams real-time events to the dashboard via SSE during the delay.
+
+### Request
+
+```json
+{
+  "order_id": "12345"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `order_id` | `string` | yes | Order ID to look up (mock data: `12345`, `67890`, `11111`) |
+
+### Response `200`
+
+```json
+{
+  "result": {
+    "order_id": "12345",
+    "status": "shipped",
+    "carrier": "FedEx",
+    "tracking": "FX-98765",
+    "eta": "2026-07-20",
+    "items": ["Wireless Headset", "USB-C Cable"]
+  }
+}
+```
+
+**Try it:**
+
+```bash
+curl -X POST http://localhost:5000/webhook/order-status \
+  -H "Content-Type: application/json" \
+  -d '{"order_id": "12345"}'
+```
+
+---
+
+## `GET /`
+
+Serves the split-screen dashboard HTML page.
+
+### Response `200`
+
+HTML page with two panels:
+- **Left**: Call timeline showing tool calls, filler message indicators, and responses
+- **Right**: Webhook server log with request/response JSON and delay countdown
+
+**Try it:**
+
+Open `http://localhost:5000` in a browser.
+
+---
+
+## `GET /events`
+
+Server-Sent Events (SSE) stream for the dashboard. Emits these event types:
+
+| Event | When | Data |
+|-------|------|------|
+| `tool_call_received` | Webhook request arrives | `order_id`, `request_body`, `delay_seconds` |
+| `filler_message` | At webhook receipt (shows configured fillers) | `content`, `filler_type`, `timing_ms` |
+| `countdown` | Each second during delay | `elapsed`, `total`, `remaining` |
+| `response_sent` | Webhook responds | `order_id`, `response_body`, `duration_seconds` |
+
+**Try it:**
+
+```bash
+curl -N http://localhost:5000/events
+```
+
+---
+
+## `GET /health`
+
+Health check and service status.
+
+### Response `200`
+
+```json
+{
+  "status": "ok",
+  "delay_seconds": 12,
+  "connected_clients": 1
+}
+```
+
+**Try it:**
+
+```bash
+curl http://localhost:5000/health
+```
+
+---
+
+## Mock Order Data
+
+| Order ID | Status | Carrier | ETA |
+|----------|--------|---------|-----|
+| `12345` | shipped | FedEx | 2026-07-20 |
+| `67890` | processing | pending | 2026-07-25 |
+| `11111` | delivered | UPS | 2026-07-14 |
+
+## Error Handling
+
+All endpoints return JSON. On error:
+
+```json
+{
+  "result": {
+    "order_id": "99999",
+    "status": "not_found",
+    "error": "Order not found"
+  }
+}
+```
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Success |
+| `500` | Server error |

--- a/ai-assistant-filler-messages-demo-python/GUIDE.md
+++ b/ai-assistant-filler-messages-demo-python/GUIDE.md
@@ -106,6 +106,8 @@ Everything lives in `app.py` (~100 lines). Here's what each piece does.
 
 ## Step 5: Configure Filler Messages
 
+Filler messages **must be configured through the Mission Control UI**. While `setup.py` sets these values via the API, playback on calls only works when the messages are added through the UI's Filler Messages tab.
+
 In the tool settings, open the **Filler Messages** tab and add:
 
 | Type | Content | Timing |
@@ -113,6 +115,8 @@ In the tool settings, open the **Filler Messages** tab and add:
 | `request_start` | "Let me look that up for you." | immediate |
 | `request_response_delayed` | "Still working on this, one moment please." | 5000ms |
 | `request_response_delayed` | "Almost there, thanks for your patience." | 15000ms |
+
+Also verify the **tool-level timeout** is set to at least **30000ms**. The default (5000ms) is shorter than the webhook delay and will cause the assistant to time out before the webhook responds.
 
 This corresponds to the JSON configuration:
 

--- a/ai-assistant-filler-messages-demo-python/GUIDE.md
+++ b/ai-assistant-filler-messages-demo-python/GUIDE.md
@@ -1,0 +1,193 @@
+# Build a Filler Messages Demo for Telnyx AI Assistants
+
+Demonstrate how AI Assistant filler messages eliminate dead air during sync webhook tool calls. This guide walks through setting up a webhook server with a live dashboard, configuring filler messages in Mission Control, and recording a split-screen demo.
+
+## How It Works
+
+```
+  Caller dials AI Assistant
+        │
+        ▼
+  ┌──────────────────────┐
+  │ Telnyx AI Assistant   │
+  │ (Mission Control)     │
+  └────────┬─────────────┘
+           │ sync tool call
+           ▼
+  ┌──────────────────────┐    SSE     ┌──────────────────┐
+  │ Flask Webhook Server  │──────────►│ Browser Dashboard  │
+  │ (intentional delay)   │           │ (split-screen)     │
+  └──────────────────────┘           └──────────────────┘
+```
+
+When the AI Assistant invokes the `check_order_status` tool, the webhook server intentionally delays its response. During that delay, the AI Assistant speaks the configured filler messages to the caller. The dashboard shows both sides in real time — the call timeline and the server logs.
+
+## Telnyx Products Used
+
+- **AI Assistants** — Voice AI agent with sync webhook tools and filler messages
+
+## API Endpoints
+
+- **AI Assistants**: Sync webhook tool calls — [Docs](https://developers.telnyx.com/docs/voice/ai-assistants)
+
+## Prerequisites
+
+- Python 3.8+
+- [Telnyx account](https://portal.telnyx.com/sign-up) with funded balance
+- [API key](https://portal.telnyx.com/api-keys)
+- [ngrok](https://ngrok.com) or similar tunnel for exposing localhost
+- A phone number assigned to an AI Assistant
+
+## Step 1: Set Up the Project
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/ai-assistant-filler-messages-demo-python
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Edit `.env` with your credentials:
+
+```
+TELNYX_API_KEY=your_telnyx_api_key_here
+WEBHOOK_DELAY_SECONDS=12
+PORT=5000
+```
+
+The `WEBHOOK_DELAY_SECONDS` controls how long the webhook waits before responding. Set it long enough (10–15s) so multiple filler messages trigger.
+
+## Step 2: Understand the Code
+
+Everything lives in `app.py` (~100 lines). Here's what each piece does.
+
+### Webhook Endpoint
+
+**`webhook_order_status()`** — Receives the sync tool call from the AI Assistant, broadcasts SSE events to the dashboard, sleeps for the configured delay, then returns mock order data.
+
+### SSE Streaming
+
+**`events()`** — Server-Sent Events endpoint that pushes real-time updates to the dashboard: tool call received, filler message indicators, countdown ticks, and response sent.
+
+### Dashboard
+
+**`dashboard()`** — Serves the split-screen HTML page that connects to the SSE stream and renders events in two panels.
+
+### All Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/webhook/order-status` | Sync webhook endpoint for AI Assistant tool calls |
+| `GET` | `/` | Split-screen dashboard UI |
+| `GET` | `/events` | SSE event stream for dashboard |
+| `GET` | `/health` | Health check |
+
+## Step 3: Create the AI Assistant
+
+1. Go to [Mission Control](https://portal.telnyx.com) → AI → Assistants
+2. Create a new assistant (or edit an existing one)
+3. Assign a phone number to the assistant
+
+## Step 4: Add the Webhook Tool
+
+1. In the assistant settings, add a new **sync webhook tool**:
+   - **Name**: `check_order_status`
+   - **Description**: "Check the status of a customer order by order ID"
+   - **Parameters**: `order_id` (string, required)
+
+2. Start ngrok and set the webhook URL:
+
+   ```bash
+   ngrok http 5000
+   ```
+
+   Copy the HTTPS URL and set the tool's webhook URL to:
+   `https://<id>.ngrok.io/webhook/order-status`
+
+## Step 5: Configure Filler Messages
+
+In the tool settings, open the **Filler Messages** tab and add:
+
+| Type | Content | Timing |
+|------|---------|--------|
+| `request_start` | "Let me look that up for you." | immediate |
+| `request_response_delayed` | "Still working on this, one moment please." | 5000ms |
+| `request_response_delayed` | "Almost there, thanks for your patience." | 15000ms |
+
+This corresponds to the JSON configuration:
+
+```json
+{
+  "filler_messages": [
+    { "type": "request_start", "content": "Let me look that up for you." },
+    { "type": "request_response_delayed", "content": "Still working on this, one moment please.", "timing_ms": 5000 },
+    { "type": "request_response_delayed", "content": "Almost there, thanks for your patience.", "timing_ms": 15000 }
+  ]
+}
+```
+
+## Step 6: Run the Demo
+
+1. Start the Flask server:
+
+   ```bash
+   python app.py
+   ```
+
+2. Open `http://localhost:5000` in a browser — you'll see the split-screen dashboard.
+
+3. Call your AI Assistant's phone number.
+
+4. Ask: *"What's the status of my order 12345?"*
+
+5. Watch:
+   - The **dashboard** updates in real time (left: call timeline, right: server logs with countdown)
+   - The **phone call** plays filler messages while the webhook delays
+   - After the delay, the assistant reads back the order status
+
+## Step 7: Test Without a Phone Call
+
+You can test the webhook endpoint directly:
+
+```bash
+curl -X POST http://localhost:5000/webhook/order-status \
+  -H "Content-Type: application/json" \
+  -d '{"order_id": "12345"}'
+```
+
+Open the dashboard in a browser first to see the events stream in real time.
+
+## Step 8: Record the Demo Video
+
+For the demo video, set up a split-screen recording:
+
+1. **Left side**: The browser showing `http://localhost:5000` dashboard
+2. **Right side**: Terminal showing `python app.py` server output
+3. **Audio**: The phone call audio (use speakerphone or a recording app)
+
+Record the full flow: dial in → ask about an order → filler messages play → webhook responds → assistant delivers the answer.
+
+## Going to Production
+
+This example uses mock data and intentional delays. For production:
+
+- **Real data source** — Replace `MOCK_ORDERS` with actual database or API queries
+- **Remove artificial delay** — The delay exists only for demo purposes; real webhooks should respond as fast as possible
+- **Webhook verification** — Validate Telnyx webhook signatures
+- **Error handling** — Add timeout handling and retry logic
+- **Monitoring** — Add structured logging and alerting
+
+## Run
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+## Resources
+
+- [Source code and reference](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/ai-assistant-filler-messages-demo-python/README.md)
+- [AI Assistants Guide](https://developers.telnyx.com/docs/voice/ai-assistants)
+- [Filler Messages Release Note](https://telnyx.com/release-notes/webhook-tool-filler-messages)
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Telnyx Portal](https://portal.telnyx.com)

--- a/ai-assistant-filler-messages-demo-python/README.md
+++ b/ai-assistant-filler-messages-demo-python/README.md
@@ -1,0 +1,168 @@
+---
+name: ai-assistant-filler-messages-demo
+title: "AI Assistant Filler Messages Demo"
+description: "Webhook server with live split-screen dashboard for demoing AI Assistant filler messages during sync tool calls."
+language: python
+framework: flask
+telnyx_products: [AI Assistants]
+---
+
+# AI Assistant Filler Messages Demo
+
+Webhook server with live split-screen dashboard for demoing AI Assistant filler messages during sync tool calls. When an AI Assistant calls a sync webhook tool, filler messages let you configure scripted phrases the assistant speaks while waiting for the webhook response — eliminating dead air.
+
+## Telnyx API Endpoints Used
+
+- **AI Assistants**: Sync webhook tool calls — [AI Assistants docs](https://developers.telnyx.com/docs/voice/ai-assistants)
+- **Filler Messages**: Configured per-tool in Mission Control — [Release note](https://telnyx.com/release-notes/webhook-tool-filler-messages)
+
+## Architecture
+
+```
+  Caller dials AI Assistant
+        │
+        ▼
+  ┌──────────────────────┐
+  │ Telnyx AI Assistant   │
+  │ (Mission Control)     │
+  └────────┬─────────────┘
+           │ sync tool call
+           ▼
+  ┌──────────────────────┐    SSE     ┌──────────────────┐
+  │ Flask Webhook Server  │──────────►│ Browser Dashboard  │
+  │ POST /webhook/        │           │ Split-screen UI    │
+  │   order-status        │           │ (timeline + logs)  │
+  └──────────────────────┘           └──────────────────┘
+           │
+    delays N seconds,
+    then returns mock
+    order status
+```
+
+While the webhook delays, the AI Assistant speaks the configured filler messages on the phone call:
+- **0s** — "Let me look that up for you."
+- **5s** — "Still working on this, one moment please."
+- **15s** — "Almost there, thanks for your patience."
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Type | Example | Required | Description | Where to get it |
+|----------|------|---------|----------|-------------|-----------------|
+| `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `WEBHOOK_DELAY_SECONDS` | `integer` | `12` | no | How long the webhook delays before responding | — |
+| `PORT` | `integer` | `5000` | no | HTTP server port | — |
+
+## Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/ai-assistant-filler-messages-demo-python
+cp .env.example .env    # ← fill in your credentials
+pip install -r requirements.txt
+python app.py           # starts on http://localhost:5000
+```
+
+### Webhook Configuration
+
+1. Expose your local server:
+
+   ```bash
+   ngrok http 5000
+   ```
+
+2. In [Mission Control](https://portal.telnyx.com), create or edit an AI Assistant:
+   - Add a sync webhook tool named `check_order_status` with parameter `order_id` (string)
+   - Set the webhook URL to `https://<id>.ngrok.io/webhook/order-status`
+   - Under the **Filler Messages** tab, add:
+     - `request_start`: "Let me look that up for you."
+     - `request_response_delayed` at 5000ms: "Still working on this, one moment please."
+     - `request_response_delayed` at 15000ms: "Almost there, thanks for your patience."
+
+3. Open `http://localhost:5000` in a browser to see the live dashboard.
+
+4. Call your AI Assistant's phone number and ask: *"What's the status of my order 12345?"*
+
+## API Reference
+
+### `POST /webhook/order-status`
+
+Receives the sync tool call from the AI Assistant, delays for the configured duration, then returns mock order status.
+
+```bash
+curl -X POST http://localhost:5000/webhook/order-status \
+  -H "Content-Type: application/json" \
+  -d '{"order_id": "12345"}'
+```
+
+**Response (after delay):**
+
+```json
+{
+  "result": {
+    "order_id": "12345",
+    "status": "shipped",
+    "carrier": "FedEx",
+    "tracking": "FX-98765",
+    "eta": "2026-07-20",
+    "items": ["Wireless Headset", "USB-C Cable"]
+  }
+}
+```
+
+### `GET /`
+
+Serves the split-screen dashboard UI.
+
+### `GET /events`
+
+SSE stream of real-time events for the dashboard.
+
+### `GET /health`
+
+Health check.
+
+```bash
+curl http://localhost:5000/health
+```
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "delay_seconds": 12,
+  "connected_clients": 1
+}
+```
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Dashboard shows "Disconnected" | SSE connection dropped | Refresh the browser page |
+| Webhook not triggered | AI Assistant not configured to call your URL | Verify the webhook URL in Mission Control matches your ngrok URL + `/webhook/order-status` |
+| No filler messages heard | Filler messages not configured on the tool | Open the tool settings in Mission Control and add filler messages under the Filler Messages tab |
+| Order not found response | Using an order ID not in mock data | Use `12345`, `67890`, or `11111` |
+| `connection refused` | Flask not running or wrong port | Check `PORT` in `.env` and ensure `python app.py` is running |
+
+## Related Examples
+
+- [AI Assistant Phone Setup (Python)](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/ai-assistant-phone-setup-python/README.md)
+- [AI Assistant Multi-Tool (Python)](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/ai-assistant-multi-tool-python/README.md)
+- [AI Assistant Knowledge Base (Python)](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/ai-assistant-knowledge-base-python/README.md)
+- [AI Voice Agent with Function Calling (Python)](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/ai-voice-agent-with-function-calling-python/README.md)
+- [Webhook Debugger AI Assistant (Python)](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/webhook-debugger-ai-assistant-python/README.md)
+
+## Resources
+
+- [AI Assistants Guide](https://developers.telnyx.com/docs/voice/ai-assistants)
+- [Filler Messages Release Note](https://telnyx.com/release-notes/webhook-tool-filler-messages)
+- [AI Assistants Product Page](https://telnyx.com/ai-assistants)
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+- [Telnyx Portal](https://portal.telnyx.com)
+
+## Why Telnyx
+
+Telnyx is an **AI Communications Infrastructure** platform — voice, messaging, SIP, AI, and IoT on one private, global network.

--- a/ai-assistant-filler-messages-demo-python/README.md
+++ b/ai-assistant-filler-messages-demo-python/README.md
@@ -146,6 +146,7 @@ curl http://localhost:5000/health
 | No filler messages heard | Filler messages not configured on the tool | Open the tool settings in Mission Control and add filler messages under the Filler Messages tab |
 | Order not found response | Using an order ID not in mock data | Use `12345`, `67890`, or `11111` |
 | `connection refused` | Flask not running or wrong port | Check `PORT` in `.env` and ensure `python app.py` is running |
+| Assistant says it can't find the order | Tool timeout shorter than webhook delay | Set tool `timeout_ms` to at least `30000` in Mission Control or via API |
 
 ## Related Examples
 

--- a/ai-assistant-filler-messages-demo-python/app.py
+++ b/ai-assistant-filler-messages-demo-python/app.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""AI Assistant Filler Messages Demo — webhook server with live split-screen dashboard for demoing filler messages during sync tool calls."""
+import os, json, time, threading, queue
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify, render_template, Response
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(os.path.join(BASE_DIR, ".env"))
+app = Flask(__name__, template_folder=os.path.join(BASE_DIR, "templates"))
+
+WEBHOOK_DELAY_SECONDS = int(os.getenv("WEBHOOK_DELAY_SECONDS", "12"))
+
+MOCK_ORDERS = {
+    "12345": {"order_id": "12345", "status": "shipped", "carrier": "FedEx", "tracking": "FX-98765", "eta": "2026-07-20", "items": ["Wireless Headset", "USB-C Cable"]},
+    "67890": {"order_id": "67890", "status": "processing", "carrier": "pending", "tracking": "pending", "eta": "2026-07-25", "items": ["Desk Lamp"]},
+    "11111": {"order_id": "11111", "status": "delivered", "carrier": "UPS", "tracking": "1Z999AA10123456784", "eta": "2026-07-14", "items": ["Keyboard", "Mouse", "Monitor Stand"]},
+}
+
+FILLER_CONFIG = [
+    {"type": "request_start", "content": "Let me look that up for you.", "timing_ms": 0},
+    {"type": "request_response_delayed", "content": "Still working on this, one moment please.", "timing_ms": 5000},
+    {"type": "request_response_delayed", "content": "Almost there, thanks for your patience.", "timing_ms": 15000},
+]
+
+clients = []
+clients_lock = threading.Lock()
+
+
+def broadcast(event_type, data):
+    """Send an SSE event to all connected dashboard clients."""
+    payload = json.dumps({"type": event_type, "timestamp": time.time(), **data})
+    msg = f"event: {event_type}\ndata: {payload}\n\n"
+    dead = []
+    with clients_lock:
+        for q in clients:
+            try:
+                q.put_nowait(msg)
+            except queue.Full:
+                dead.append(q)
+        for q in dead:
+            clients.remove(q)
+
+
+@app.route("/webhook/order-status", methods=["POST"])
+def webhook_order_status():
+    body = request.get_json(silent=True) or {}
+    order_id = body.get("order_id", "unknown")
+    received_at = time.time()
+
+    app.logger.info("Webhook received: order_id=%s", order_id)
+    broadcast("tool_call_received", {
+        "order_id": order_id,
+        "request_body": body,
+        "delay_seconds": WEBHOOK_DELAY_SECONDS,
+    })
+
+    for filler in FILLER_CONFIG:
+        elapsed_ms = filler.get("timing_ms", 0)
+        if elapsed_ms / 1000 < WEBHOOK_DELAY_SECONDS:
+            broadcast("filler_message", {
+                "content": filler["content"],
+                "filler_type": filler["type"],
+                "timing_ms": elapsed_ms,
+            })
+
+    for elapsed in range(1, WEBHOOK_DELAY_SECONDS + 1):
+        time.sleep(1)
+        broadcast("countdown", {
+            "elapsed": elapsed,
+            "total": WEBHOOK_DELAY_SECONDS,
+            "remaining": WEBHOOK_DELAY_SECONDS - elapsed,
+        })
+
+    order = MOCK_ORDERS.get(order_id, {"order_id": order_id, "status": "not_found", "error": "Order not found"})
+    response_body = {"result": order}
+
+    app.logger.info("Webhook responding: order_id=%s status=%s", order_id, order.get("status"))
+    broadcast("response_sent", {
+        "order_id": order_id,
+        "response_body": response_body,
+        "duration_seconds": round(time.time() - received_at, 1),
+    })
+
+    return jsonify(response_body), 200
+
+
+@app.route("/")
+def dashboard():
+    return render_template("index.html",
+                           delay_seconds=WEBHOOK_DELAY_SECONDS,
+                           filler_config=FILLER_CONFIG)
+
+
+@app.route("/events")
+def events():
+    q = queue.Queue(maxsize=100)
+    with clients_lock:
+        clients.append(q)
+
+    def stream():
+        try:
+            yield f"data: {json.dumps({'type': 'connected', 'timestamp': time.time(), 'delay_seconds': WEBHOOK_DELAY_SECONDS})}\n\n"
+            while True:
+                try:
+                    msg = q.get(timeout=30)
+                    yield msg
+                except queue.Empty:
+                    yield ": keepalive\n\n"
+        finally:
+            with clients_lock:
+                if q in clients:
+                    clients.remove(q)
+
+    return Response(stream(), mimetype="text/event-stream",
+                    headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
+
+
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok", "delay_seconds": WEBHOOK_DELAY_SECONDS, "connected_clients": len(clients)}), 200
+
+
+if __name__ == "__main__":
+    app.run(debug=False, threaded=True, host=os.getenv("HOST", "127.0.0.1"), port=int(os.getenv("PORT", "5000")))

--- a/ai-assistant-filler-messages-demo-python/requirements.txt
+++ b/ai-assistant-filler-messages-demo-python/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+python-dotenv>=1.0

--- a/ai-assistant-filler-messages-demo-python/requirements.txt
+++ b/ai-assistant-filler-messages-demo-python/requirements.txt
@@ -1,2 +1,3 @@
 flask>=3.0
 python-dotenv>=1.0
+requests>=2.31

--- a/ai-assistant-filler-messages-demo-python/setup.py
+++ b/ai-assistant-filler-messages-demo-python/setup.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Set up an AI Assistant with a sync webhook tool and filler messages via the Telnyx API.
+
+Usage:
+    python setup.py <ngrok_url>
+
+This script:
+1. Lists your phone numbers and lets you pick one
+2. Creates an AI Assistant with telephony enabled
+3. Adds a sync webhook tool (check_order_status) with filler messages
+4. Assigns the phone number to the assistant's backing TeXML app
+"""
+import os, sys, json, requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("TELNYX_API_KEY")
+if not API_KEY:
+    print("Error: TELNYX_API_KEY not set in .env")
+    sys.exit(1)
+
+BASE = "https://api.telnyx.com/v2"
+HEADERS = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+
+
+def api(method, path, body=None):
+    url = f"{BASE}{path}"
+    r = requests.request(method, url, headers=HEADERS, json=body, timeout=30)
+    if r.status_code >= 400:
+        print(f"API error {r.status_code}: {r.text}")
+        sys.exit(1)
+    return r.json()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python setup.py <ngrok_url>")
+        print("Example: python setup.py https://abc123.ngrok.io")
+        sys.exit(1)
+
+    ngrok_url = sys.argv[1].rstrip("/")
+    webhook_url = f"{ngrok_url}/webhook/order-status"
+
+    # 1. Find a phone number
+    print("Finding phone numbers on your account...")
+    nums = api("GET", "/phone_numbers?page[size]=20&filter[status]=active")
+    numbers = nums.get("data", [])
+    if not numbers:
+        print("No active phone numbers found. Purchase one in the Telnyx Portal first.")
+        sys.exit(1)
+
+    print(f"Found {len(numbers)} number(s):")
+    for i, n in enumerate(numbers):
+        phone = n.get("phone_number", "unknown")
+        conn = n.get("connection_name", "none")
+        print(f"  [{i}] {phone}  (connection: {conn})")
+
+    choice = input(f"\nPick a number [0-{len(numbers)-1}]: ").strip()
+    try:
+        num = numbers[int(choice)]
+    except (ValueError, IndexError):
+        print("Invalid choice.")
+        sys.exit(1)
+
+    phone_number = num["phone_number"]
+    print(f"\nUsing: {phone_number}")
+
+    # 2. Create the AI Assistant
+    print("\nCreating AI Assistant...")
+    assistant = api("POST", "/ai/assistants", {
+        "name": "Filler Messages Demo",
+        "instructions": (
+            "You are a helpful order status assistant. When a customer asks about their order, "
+            "use the check_order_status tool to look up the order. Report back the status, "
+            "carrier, tracking number, and estimated delivery date. Be friendly and concise."
+        ),
+        "model": "anthropic/claude-haiku-4-5",
+        "enabled_features": ["telephony"],
+    })
+    # Response is flat (no "data" wrapper)
+    assistant_id = assistant["id"]
+    print(f"Created assistant: {assistant_id}")
+
+    # 3. Add the webhook tool with filler messages via PATCH (inline tools)
+    print(f"\nAdding webhook tool pointing to: {webhook_url}")
+    api("PATCH", f"/ai/assistants/{assistant_id}", {
+        "tools": [{
+            "type": "webhook",
+            "webhook": {
+                "name": "check_order_status",
+                "description": "Check the status of a customer order by order ID. Use this whenever a customer asks about their order.",
+                "url": webhook_url,
+                "method": "POST",
+                "async": False,
+                "timeout_ms": 30000,
+                "body_parameters": {
+                    "type": "object",
+                    "properties": {
+                        "order_id": {
+                            "type": "string",
+                            "description": "The customer's order ID number"
+                        }
+                    },
+                    "required": ["order_id"]
+                },
+                "filler_messages": [
+                    {"type": "request_start", "content": "Let me look that up for you."},
+                    {"type": "request_response_delayed", "content": "Still working on this, one moment please.", "timing_ms": 5000},
+                    {"type": "request_response_delayed", "content": "Almost there, thanks for your patience.", "timing_ms": 15000},
+                ]
+            }
+        }]
+    })
+    print("Webhook tool with filler messages added.")
+
+    # 4. Assign the phone number to the assistant's backing TeXML app
+    # Each AI Assistant with telephony gets a TeXML app automatically.
+    # We read its ID from telephony_settings and assign the phone number to it.
+    print(f"\nAssigning {phone_number} to assistant...")
+    assistant_data = api("GET", f"/ai/assistants/{assistant_id}")
+    texml_app_id = (assistant_data.get("telephony_settings") or {}).get("default_texml_app_id")
+    if not texml_app_id:
+        print("Warning: could not find TeXML app ID. Assign the phone number manually in Mission Control.")
+    else:
+        api("PATCH", f"/phone_numbers/{phone_number}", {"connection_id": texml_app_id})
+        print(f"Phone number assigned (TeXML app: {texml_app_id}).")
+
+    # Done
+    print("\n" + "=" * 60)
+    print("Setup complete!")
+    print("=" * 60)
+    print(f"  Assistant ID:  {assistant_id}")
+    print(f"  Phone number:  {phone_number}")
+    print(f"  Webhook URL:   {webhook_url}")
+    print(f"  Delay:         {os.getenv('WEBHOOK_DELAY_SECONDS', '12')}s")
+    print()
+    print("Next steps:")
+    print("  1. Start the webhook server:  python app.py")
+    print("  2. Open the dashboard:        http://localhost:5000")
+    print(f"  3. Call {phone_number}")
+    print('  4. Ask: "What\'s the status of my order 12345?"')
+    print()
+    print(f"To clean up later: delete assistant {assistant_id} in Mission Control")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-assistant-filler-messages-demo-python/setup.py
+++ b/ai-assistant-filler-messages-demo-python/setup.py
@@ -13,7 +13,8 @@ This script:
 import os, sys, json, requests
 from dotenv import load_dotenv
 
-load_dotenv()
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(os.path.join(BASE_DIR, ".env"))
 
 API_KEY = os.getenv("TELNYX_API_KEY")
 if not API_KEY:
@@ -76,6 +77,7 @@ def main():
             "carrier, tracking number, and estimated delivery date. Be friendly and concise."
         ),
         "model": "anthropic/claude-haiku-4-5",
+        "greeting": "Hello! Thanks for calling. I can help you check the status of your order. Just give me your order number.",
         "enabled_features": ["telephony"],
     })
     # Response is flat (no "data" wrapper)
@@ -87,6 +89,7 @@ def main():
     api("PATCH", f"/ai/assistants/{assistant_id}", {
         "tools": [{
             "type": "webhook",
+            "timeout_ms": 30000,
             "webhook": {
                 "name": "check_order_status",
                 "description": "Check the status of a customer order by order ID. Use this whenever a customer asks about their order.",
@@ -135,11 +138,18 @@ def main():
     print(f"  Webhook URL:   {webhook_url}")
     print(f"  Delay:         {os.getenv('WEBHOOK_DELAY_SECONDS', '12')}s")
     print()
+    print("IMPORTANT: Filler messages must be configured through Mission Control UI.")
+    print("The API sets the values, but playback requires the Mission Control Filler Messages tab.")
+    print(f"  → Go to: https://portal.telnyx.com → AI → Assistants → {assistant_id}")
+    print("  → Open the check_order_status tool → Filler Messages tab")
+    print("  → Add the filler messages listed in the guide")
+    print()
     print("Next steps:")
-    print("  1. Start the webhook server:  python app.py")
-    print("  2. Open the dashboard:        http://localhost:5000")
-    print(f"  3. Call {phone_number}")
-    print('  4. Ask: "What\'s the status of my order 12345?"')
+    print("  1. Configure filler messages in Mission Control (see above)")
+    print("  2. Start the webhook server:  python app.py")
+    print("  3. Open the dashboard:        http://localhost:5000")
+    print(f"  4. Call {phone_number}")
+    print('  5. Ask: "What\'s the status of my order 12345?"')
     print()
     print(f"To clean up later: delete assistant {assistant_id} in Mission Control")
 

--- a/ai-assistant-filler-messages-demo-python/templates/index.html
+++ b/ai-assistant-filler-messages-demo-python/templates/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Filler Messages Demo — Telnyx AI Assistant</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; background: #0d1117; color: #c9d1d9; height: 100vh; display: flex; flex-direction: column; }
+  header { background: #161b22; border-bottom: 1px solid #30363d; padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; }
+  header h1 { font-size: 18px; color: #58a6ff; font-weight: 600; }
+  header h1 span { color: #8b949e; font-weight: 400; }
+  .status-badge { padding: 4px 12px; border-radius: 12px; font-size: 12px; background: #1f6feb33; color: #58a6ff; border: 1px solid #1f6feb; }
+  .status-badge.active { background: #23883333; color: #3fb950; border-color: #238833; animation: pulse 2s infinite; }
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
+  .container { display: flex; flex: 1; overflow: hidden; }
+  .panel { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+  .panel:first-child { border-right: 1px solid #30363d; }
+  .panel-header { background: #161b22; padding: 12px 20px; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 8px; }
+  .panel-header h2 { font-size: 14px; font-weight: 600; color: #e6edf3; }
+  .panel-icon { font-size: 16px; }
+  .panel-body { flex: 1; overflow-y: auto; padding: 16px 20px; }
+  .event { padding: 12px 16px; margin-bottom: 8px; border-radius: 8px; border-left: 3px solid #30363d; background: #161b22; animation: slideIn 0.3s ease-out; }
+  @keyframes slideIn { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
+  .event .time { font-size: 11px; color: #8b949e; margin-bottom: 4px; }
+  .event .label { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+  .event .detail { font-size: 12px; color: #8b949e; }
+  .event.tool-call { border-left-color: #d29922; }
+  .event.tool-call .label { color: #d29922; }
+  .event.filler { border-left-color: #a371f7; }
+  .event.filler .label { color: #a371f7; }
+  .event.response { border-left-color: #3fb950; }
+  .event.response .label { color: #3fb950; }
+  .event.countdown { border-left-color: #1f6feb; background: transparent; border: none; padding: 4px 16px; margin-bottom: 2px; }
+  .event.countdown .label { color: #58a6ff; font-weight: 400; font-size: 12px; }
+  .event.info { border-left-color: #8b949e; }
+  .event.info .label { color: #8b949e; }
+  .progress-bar { width: 100%; height: 4px; background: #21262d; border-radius: 2px; margin-top: 6px; overflow: hidden; }
+  .progress-bar .fill { height: 100%; background: linear-gradient(90deg, #1f6feb, #58a6ff); border-radius: 2px; transition: width 0.5s ease; }
+  pre.json { background: #0d1117; border: 1px solid #30363d; border-radius: 6px; padding: 12px; font-size: 12px; overflow-x: auto; margin-top: 8px; white-space: pre-wrap; word-break: break-all; }
+  .key { color: #7ee787; }
+  .string { color: #a5d6ff; }
+  .number { color: #d2a8ff; }
+  .null { color: #8b949e; }
+  .empty-state { text-align: center; padding: 60px 20px; color: #484f58; }
+  .empty-state p { font-size: 14px; margin-bottom: 8px; }
+  .empty-state code { background: #21262d; padding: 2px 8px; border-radius: 4px; font-size: 13px; color: #8b949e; }
+  .filler-config { margin-top: 16px; padding: 12px; background: #21262d; border-radius: 6px; font-size: 12px; }
+  .filler-config .cfg-title { color: #a371f7; font-weight: 600; margin-bottom: 8px; }
+  .filler-config .cfg-item { color: #8b949e; padding: 2px 0; }
+  .filler-config .cfg-item span { color: #c9d1d9; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Filler Messages Demo <span>— Telnyx AI Assistant</span></h1>
+  <div class="status-badge" id="status">Waiting for call</div>
+</header>
+<div class="container">
+  <div class="panel">
+    <div class="panel-header">
+      <span class="panel-icon">&#128222;</span>
+      <h2>Call Timeline</h2>
+    </div>
+    <div class="panel-body" id="timeline">
+      <div class="empty-state" id="timeline-empty">
+        <p>Waiting for an incoming tool call...</p>
+        <p style="margin-top:12px">Call your AI Assistant and ask:</p>
+        <code>"What's the status of my order 12345?"</code>
+        <div class="filler-config">
+          <div class="cfg-title">Configured Filler Messages</div>
+          {% for f in filler_config %}
+          <div class="cfg-item">
+            {% if f.timing_ms == 0 %}@ start{% else %}@ {{ f.timing_ms // 1000 }}s{% endif %}
+            — <span>"{{ f.content }}"</span>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-header">
+      <span class="panel-icon">&#128421;</span>
+      <h2>Webhook Server Log</h2>
+    </div>
+    <div class="panel-body" id="serverlog">
+      <div class="empty-state" id="server-empty">
+        <p>No webhook requests yet.</p>
+        <p style="margin-top:8px">Endpoint: <code>POST /webhook/order-status</code></p>
+        <p style="margin-top:4px">Configured delay: <code>{{ delay_seconds }}s</code></p>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+const timeline = document.getElementById('timeline');
+const serverlog = document.getElementById('serverlog');
+const statusBadge = document.getElementById('status');
+let timelineEmpty = document.getElementById('timeline-empty');
+let serverEmpty = document.getElementById('server-empty');
+
+function fmtTime(ts) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleTimeString('en-US', {hour12: false, hour:'2-digit', minute:'2-digit', second:'2-digit'}) + '.' + String(d.getMilliseconds()).padStart(3,'0');
+}
+
+function syntaxHighlight(obj) {
+  let json = JSON.stringify(obj, null, 2);
+  return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function(match) {
+    let cls = 'number';
+    if (/^"/.test(match)) { cls = /:$/.test(match) ? 'key' : 'string'; }
+    else if (/true|false/.test(match)) cls = 'number';
+    else if (/null/.test(match)) cls = 'null';
+    return '<span class="' + cls + '">' + match + '</span>';
+  });
+}
+
+function addTimeline(cls, label, detail, ts) {
+  if (timelineEmpty) { timelineEmpty.remove(); timelineEmpty = null; }
+  const div = document.createElement('div');
+  div.className = 'event ' + cls;
+  div.innerHTML = '<div class="time">' + fmtTime(ts) + '</div><div class="label">' + label + '</div>' + (detail ? '<div class="detail">' + detail + '</div>' : '');
+  timeline.appendChild(div);
+  timeline.scrollTop = timeline.scrollHeight;
+}
+
+function addServerLog(cls, label, detail, ts, jsonObj) {
+  if (serverEmpty) { serverEmpty.remove(); serverEmpty = null; }
+  const div = document.createElement('div');
+  div.className = 'event ' + cls;
+  let html = '<div class="time">' + fmtTime(ts) + '</div><div class="label">' + label + '</div>';
+  if (detail) html += '<div class="detail">' + detail + '</div>';
+  if (jsonObj) html += '<pre class="json">' + syntaxHighlight(jsonObj) + '</pre>';
+  div.innerHTML = html;
+  serverlog.appendChild(div);
+  serverlog.scrollTop = serverlog.scrollHeight;
+}
+
+let progressDiv = null;
+
+const es = new EventSource('/events');
+
+es.onmessage = function(e) {
+  const d = JSON.parse(e.data);
+  if (d.type === 'connected') {
+    statusBadge.textContent = 'Connected';
+    statusBadge.className = 'status-badge active';
+  }
+};
+
+es.addEventListener('tool_call_received', function(e) {
+  const d = JSON.parse(e.data);
+  statusBadge.textContent = 'Processing webhook';
+  addTimeline('tool-call', 'Tool Call: check_order_status', 'order_id: ' + d.order_id, d.timestamp);
+  addServerLog('tool-call', 'POST /webhook/order-status', 'Received tool call — delaying ' + d.delay_seconds + 's', d.timestamp, d.request_body);
+
+  progressDiv = document.createElement('div');
+  progressDiv.className = 'event countdown';
+  progressDiv.id = 'progress-event';
+  progressDiv.innerHTML = '<div class="label">Delay: 0 / ' + d.delay_seconds + 's</div><div class="progress-bar"><div class="fill" id="progress-fill" style="width:0%"></div></div>';
+  serverlog.appendChild(progressDiv);
+});
+
+es.addEventListener('filler_message', function(e) {
+  const d = JSON.parse(e.data);
+  const when = d.timing_ms === 0 ? 'immediately' : 'at ' + (d.timing_ms / 1000) + 's';
+  addTimeline('filler', 'Filler: "' + d.content + '"', 'Type: ' + d.filler_type + ' — plays ' + when, d.timestamp);
+});
+
+es.addEventListener('countdown', function(e) {
+  const d = JSON.parse(e.data);
+  const pct = Math.round((d.elapsed / d.total) * 100);
+  const fill = document.getElementById('progress-fill');
+  const prog = document.getElementById('progress-event');
+  if (fill) fill.style.width = pct + '%';
+  if (prog) prog.querySelector('.label').textContent = 'Delay: ' + d.elapsed + ' / ' + d.total + 's (' + d.remaining + 's remaining)';
+  if (serverlog) serverlog.scrollTop = serverlog.scrollHeight;
+});
+
+es.addEventListener('response_sent', function(e) {
+  const d = JSON.parse(e.data);
+  statusBadge.textContent = 'Waiting for call';
+  statusBadge.className = 'status-badge';
+  if (progressDiv) { progressDiv.remove(); progressDiv = null; }
+  addTimeline('response', 'Webhook Response Sent', 'order_id: ' + d.order_id + ' — took ' + d.duration_seconds + 's', d.timestamp);
+  addServerLog('response', 'Response 200 OK', 'Returned order status after ' + d.duration_seconds + 's delay', d.timestamp, d.response_body);
+});
+
+es.onerror = function() {
+  statusBadge.textContent = 'Disconnected';
+  statusBadge.className = 'status-badge';
+};
+</script>
+</body>
+</html>

--- a/scripts/examples_mapping.yaml
+++ b/scripts/examples_mapping.yaml
@@ -616,6 +616,12 @@ examples:
     folder: ai-assistant-phone-setup-python
 
   - product: ai
+    use_case: ai-assistant-filler-messages-demo
+    language: python
+    framework: flask
+    folder: ai-assistant-filler-messages-demo-python
+
+  - product: ai
     use_case: ai-audiobook-narrator
     language: python
     framework: flask


### PR DESCRIPTION
## Summary
- Adds `ai-assistant-filler-messages-demo-python/` — webhook server with split-screen dashboard for demoing AI Assistant filler messages during sync tool calls
- Includes `setup.py` to provision the assistant, webhook tool with filler messages, and phone number assignment via API
- Registers the new example in `scripts/examples_mapping.yaml`

## What it does
- **`POST /webhook/order-status`** — receives sync tool calls from the AI Assistant, delays configurable seconds, returns mock order status
- **`GET /`** — serves a dark-themed split-screen dashboard (call timeline + webhook server log) via SSE
- **`setup.py`** — creates AI Assistant, adds webhook tool with filler messages, assigns phone number — all via Telnyx API

## Test plan
- [ ] `python -m py_compile app.py` passes
- [ ] `python scripts/verify.py --only ai-assistant-filler-messages-demo-python` passes
- [ ] Dashboard renders at `http://localhost:5000`
- [ ] Webhook endpoint responds with mock order data after delay
- [ ] SSE stream pushes real-time events to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)