### PR TITLE
Fix TTS/STT language_code mismatch in translation bridge

### DIFF
--- a/ai-real-time-translation-bridge-python/GUIDE.md
+++ b/ai-real-time-translation-bridge-python/GUIDE.md
@@ -63,7 +63,7 @@ Edit `.env` with your Telnyx credentials. Each variable links to where you find 
 
 ## Step 2: Understand the Code
 
-Everything lives in `app.py` (128 lines). Here's what each piece does.
+Everything lives in `app.py` (141 lines). Here's what each piece does.
 
 ### Starting the Workflow
 

--- a/ai-real-time-translation-bridge-python/GUIDE.md
+++ b/ai-real-time-translation-bridge-python/GUIDE.md
@@ -5,7 +5,7 @@ Connect two callers who speak different languages on the same phone call. Your a
 ## How It Works
 
 ```
-  Inbound Phone Call
+  Outbound Call to Caller A
         │
         ▼
   ┌──────────────────┐
@@ -14,7 +14,7 @@ Connect two callers who speak different languages on the same phone call. Your a
            │
            ▼
   ┌──────────────────┐
-  │ Gather Speech     │ ── STT transcription
+  │ Gather Speech     │ ── STT transcription (caller's language)
   └────────┬─────────┘
            │
            ▼
@@ -25,7 +25,7 @@ Connect two callers who speak different languages on the same phone call. Your a
            │ ◄──── conversation loop
            │
            ▼
-     JSON response
+  TTS to other caller (target language)
 ```
 
 ## API Endpoints
@@ -63,7 +63,7 @@ Edit `.env` with your Telnyx credentials. Each variable links to where you find 
 
 ## Step 2: Understand the Code
 
-Everything lives in `app.py` (100 lines). Here's what each piece does.
+Everything lives in `app.py` (128 lines). Here's what each piece does.
 
 ### Starting the Workflow
 
@@ -77,7 +77,7 @@ data = request.get_json()
     try:
         resp = requests.post("https://api.telnyx.com/v2/calls", headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
             json={"to": data["number_a"], "from": BRIDGE_NUMBER, "connection_id": CONNECTION_ID,
-                "client_state": json.dumps({"bid": bid, "side": "a"}).encode().hex()}, timeout=10)
+                "client_state": base64.b64encode(json.dumps({"bid": bid, "side": "a"}).encode()).decode()}, timeout=10)
 ```
 
 ### Handling Webhooks
@@ -116,13 +116,16 @@ Server starts on `http://localhost:5000`.
 curl http://localhost:5000/health
 ```
 
-**Trigger the workflow:**
+**Trigger the bridge:**
 
 ```bash
 curl -X POST http://localhost:5000/bridge \
   -H "Content-Type: application/json" \
   -d '{
-    "phone": "+12125559999"
+    "number_a": "+13125550001",
+    "lang_a": "English",
+    "number_b": "+5215550002",
+    "lang_b": "Spanish"
   }'
 ```
 

--- a/ai-real-time-translation-bridge-python/README.md
+++ b/ai-real-time-translation-bridge-python/README.md
@@ -30,7 +30,7 @@ This app handles these webhook events ([Call Control docs](https://developers.te
 ## Architecture
 
 ```
-  Inbound Phone Call
+  Outbound Call to Caller A
         │
         ▼
   ┌──────────────────┐
@@ -39,7 +39,7 @@ This app handles these webhook events ([Call Control docs](https://developers.te
            │
            ▼
   ┌──────────────────┐
-  │ Gather Speech     │ ── STT transcription
+  │ Gather Speech     │ ── STT transcription (caller's language)
   └────────┬─────────┘
            │
            ▼
@@ -50,7 +50,7 @@ This app handles these webhook events ([Call Control docs](https://developers.te
            │ ◄──── conversation loop
            │
            ▼
-     JSON response
+  TTS to other caller (target language)
 ```
 
 ## Environment Variables
@@ -60,8 +60,9 @@ Copy `.env.example` to `.env` and fill in:
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
 | `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) |
+| `TELNYX_PUBLIC_KEY` | `string` | `-----BEGIN PUBLIC KEY-----...` | **yes** | Telnyx public key for webhook signature verification | [Portal](https://portal.telnyx.com/api-keys) |
 | `AI_MODEL` | `string` | `moonshotai/Kimi-K2.6` | no | Telnyx AI Inference model name | [Portal](https://developers.telnyx.com/docs/inference/models) |
-| `BRIDGE_NUMBER` | `string` | `your_value` | **yes** | Bridge number | - |
+| `BRIDGE_NUMBER` | `string` | `+13125550000` | **yes** | Telnyx phone number to call from | [Portal](https://portal.telnyx.com/numbers) |
 | `CONNECTION_ID` | `string` | `1494404757140276705` | **yes** | Call Control connection/app ID | [Portal](https://portal.telnyx.com/call-control/applications) |
 | `PORT` | `integer` | `5000` | no | HTTP server port | - |
 
@@ -91,27 +92,26 @@ python app.py           # starts on http://localhost:5000
 
 ### `POST /bridge`
 
-Triggers bridge
+Triggers a new translation bridge by calling both parties.
 
 ```bash
 curl -X POST http://localhost:5000/bridge \
   -H "Content-Type: application/json" \
-  -d '{}'
+  -d '{"number_a": "+13125550001", "lang_a": "English", "number_b": "+5215550002", "lang_b": "Spanish"}'
 ```
 
 **Response:**
 
 ```json
 {
-  "id": "item-1750280400",
-  "status": "created",
-  "created_at": "2026-07-15T14:30:00Z"
+  "bridge_id": "BR-1754020800",
+  "status": "calling_a"
 }
 ```
 
 ### `GET /bridges`
 
-Returns bridges
+Returns all active and recent bridges.
 
 ```bash
 curl http://localhost:5000/bridges
@@ -121,19 +121,18 @@ curl http://localhost:5000/bridges
 
 ```json
 {
-  "items": [
-    {
-      "id": "item-001",
-      "status": "active",
-      "created_at": "2026-07-15T14:30:00Z"
+  "bridges": {
+    "BR-1754020800": {
+      "state": "active",
+      "languages": "English<>Spanish"
     }
-  ]
+  }
 }
 ```
 
 ### `GET /health`
 
-Returns health
+Returns service health and active bridge count.
 
 ```bash
 curl http://localhost:5000/health
@@ -144,9 +143,7 @@ curl http://localhost:5000/health
 ```json
 {
   "status": "ok",
-  "uptime_seconds": 3842,
-  "active_sessions": 2,
-  "version": "1.0.0"
+  "active_bridges": 1
 }
 ```
 

--- a/ai-real-time-translation-bridge-python/app.py
+++ b/ai-real-time-translation-bridge-python/app.py
@@ -16,6 +16,17 @@ CONNECTION_ID = os.getenv("CONNECTION_ID")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 bridges = {}
 
+LANG_CODES = {
+    "english": "en-US", "spanish": "es-US", "french": "fr-FR",
+    "german": "de-DE", "italian": "it-IT", "portuguese": "pt-BR",
+    "hindi": "hi-IN", "arabic": "ar-SA", "chinese": "zh-CN",
+    "japanese": "ja-JP", "korean": "ko-KR", "russian": "ru-RU",
+}
+
+def lang_code(lang):
+    """Map a language name to a BCP-47 code for TTS/STT."""
+    return LANG_CODES.get(lang.lower(), "en-US")
+
 def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
     def _cleanup():
         while True:
@@ -92,7 +103,9 @@ def handle_voice():
             bridge["state"] = "active"
         return jsonify({"status": "ok"}), 200
     elif event_type == "call.speak.ended" and bridge:
-        client.calls.actions.gather(ccid, input_type="speech", end_silence_timeout_secs=2, timeout_secs=15, language_code="en-US")
+        my_side = "a" if ccid == bridge["ccids"].get("a") else "b"
+        my_lang = lang_code(bridge[f"lang_{my_side}"])
+        client.calls.actions.gather(ccid, input_type="speech", end_silence_timeout_secs=2, timeout_secs=15, language_code=my_lang)
         return jsonify({"status": "listening"}), 200
     elif event_type == "call.gather.ended" and bridge:
         speech = p.get("speech", {}).get("result", "")
@@ -102,8 +115,8 @@ def handle_voice():
             other_ccid = bridge["ccids"].get("b" if side == "a" else "a")
             translated = translate(speech, from_lang, to_lang)
             if other_ccid:
-                client.calls.actions.speak(other_ccid, payload=translated, voice="female", language_code="en-US")
-            client.calls.actions.gather(ccid, input_type="speech", end_silence_timeout_secs=2, timeout_secs=15, language_code="en-US")
+                client.calls.actions.speak(other_ccid, payload=translated, voice="female", language_code=lang_code(to_lang))
+            client.calls.actions.gather(ccid, input_type="speech", end_silence_timeout_secs=2, timeout_secs=15, language_code=lang_code(bridge[f"lang_{side}"]))
         return jsonify({"status": "translated"}), 200
     elif event_type == "call.hangup" and bridge:
         other_side = "b" if side == "a" else "a"


### PR DESCRIPTION
## Bug

The AI Real-Time Translation Bridge hardcoded `language_code="en-US"` for all TTS (text-to-speech) and gather (speech-to-text) calls — even when translating between English and Spanish.

This caused two failures:
1. **TTS**: Spanish translated text was spoken with English pronunciation → unintelligible to the Spanish-speaking caller
2. **STT**: Spanish speech was transcribed using an English language model → unreliable recognition

## Fix

Added a `LANG_CODES` mapping (English→en-US, Spanish→es-US, 10+ languages) and a `lang_code()` helper. Now:

- **TTS** uses the **target language** (so translated Spanish text is spoken with `es-US` pronunciation)
- **STT gather** uses the **speaker's language** (so Spanish speech is recognized with `es-US` model)

Also fixed README and GUIDE inaccuracies:
- Corrected API responses to match actual code output (were generic placeholders)
- Added `TELNYX_PUBLIC_KEY` to env table (required for webhook signature verification but was missing)
- Corrected architecture diagram (outbound calling, not inbound)
- Fixed GUIDE code snippet (`base64.b64encode` not `.hex()`)
- Fixed GUIDE line count (128, not 100)
- Fixed GUIDE test request body (`number_a`/`number_b`/`lang_a`/`lang_b`, not `phone`)

## Testing

```bash
python3 -m py_compile app.py  # ✅ passes
```

## Files changed

- `app.py` — added LANG_CODES mapping, fixed 3 language_code parameters
- `README.md` — corrected API responses, env table, architecture diagram
- `GUIDE.md` — corrected code snippet, line count, test example, architecture diagram