### PR TITLE
DEV-643: Fix Edge Geo Smart Router storage credentials + voice IDs

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -3,7 +3,7 @@
   "description": "Production-ready code examples for Telnyx AI Communications Infrastructure.",
   "homepage": "https://developers.telnyx.com",
   "repository": "https://github.com/team-telnyx/telnyx-code-examples",
-  "generated_at": "2026-07-27T11:31:09Z",
+  "generated_at": "2026-07-27T11:51:30Z",
   "example_count": 497,
   "examples": [
     {

--- a/edge-geo-smart-router-python/.env.example
+++ b/edge-geo-smart-router-python/.env.example
@@ -1,7 +1,16 @@
 # Telnyx API key — https://portal.telnyx.com/api-keys
 TELNYX_API_KEY=
-# Webhook signature verification — https://portal.telnyx.com/api-keys
+# Webhook signature verification (Ed25519 public key) — https://portal.telnyx.com/api-keys
 TELNYX_PUBLIC_KEY=
-# Cloud Storage bucket — https://portal.telnyx.com/storage
-STORAGE_BUCKET=my-bucket
+# Telnyx Storage credentials (separate from the API key) — https://portal.telnyx.com/storage
+# Created under Portal > Storage > Credentials. The S3-compatible API uses these
+# access/secret keys, NOT the Telnyx API key.
+STORAGE_ACCESS_KEY=
+STORAGE_SECRET_KEY=
+STORAGE_BUCKET=call-recordings
+STORAGE_REGION=us-east-1
+# AI Inference model — https://developers.telnyx.com/docs/inference/models
 AI_MODEL=moonshotai/Kimi-K2.6
+# Server
+HOST=127.0.0.1
+PORT=5000

--- a/edge-geo-smart-router-python/API.md
+++ b/edge-geo-smart-router-python/API.md
@@ -36,12 +36,19 @@ Telnyx webhook handler.
 
 ## `GET /regions`
 
-Regions.
+Returns the per-region routing config (language, voice, recording, consent). `greeting` is omitted.
 
 ### Response `200`
 
 ```json
-{"status": "ok"}
+{
+  "regions": {
+    "US":     {"language": "en-US", "voice": "AWS.Polly.Joanna-Neural", "record": true,  "requires_consent": false},
+    "LATAM":  {"language": "es-MX", "voice": "AWS.Polly.Lupe-Neural",   "record": true,  "requires_consent": false},
+    "EU":     {"language": "en-GB", "voice": "AWS.Polly.Amy-Neural",     "record": false, "requires_consent": true},
+    "DEFAULT":{"language": "en-US", "voice": "AWS.Polly.Joanna-Neural", "record": true,  "requires_consent": false}
+  }
+}
 ```
 
 ### Try it
@@ -54,12 +61,12 @@ curl http://localhost:5000/regions
 
 ## `GET /health`
 
-Health.
+Health check with active call count.
 
 ### Response `200`
 
 ```json
-{"status": "ok"}
+{"status": "ok", "service": "edge-geo-smart-router", "active_calls": 0}
 ```
 
 ### Try it
@@ -79,6 +86,6 @@ curl http://localhost:5000/health
 | Status | Meaning |
 |--------|--------|
 | `200` | Success |
-| `400` | Bad request |
-| `404` | Not found |
+| `400` | Bad request (missing payload, missing `call_control_id`) |
+| `401` | Webhook signature verification failed (`telnyx-signature-ed25519` / `telnyx-timestamp` missing, stale, or invalid) |
 | `500` | Server error |

--- a/edge-geo-smart-router-python/GUIDE.md
+++ b/edge-geo-smart-router-python/GUIDE.md
@@ -46,7 +46,7 @@ Edit `.env` with your credentials.
 
 ## Step 2: Understand the Code
 
-Everything lives in `app.py` (182 lines). Here is what each piece does.
+Everything lives in `app.py` (~250 lines). Here is what each piece does.
 
 
 **`detect_region()`** -- Detect Region.

--- a/edge-geo-smart-router-python/README.md
+++ b/edge-geo-smart-router-python/README.md
@@ -42,8 +42,16 @@ Copy `.env.example` to `.env` and fill in:
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
 | `TELNYX_API_KEY` | `string` | `KEY0123456789` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PUBLIC_KEY` | `string` | _(base64 Ed25519)_ | **yes** | Webhook signature verification key | [Portal > Keys & Credentials](https://portal.telnyx.com/api-keys) |
+| `STORAGE_ACCESS_KEY` | `string` | `AKIAIOSFODNN7EXAMPLE` | for recording archival | Telnyx Storage S3 access key (separate from API key) | [Portal > Storage](https://portal.telnyx.com/storage) |
+| `STORAGE_SECRET_KEY` | `string` | _(secret)_ | for recording archival | Telnyx Storage S3 secret key | [Portal > Storage](https://portal.telnyx.com/storage) |
+| `STORAGE_BUCKET` | `string` | `call-recordings` | for recording archival | S3-compatible bucket name | [Portal > Storage](https://portal.telnyx.com/storage) |
+| `STORAGE_REGION` | `string` | `us-east-1` | no | Storage bucket region | [Portal > Storage](https://portal.telnyx.com/storage) |
 | `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | AI model | [Models](https://developers.telnyx.com/docs/inference/models) |
+| `HOST` | `string` | `127.0.0.1` | no | Server host | -- |
 | `PORT` | `integer` | `5000` | no | Server port | -- |
+
+> **Note on Storage:** Telnyx Storage is S3-compatible but uses its **own** access/secret key pair (created under Portal > Storage > Credentials), not the Telnyx API key. If `STORAGE_ACCESS_KEY` and `STORAGE_SECRET_KEY` are not set, recording archival is gracefully skipped — the app still works for routing, greetings, and AI conversation, but recordings won't be archived to Storage.
 
 ## Setup
 
@@ -65,7 +73,7 @@ python app.py
 
 ### `GET /regions`
 
-Regions.
+Returns the per-region routing config (language, voice, recording, consent).
 
 ```bash
 curl http://localhost:5000/regions
@@ -74,12 +82,19 @@ curl http://localhost:5000/regions
 **Response:**
 
 ```json
-{"status": "ok", "service": "edge-geo-smart-router"}
+{
+  "regions": {
+    "US":     {"language": "en-US", "voice": "AWS.Polly.Joanna-Neural", "record": true,  "requires_consent": false},
+    "LATAM":  {"language": "es-MX", "voice": "AWS.Polly.Lupe-Neural",   "record": true,  "requires_consent": false},
+    "EU":     {"language": "en-GB", "voice": "AWS.Polly.Amy-Neural",     "record": false, "requires_consent": true},
+    "DEFAULT":{"language": "en-US", "voice": "AWS.Polly.Joanna-Neural", "record": true,  "requires_consent": false}
+  }
+}
 ```
 
 ### `GET /health`
 
-Health.
+Health check with active call count.
 
 ```bash
 curl http://localhost:5000/health
@@ -88,7 +103,7 @@ curl http://localhost:5000/health
 **Response:**
 
 ```json
-{"status": "ok", "service": "edge-geo-smart-router"}
+{"status": "ok", "service": "edge-geo-smart-router", "active_calls": 0}
 ```
 
 
@@ -139,7 +154,8 @@ Telnyx sends call events here. Your app processes them and responds with the nex
 | Telnyx never reaches your webhook | Local server not exposed; Webhook URL points at `localhost` | Run `ngrok http 5000` and set the Call Control Application Webhook URL to `https://<id>.ngrok.io/webhooks/voice`. |
 | Inference replies with "I'm having trouble right now" | `TELNYX_API_KEY` invalid/missing or `AI_MODEL` not available | Verify `TELNYX_API_KEY` in `.env`, confirm the `AI_MODEL` slug at [Models](https://developers.telnyx.com/docs/inference/models). |
 | Caller routed to `DEFAULT` instead of expected region | Number not in E.164 form, or its prefix isn't in `EU_PREFIXES` / `LATAM_PREFIXES` | Ensure the `from` number starts with `+<country code>`; add the prefix to the lists in `app.py`. |
-| Recordings not archived | EU caller pressed 2 (no consent), or `recording_url` not on a Telnyx host | EU recording only starts after consent (digit `1`); non-Telnyx URLs are skipped to guard against SSRF. |
+| Recordings not archived | EU caller pressed 2 (no consent), `recording_url` not on a Telnyx host, OR `STORAGE_ACCESS_KEY`/`STORAGE_SECRET_KEY` not set | EU recording only starts after consent (digit `1`); non-Telnyx URLs are skipped (SSRF guard); Storage archival is skipped if Storage credentials are missing — set them in `.env` (these are separate from the Telnyx API key; created under Portal > Storage > Credentials). |
+| `400 invalid voice` / `language` ignored | Voice id is bare (`"female"`) for a non-`en-US` language | Bare `female`/`male` only work with `service_level: "basic"` (en-US). Use a full voice id like `AWS.Polly.Lupe-Neural` for `es-MX` — the defaults in `REGION_CONFIG` already do this. |
 
 ## Related Examples
 

--- a/edge-geo-smart-router-python/app.py
+++ b/edge-geo-smart-router-python/app.py
@@ -18,23 +18,48 @@ TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 AI_MODEL = os.getenv("AI_MODEL", "moonshotai/Kimi-K2.6")
+# Telnyx Storage is S3-compatible but uses SEPARATE storage credentials
+# (created in Portal > Storage), not the Telnyx API key.
+STORAGE_ACCESS_KEY = os.getenv("STORAGE_ACCESS_KEY", "")
+STORAGE_SECRET_KEY = os.getenv("STORAGE_SECRET_KEY", "")
 STORAGE_BUCKET = os.getenv("STORAGE_BUCKET", "call-recordings")
+STORAGE_REGION = os.getenv("STORAGE_REGION", "us-east-1")
 HOST = os.getenv("HOST", "127.0.0.1")
 HEADERS = {"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"}
 
-s3 = boto3.client("s3", endpoint_url="https://storage.telnyx.com",
-                   aws_access_key_id=TELNYX_API_KEY, aws_secret_access_key=TELNYX_API_KEY)
+if STORAGE_ACCESS_KEY and STORAGE_SECRET_KEY:
+    s3 = boto3.client(
+        "s3",
+        endpoint_url="https://storage.telnyx.com",
+        aws_access_key_id=STORAGE_ACCESS_KEY,
+        aws_secret_access_key=STORAGE_SECRET_KEY,
+        region_name=STORAGE_REGION,
+    )
+else:
+    s3 = None
+    app.logger.warning(
+        "STORAGE_ACCESS_KEY/STORAGE_SECRET_KEY not set — "
+        "call recording archival to Telnyx Storage is disabled."
+    )
 
+# Voice ids follow the <Provider>.<Model>.<VoiceId> format.
+# AWS.Polly neural voices support the languages below; "female"/"male" only
+# work with service_level="basic" (en-US only), so we use explicit voice ids.
 REGION_CONFIG = {
-    "US": {"language": "en-US", "voice": "female", "greeting": "Welcome. How can I help you today?",
-           "requires_consent": False, "record": True},
-    "LATAM": {"language": "es-MX", "voice": "female", "greeting": "Bienvenido. Como puedo ayudarle hoy?",
-              "requires_consent": False, "record": True},
-    "EU": {"language": "en-GB", "voice": "female",
-           "greeting": "This call will be recorded for quality purposes. Press 1 to consent and continue, or press 2 to proceed without recording.",
-           "requires_consent": True, "record": False},
-    "DEFAULT": {"language": "en-US", "voice": "female", "greeting": "Welcome. How can I help you?",
-                "requires_consent": False, "record": True}
+    "US":     {"language": "en-US", "voice": "AWS.Polly.Joanna-Neural",
+               "greeting": "Welcome. How can I help you today?",
+               "requires_consent": False, "record": True},
+    "LATAM":  {"language": "es-MX", "voice": "AWS.Polly.Lupe-Neural",
+               "greeting": "Bienvenido. Como puedo ayudarle hoy?",
+               "requires_consent": False, "record": True},
+    "EU":     {"language": "en-GB", "voice": "AWS.Polly.Amy-Neural",
+               "greeting": "This call will be recorded for quality purposes. "
+                           "Press 1 to consent and continue, or press 2 to "
+                           "proceed without recording.",
+               "requires_consent": True, "record": False},
+    "DEFAULT":{"language": "en-US", "voice": "AWS.Polly.Joanna-Neural",
+               "greeting": "Welcome. How can I help you?",
+               "requires_consent": False, "record": True}
 }
 
 EU_PREFIXES = ["+33", "+34", "+39", "+44", "+49", "+31", "+32", "+43", "+45", "+46", "+47",
@@ -201,16 +226,18 @@ def handle_voice():
     elif event_type == "call.recording.saved":
         recording_url = ep.get("recording_urls", {}).get("mp3")
         session = call_sessions.get(cc_id, {})
-        # recording_url comes from the webhook body — only fetch it (with the API key
-        # attached) if it points at a Telnyx host. Guards against SSRF.
-        if recording_url and is_telnyx_url(recording_url):
-            try:
-                audio = requests.get(recording_url, headers=HEADERS, timeout=30).content
-                region = session.get("region", "unknown")
-                key = f"recordings/{region}/{ep.get('call_session_id', 'unknown')}.mp3"
-                s3.put_object(Bucket=STORAGE_BUCKET, Key=key, Body=audio, ContentType="audio/mpeg")
-            except Exception as e:
-                app.logger.error("Recording archive failed: %s", e)
+        if not (recording_url and is_telnyx_url(recording_url)):
+            return jsonify({"status": "ok"})
+        if s3 is None:
+            app.logger.info("Recording ready at %s but Storage credentials not configured; skipping archival.", recording_url)
+            return jsonify({"status": "ok"})
+        try:
+            audio = requests.get(recording_url, headers=HEADERS, timeout=30).content
+            region = session.get("region", "unknown")
+            key = f"recordings/{region}/{ep.get('call_session_id', 'unknown')}.mp3"
+            s3.put_object(Bucket=STORAGE_BUCKET, Key=key, Body=audio, ContentType="audio/mpeg")
+        except Exception as e:
+            app.logger.error("Recording archive failed: %s", e)
 
     elif event_type == "call.hangup":
         call_sessions.pop(cc_id, None)


### PR DESCRIPTION
## Summary

Critical fixes for the Edge Geo Smart Router sample (DEV-643).

### Storage credentials (was broken)
The sample reused the Telnyx API key as **both** the S3 access key **and** the secret key. Telnyx Storage is S3-compatible but uses its **own** credential pair, created under Portal > Storage > Credentials. Archival silently failed at runtime.

Fix: add separate `STORAGE_ACCESS_KEY` / `STORAGE_SECRET_KEY` env vars. The S3 client is now optional — if Storage isn't configured, archival is skipped with a log warning (the router still serves calls; only recording archival is affected).

### Voice IDs (was broken for non-en-US)
`REGION_CONFIG` used bare `"female"` / `"male"` voice ids. Those only work with `service_level: "basic"`, which is en-US only. LATAM (`es-MX`) and EU (`en-GB`) greetings silently fell back to nothing.

Fix: use full `AWS.Polly.<VoiceId>-Neural` ids per region:
- US / DEFAULT → `AWS.Polly.Joanna-Neural` (en-US)
- LATAM → `AWS.Polly.Lupe-Neural` (es-MX)
- EU → `AWS.Polly.Amy-Neural` (en-GB)

## Files changed
- `app.py` — separate Storage creds; S3 client optional; neural voice ids; graceful archival skip
- `.env.example` — `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`, `STORAGE_REGION`, `HOST`, `PORT`; note that Storage creds ≠ API key
- `README.md` — corrected `/regions` and `/health` response examples; Storage env vars in table; new troubleshooting rows (Storage creds, voice ids)
- `API.md` — corrected `/regions` and `/health` response examples; updated error status table
- `GUIDE.md` — updated line count (182 → ~250)
- `catalog.json`, `llms.txt` — regenerated via `scripts/gen_llms_txt.py`

## Verification
- `py_compile` OK
- Import OK; server starts
- `GET /health` → `{"status":"ok","service":"edge-geo-smart-router","active_calls":0}`
- `GET /regions` → returns 4 regions with neural voice ids
- `POST /webhooks/voice` without signature → 401 (expected)
- `detect_region()` tested for +1, +55, +44, +33, +52
- `s3` is `None` (with warning) when Storage creds unset; call flow still works

Linear: DEV-643