### PR TITLE
Fix subscription assistant docs links

### DIFF
--- a/ai-subscription-cancel-save-retention-agent-python/README.md
+++ b/ai-subscription-cancel-save-retention-agent-python/README.md
@@ -41,8 +41,8 @@ or text-to-speech pipeline.
 ## Telnyx API Endpoints Used
 
 - AI Assistants: Create — `POST /v2/ai/assistants` — [reference](https://developers.telnyx.com/api-reference/assistants/create-an-assistant)
-- AI Assistants: Update — `POST /v2/ai/assistants/{assistant_id}` — [reference](https://developers.telnyx.com/api-reference/assistants/update-assistant)
-- AI Assistants: Get — `GET /v2/ai/assistants/{assistant_id}` — [reference](https://developers.telnyx.com/api-reference/assistants/get-assistant)
+- AI Assistants: Update — `POST /v2/ai/assistants/{assistant_id}` — [reference](https://developers.telnyx.com/api-reference/assistants/update-an-assistant)
+- AI Assistants: Get — `GET /v2/ai/assistants/{assistant_id}` — [reference](https://developers.telnyx.com/api-reference/assistants/get-an-assistant)
 - Phone Numbers: List — `GET /v2/phone_numbers`
 - Phone Numbers: Update — `PATCH /v2/phone_numbers/{id}`
 


### PR DESCRIPTION
## Summary

- Fix stale Telnyx AI Assistants API reference links in the subscription cancel-save sample README.

- `update-assistant` and `get-assistant` now use the current `update-an-assistant` and `get-an-assistant` docs slugs.


## Validation

- Checked all external README/GUIDE links for the subscription sample with `curl -L -I`; all non-localhost links return 200.
- `python3 -m py_compile ai-subscription-cancel-save-retention-agent-python/app.py`

- `scripts/verify.py --verbose --only ai-subscription-cancel-save-retention-agent-python`

- `scripts/gen_llms_txt.py --check`
- `scripts/rewrite_repo_links.py --check`




