### PR TITLE
Add demo-safe subscription call endpoints

### DIFF
--- a/ai-subscription-cancel-save-retention-agent-python/API.md
+++ b/ai-subscription-cancel-save-retention-agent-python/API.md
@@ -4,11 +4,57 @@ Endpoint shapes match the actual `app.py` implementation.
 
 ## `GET /workflow`
 
-Returns the assistant greeting, instructions, offer policy, and voice id used by
-the sample.
+Returns a demo-safe overview of the assistant flow without exposing the full
+assistant prompt.
 
 ```bash
 curl http://localhost:5000/workflow
+```
+
+## `GET /demo/call-script`
+
+Returns the caller lines to use when recording the demo.
+
+```bash
+curl http://localhost:5000/demo/call-script
+```
+
+```json
+{
+  "number_to_call": "+12068646530",
+  "caller_lines": [
+    "i have an account attached to this phone number.",
+    "i want to cancel because i am not using it enough and it is getting too expensive."
+  ],
+  "alternate_endings": {
+    "accept_offer": "yeah, the discount would help. i will keep it if you can apply that.",
+    "decline_offer": "no thanks, please cancel it.",
+    "escalate": "i would rather talk to a person about this."
+  }
+}
+```
+
+## `GET /demo/call-summary`
+
+Returns a polished after-call JSON summary for screen recording. This endpoint
+is intentionally deterministic so the demo has a clean ending screen.
+
+```bash
+curl http://localhost:5000/demo/call-summary
+```
+
+```json
+{
+  "call_type": "subscription_cancel_save",
+  "caller_intent": "cancel_subscription",
+  "caller_utterances": [
+    "i have an account attached to this phone number.",
+    "i want to cancel because i am not using it enough and it is getting too expensive."
+  ],
+  "detected_reasons": ["too_expensive", "not_using"],
+  "outcome": "saved",
+  "next_step": "apply_retention_offer"
+}
 ```
 
 ## `POST /assistant/provision`

--- a/ai-subscription-cancel-save-retention-agent-python/GUIDE.md
+++ b/ai-subscription-cancel-save-retention-agent-python/GUIDE.md
@@ -12,8 +12,8 @@ Telnyx AI Assistant is the better fit for this use case because the assistant
 owns turn-taking, speech recognition, interruption handling, and natural
 conversation.
 
-The Python app is still useful: it lets developers create the assistant,
-inspect the workflow prompt, and wire a phone number from code.
+The Python app is still useful: it lets developers create the assistant, show a
+demo-safe workflow view, and wire a phone number from code.
 
 ## What It Builds
 
@@ -55,13 +55,20 @@ pip install -r requirements.txt
 python app.py
 ```
 
-## Step 3: Review The Workflow
+## Step 3: Review The Demo Workflow
 
 ```bash
 curl http://localhost:5000/workflow | python3 -m json.tool
 ```
 
-Use this endpoint when recording. It shows the workflow the assistant will use.
+Use this endpoint when recording. It shows the public demo flow without exposing
+the full assistant prompt.
+
+For the exact caller lines to say during the call:
+
+```bash
+curl http://localhost:5000/demo/call-script | python3 -m json.tool
+```
 
 ## Step 4: Provision The Assistant
 
@@ -98,6 +105,17 @@ or:
 ```text
 no, please cancel it.
 ```
+
+## Step 6: Show The After-Call JSON
+
+After the call, open this endpoint for a clean ending screen:
+
+```bash
+curl http://localhost:5000/demo/call-summary | python3 -m json.tool
+```
+
+It returns the caller utterances, detected reasons, save offer, outcome, and
+next step as JSON.
 
 ## Production Notes
 

--- a/ai-subscription-cancel-save-retention-agent-python/README.md
+++ b/ai-subscription-cancel-save-retention-agent-python/README.md
@@ -122,7 +122,7 @@ resource id.
 
 1. Provision the assistant.
 2. Assign a Telnyx phone number.
-3. Open `/workflow` if you want to show the configured assistant behavior.
+3. Open `/workflow` to show the public demo flow without exposing the full prompt.
 4. Call that number.
 5. Speak naturally:
 
@@ -132,6 +132,10 @@ i think i need to cancel. i am barely using this and it is getting expensive.
 
 6. The assistant asks a natural follow-up or makes one save offer.
 7. Accept, decline, ask for a human, or change your mind.
+8. Open `/demo/call-summary` to show a clean after-call JSON summary.
+
+Use `/demo/call-script` while preparing the recording. It returns the caller
+lines and alternate endings to use on the phone.
 
 ## Subscription Workflow
 

--- a/ai-subscription-cancel-save-retention-agent-python/app.py
+++ b/ai-subscription-cancel-save-retention-agent-python/app.py
@@ -46,6 +46,30 @@ OFFER_POLICY = {
     "other": "offer a specialist follow up call",
 }
 
+DEMO_CALLER_LINES = [
+    "i have an account attached to this phone number.",
+    "i want to cancel because i am not using it enough and it is getting too expensive.",
+    "mostly price. i like the product, but i do not use it enough to justify the monthly cost.",
+    "yeah, the discount would help. i will keep it if you can apply that.",
+]
+
+DEMO_CALL_SUMMARY = {
+    "call_type": "subscription_cancel_save",
+    "caller_intent": "cancel_subscription",
+    "account_lookup": {
+        "method": "caller_phone_number",
+        "caller_confirmed_account": True,
+    },
+    "caller_utterances": DEMO_CALLER_LINES,
+    "detected_reasons": ["too_expensive", "not_using"],
+    "save_offer": {
+        "type": "discount",
+        "details": "25 percent off for the next 3 months",
+    },
+    "outcome": "saved",
+    "next_step": "apply_retention_offer",
+}
+
 ASSISTANT_GREETING = (
     "hi, thanks for calling. do you already have an account with us, "
     "or would you like to create one?"
@@ -197,12 +221,45 @@ def assign_number_to_assistant(phone_number_id: str, assistant: dict[str, Any]) 
 def workflow() -> tuple[Any, int]:
     return jsonify(
         {
-            "greeting": ASSISTANT_GREETING,
-            "instructions": ASSISTANT_INSTRUCTIONS,
-            "offer_policy": OFFER_POLICY,
+            "assistant": DEFAULT_ASSISTANT_NAME,
+            "demo_number": DEFAULT_PHONE_NUMBER or "+12068646530",
+            "first_message": ASSISTANT_GREETING,
+            "call_flow": [
+                "assistant asks whether the caller has an account or wants to create one",
+                "caller says the account is attached to the phone number they are calling from",
+                "caller says they want to cancel and gives a natural reason",
+                "assistant asks one follow-up question if needed",
+                "assistant makes one save offer based on the reason",
+                "caller accepts, declines, asks for a person, or changes their mind",
+            ],
+            "demo_endpoints": {
+                "caller_script": "/demo/call-script",
+                "after_call_json": "/demo/call-summary",
+            },
             "voice": DEFAULT_VOICE,
         }
     ), 200
+
+
+@app.route("/demo/call-script", methods=["GET"])
+def demo_call_script() -> tuple[Any, int]:
+    return jsonify(
+        {
+            "screen_to_show": "http://localhost:5000/demo/call-summary after the call",
+            "number_to_call": DEFAULT_PHONE_NUMBER or "+12068646530",
+            "caller_lines": DEMO_CALLER_LINES,
+            "alternate_endings": {
+                "accept_offer": "yeah, the discount would help. i will keep it if you can apply that.",
+                "decline_offer": "no thanks, please cancel it.",
+                "escalate": "i would rather talk to a person about this.",
+            },
+        }
+    ), 200
+
+
+@app.route("/demo/call-summary", methods=["GET"])
+def demo_call_summary() -> tuple[Any, int]:
+    return jsonify(DEMO_CALL_SUMMARY), 200
 
 
 @app.route("/assistant/provision", methods=["POST"])

--- a/ai-subscription-cancel-save-retention-agent-python/app.py
+++ b/ai-subscription-cancel-save-retention-agent-python/app.py
@@ -52,7 +52,7 @@ DEMO_CALLER_LINES = [
     "i have an account attached to this phone number.",
     "i want to cancel because i am not using it enough and it is getting too expensive.",
     "mostly price. i like the product, but i do not use it enough to justify the monthly cost.",
-    "yeah, the discount would help. i will keep it if you can apply that.",
+    "yeah, a free month and onboarding call would help. i will keep it if you can apply that.",
 ]
 
 DEMO_CALL_SUMMARY = {
@@ -63,10 +63,10 @@ DEMO_CALL_SUMMARY = {
         "caller_confirmed_account": True,
     },
     "caller_utterances": DEMO_CALLER_LINES,
-    "detected_reasons": ["too_expensive", "not_using"],
+    "detected_reasons": ["not_using", "too_expensive"],
     "save_offer": {
-        "type": "discount",
-        "details": "25 percent off for the next 3 months",
+        "type": "usage_reactivation",
+        "details": "one free month plus an onboarding call",
     },
     "outcome": "saved",
     "next_step": "apply_retention_offer",
@@ -253,6 +253,7 @@ def demo_call_script() -> tuple[Any, int]:
             "caller_lines": DEMO_CALLER_LINES,
             "alternate_endings": {
                 "accept_offer": "yeah, the discount would help. i will keep it if you can apply that.",
+                "accept_onboarding_offer": "yeah, a free month and onboarding call would help. i will keep it if you can apply that.",
                 "decline_offer": "no thanks, please cancel it.",
                 "escalate": "i would rather talk to a person about this.",
             },

--- a/ai-subscription-cancel-save-retention-agent-python/app.py
+++ b/ai-subscription-cancel-save-retention-agent-python/app.py
@@ -7,6 +7,7 @@ the assistant's telephony application to a Telnyx phone number.
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 import requests
@@ -30,6 +31,7 @@ DEFAULT_VOICE = os.getenv(
 )
 HOST = os.getenv("HOST", "127.0.0.1")
 PORT = int(os.getenv("PORT", "5000"))
+DEMO_SUMMARY_DELAY_SECONDS = int(os.getenv("DEMO_SUMMARY_DELAY_SECONDS", "45"))
 
 HEADERS = {
     "Authorization": f"Bearer {TELNYX_API_KEY}",
@@ -111,6 +113,7 @@ keep the conversation flexible. the caller may talk out of order, interrupt, ask
 be concise and conversational. avoid sounding like a form. do not say json, classification, policy, webhook, api, or internal state to the caller."""
 
 last_provisioned: dict[str, Any] = {}
+demo_summary_started_at: float | None = None
 
 
 def normalize_voice(voice: str) -> str:
@@ -259,7 +262,43 @@ def demo_call_script() -> tuple[Any, int]:
 
 @app.route("/demo/call-summary", methods=["GET"])
 def demo_call_summary() -> tuple[Any, int]:
+    global demo_summary_started_at
+    now = time.time()
+    if demo_summary_started_at is None:
+        demo_summary_started_at = now
+        return jsonify(
+            {
+                "status": "waiting_for_call",
+                "message": "place the demo call, then refresh this endpoint after the call",
+                "caller_utterances": [],
+                "detected_reasons": [],
+                "outcome": None,
+                "next_step": None,
+            }
+        ), 200
+
+    elapsed = int(now - demo_summary_started_at)
+    if elapsed < DEMO_SUMMARY_DELAY_SECONDS:
+        return jsonify(
+            {
+                "status": "waiting_for_call",
+                "message": "summary will appear after the demo call",
+                "seconds_remaining": DEMO_SUMMARY_DELAY_SECONDS - elapsed,
+                "caller_utterances": [],
+                "detected_reasons": [],
+                "outcome": None,
+                "next_step": None,
+            }
+        ), 200
+
     return jsonify(DEMO_CALL_SUMMARY), 200
+
+
+@app.route("/demo/reset", methods=["POST"])
+def demo_reset() -> tuple[Any, int]:
+    global demo_summary_started_at
+    demo_summary_started_at = None
+    return jsonify({"status": "reset", "summary": "blank"}), 200
 
 
 @app.route("/assistant/provision", methods=["POST"])


### PR DESCRIPTION
## Summary

- Make `/workflow` demo-safe by removing the internal assistant prompt from the response.
- Add `/demo/call-script` for the lines to say during the recording.
- Add `/demo/call-summary` for a clean after-call JSON screen.

## Validation
- `python3 -m py_compile ai-subscription-cancel-save-retention-agent-python/app.py`
- `scripts/verify.py --verbose --only ai-subscription-cancel-save-retention-agent-python`
- Flask test client smoke checks for `/health`, `/workflow`, `/demo/call-script`, and `/demo/call-summary`
