### PR TITLE
fix: correct broken SDK method calls across 48 Python examples

### DIFF
--- a/.github/workflows/api-contract-check.yml
+++ b/.github/workflows/api-contract-check.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - "**/API.md"
+      - "**/app.py"
+      - "scripts/check_sdk_calls.py"
+      - ".github/workflows/api-contract-check.yml"
 
 permissions:
   contents: read
@@ -27,3 +30,46 @@ jobs:
 
       - name: Check API contract
         run: python scripts/check_api_contract.py --verbose
+
+  sdk-call-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0  # need full history for diff against base
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install telnyx SDK
+        run: pip install telnyx
+
+      - name: Check SDK calls (changed files only)
+        run: |
+          # Determine the base branch for diffing
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            # Scheduled/manual runs — check everything
+            BASE=""
+          fi
+
+          if [ -n "$BASE" ]; then
+            # Ratchet mode: only check app.py files changed in this PR
+            git fetch origin "$GITHUB_BASE_REF" --depth=1 2>/dev/null || true
+            CHANGED=$(git diff --name-only --diff-filter=AM "$BASE...HEAD" -- '**/app.py' | sed 's|/app.py$||' | sort -u)
+            if [ -z "$CHANGED" ]; then
+              echo "No app.py files changed in this PR — skipping SDK call check."
+              exit 0
+            fi
+            echo "Checking changed examples:"
+            echo "$CHANGED"
+            echo ""
+            for folder in $CHANGED; do
+              python scripts/check_sdk_calls.py --only "$folder" --verbose
+            done
+          else
+            # Full check — catches all violations (scheduled/manual runs)
+            python scripts/check_sdk_calls.py
+          fi

--- a/activate-sim-card-python/app.py
+++ b/activate-sim-card-python/app.py
@@ -17,7 +17,7 @@ client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
 def list_sim_cards() -> list:
     """Retrieve all SIM cards and return JSON-serializable list."""
     response = client.sim_cards.list()
-    
+
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return [
         {
@@ -33,7 +33,7 @@ def list_sim_cards() -> list:
 def get_sim_card(sim_card_id: str) -> dict:
     """Retrieve a single SIM card by ID and return JSON-serializable data."""
     response = client.sim_cards.retrieve(sim_card_id)
-    
+
     # Extract serializable data from the response object
     return {
         "id": response.data.id,
@@ -47,10 +47,10 @@ def activate_sim_card(sim_card_id: str) -> dict:
     """Activate a SIM card and return JSON-serializable response data."""
     if not sim_card_id:
         raise ValueError("SIM card ID is required")
-    
-    # Call the activate method with the SIM card ID
-    response = client.sim_cards.activate(sim_card_id)
-    
+
+    # Enable (activate) the SIM card via the actions subresource
+    response = client.sim_cards.actions.enable(sim_card_id)
+
     # Extract serializable data from the response object
     return {
         "id": response.data.id,
@@ -66,13 +66,15 @@ def list_sims():
     try:
         sims = list_sim_cards()
         return jsonify({"data": sims}), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -83,13 +85,15 @@ def get_sim(sim_card_id):
     try:
         sim = get_sim_card(sim_card_id)
         return jsonify(sim), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
 
@@ -99,24 +103,28 @@ def activate_sim(sim_card_id):
     """HTTP endpoint to activate a SIM card."""
     try:
         result = activate_sim_card(sim_card_id)
-        return jsonify({"message": "SIM card activated successfully", "data": result}), 200
-        
+        return jsonify(
+            {"message": "SIM card activated successfully", "data": result}
+        ), 200
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
         return jsonify({"error": "Invalid request"}), 400
 
 
-
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200
+
 
 if __name__ == "__main__":
     app.run(debug=False, port=5000)

--- a/ai-conference-note-taker-python/app.py
+++ b/ai-conference-note-taker-python/app.py
@@ -140,7 +140,7 @@ def handle_voice():
     if event_type == "call.answered" and meeting:
         meeting["status"] = "recording"
         # Start real-time transcription
-        client.calls.actions.transcription_start(call_control_id, language="en")
+        client.calls.actions.start_transcription(call_control_id, language="en")
         return jsonify({"status": "transcribing"}), 200
 
     elif event_type == "call.transcription" and meeting:

--- a/ai-debt-collection-compliance-agent-python/app.py
+++ b/ai-debt-collection-compliance-agent-python/app.py
@@ -88,7 +88,7 @@ def handle_voice():
         debtor = call["debtor"]
         greeting = f"Hello, this is a call from ABC Collections regarding an outstanding balance. This is an attempt to collect a debt and any information obtained will be used for that purpose. Am I speaking with {debtor.get('name', 'the account holder')}?"
         client.calls.actions.speak(ccid, payload=greeting, voice="female", language_code="en-US")
-        client.calls.actions.record_start(ccid, format="mp3", channels="dual")
+        client.calls.actions.start_recording(ccid, format="mp3", channels="dual")
         call["conversation"].append({"role": "assistant", "content": greeting})
         return jsonify({"status": "greeting"}), 200
     elif event_type == "call.speak.ended" and call:

--- a/ai-hiring-phone-screen-python/app.py
+++ b/ai-hiring-phone-screen-python/app.py
@@ -80,7 +80,7 @@ def handle_voice():
     if event_type == "call.answered" and call:
         name = call["candidate"].get("name", "")
         client.calls.actions.speak(ccid, payload=f"Hi {name}, thanks for taking the time to chat! I'm going to ask you a few questions about your background. Ready to get started?", voice="female", language_code="en-US")
-        client.calls.actions.record_start(ccid, format="mp3", channels="dual")
+        client.calls.actions.start_recording(ccid, format="mp3", channels="dual")
         return jsonify({"status": "greeting"}), 200
     elif event_type == "call.speak.ended" and call:
         client.calls.actions.gather(ccid, input_type="speech", end_silence_timeout_secs=3, timeout_secs=30, language_code="en-US")

--- a/ai-podcast-post-producer-python/app.py
+++ b/ai-podcast-post-producer-python/app.py
@@ -37,7 +37,7 @@ def handle_voice():
         client.calls.actions.answer(ccid)
         return jsonify({"status": "answering"}), 200
     elif event_type == "call.answered":
-        client.calls.actions.record_start(ccid, format="mp3", channels="dual")
+        client.calls.actions.start_recording(ccid, format="mp3", channels="dual")
         client.calls.actions.speak(ccid, payload="Podcast recording started. Speak naturally. The recording will be processed when the call ends.", voice="female", language_code="en-US")
         return jsonify({"status": "recording"}), 200
     elif event_type == "call.recording.saved":

--- a/ai-sales-call-with-live-crm-updates-python/app.py
+++ b/ai-sales-call-with-live-crm-updates-python/app.py
@@ -136,7 +136,7 @@ def handle_voice_webhook():
     # --- Call answered: start transcription + AI listening ---
     elif event_type == "call.answered":
         # Start transcription to capture the conversation
-        client.calls.actions.transcription_start(
+        client.calls.actions.start_transcription(
             call_control_id,
             language="en",
         )

--- a/ai-voicemail-transcription-forwarding-python/app.py
+++ b/ai-voicemail-transcription-forwarding-python/app.py
@@ -76,8 +76,8 @@ def handle_voice():
         client.calls.actions.speak(ccid, payload="Hi, I'm not available right now. Please leave a message after the beep and I'll get back to you.", voice="female", language_code="en-US")
         return jsonify({"status": "greeting"}), 200
     elif event_type == "call.speak.ended":
-        client.calls.actions.record_start(ccid, format="mp3", channels="single", play_beep=True)
-        client.calls.actions.transcription_start(ccid, language="en")
+        client.calls.actions.start_recording(ccid, format="mp3", channels="single", play_beep=True)
+        client.calls.actions.start_transcription(ccid, language="en")
         return jsonify({"status": "recording"}), 200
     elif event_type == "call.transcription":
         text = p.get("transcription_data", {}).get("transcript", "")

--- a/alphanumeric-sender-id-sms-python/app.py
+++ b/alphanumeric-sender-id-sms-python/app.py
@@ -77,7 +77,7 @@ def send_sms_with_alphanumeric_id(
         raise ValueError("TELNYX_MESSAGING_PROFILE_ID environment variable not set")
     
     # Create message with alphanumeric sender ID
-    response = client.messages.create(
+    response = client.messages.send(
         from_=sender_id,
         to=to_number,
         text=message,

--- a/call-queue-with-hold-music-python/app.py
+++ b/call-queue-with-hold-music-python/app.py
@@ -70,7 +70,7 @@ def handle_voice():
     elif event_type == "call.speak.ended":
         call = active_calls.get(ccid)
         if call and call.get("state") == "holding":
-            client.calls.actions.playback_start(ccid, audio_url="https://file-examples.com/storage/fedc3e8bdb6832b296ac7cc/2017/11/file_example_MP3_700KB.mp3", loop="infinity")
+            client.calls.actions.start_playback(ccid, audio_url="https://file-examples.com/storage/fedc3e8bdb6832b296ac7cc/2017/11/file_example_MP3_700KB.mp3", loop="infinity")
         elif call and call.get("state") == "connecting":
             agent_num = get_available_agent() or (AGENT_NUMBERS[0] if AGENT_NUMBERS else "")
             if agent_num:

--- a/chat-with-ai-assistant-python/app.py
+++ b/chat-with-ai-assistant-python/app.py
@@ -22,8 +22,8 @@ def chat_with_assistant(assistant_id: str, user_message: str) -> dict:
     if not user_message or not user_message.strip():
         raise ValueError("Message cannot be empty")
     
-    # Use client.ai_assistants.chat() to send a message to the assistant
-    response = client.ai_assistants.chat(
+    # Use client.ai.assistants.chat() to send a message to the assistant
+    response = client.ai.assistants.chat(
         assistant_id=assistant_id,
         messages=[
             {

--- a/clone-ai-assistant-python/app.py
+++ b/clone-ai-assistant-python/app.py
@@ -16,7 +16,7 @@ client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
 
 def get_assistant_details(assistant_id: str) -> dict:
     """Retrieve full details of an assistant for inspection before cloning."""
-    response = client.ai_assistants.retrieve(assistant_id)
+    response = client.ai.assistants.retrieve(assistant_id)
     
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {
@@ -36,7 +36,7 @@ def clone_assistant(source_assistant_id: str, new_name: str = None, new_instruct
         raise ValueError("source_assistant_id is required")
     
     # Retrieve source assistant to validate it exists
-    source = client.ai_assistants.retrieve(source_assistant_id)
+    source = client.ai.assistants.retrieve(source_assistant_id)
     
     # Use provided overrides or fall back to source values
     clone_name = new_name if new_name else f"{source.data.name} (Clone)"
@@ -58,7 +58,7 @@ def clone_assistant(source_assistant_id: str, new_name: str = None, new_instruct
         clone_params["enabled_features"] = source.data.enabled_features
     
     # Create the cloned assistant
-    response = client.ai_assistants.create(**clone_params)
+    response = client.ai.assistants.create(**clone_params)
     
     # Extract serializable data
     return {

--- a/compliance-call-recorder-ai-auditor-python/app.py
+++ b/compliance-call-recorder-ai-auditor-python/app.py
@@ -177,8 +177,8 @@ def handle_voice():
     elif event_type == "call.answered":
         if call_control_id in call_records:
             # Start recording and transcription
-            client.calls.actions.record_start(call_control_id, format="mp3", channels="dual")
-            client.calls.actions.transcription_start(call_control_id, language="en")
+            client.calls.actions.start_recording(call_control_id, format="mp3", channels="dual")
+            client.calls.actions.start_transcription(call_control_id, language="en")
         return jsonify({"status": "recording"}), 200
 
     elif event_type == "call.transcription":

--- a/configure-sip-codecs-python/app.py
+++ b/configure-sip-codecs-python/app.py
@@ -61,7 +61,7 @@ def create_sip_connection_with_codecs(
         normalized_codecs.append(codec_map[codec])
     
     # Create SIP connection with codec preferences
-    response = client.sip_connections.create(
+    response = client.credential_connections.create(
         connection_name=name,
         outbound_voice_profile_id=None,
         inbound_sip_credentials=[
@@ -101,7 +101,7 @@ def get_sip_connection_codecs(connection_id: str) -> dict:
     Returns:
         Dictionary with connection details and current codec settings.
     """
-    response = client.sip_connections.retrieve(connection_id)
+    response = client.credential_connections.retrieve(connection_id)
     
     # Extract codec configuration from the response
     codecs = []
@@ -129,7 +129,7 @@ def list_sip_connections() -> list:
     Returns:
         List of dictionaries containing connection details.
     """
-    response = client.sip_connections.list()
+    response = client.credential_connections.list()
     
     connections = []
     for conn in response.data:

--- a/create-ai-assistant-python/app.py
+++ b/create-ai-assistant-python/app.py
@@ -14,29 +14,36 @@ app = Flask(__name__)
 client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
 
 
-def create_ai_assistant(name: str, instructions: str, model: str = "meta-llama/Meta-Llama-3.1-70B-Instruct", enabled_features: list = None) -> dict:
+def create_ai_assistant(
+    name: str,
+    instructions: str,
+    model: str = "meta-llama/Meta-Llama-3.1-70B-Instruct",
+    enabled_features: list = None,
+) -> dict:
     """Create AI assistant via Telnyx and return JSON-serializable response data."""
     if not name or not instructions:
         raise ValueError("Name and instructions are required")
-    
+
     # Default to messaging if no features specified
     if enabled_features is None:
         enabled_features = ["messaging"]
-    
+
     # Validate enabled features
     valid_features = ["messaging", "telephony"]
     for feature in enabled_features:
         if feature not in valid_features:
-            raise ValueError(f"Invalid feature: {feature}. Must be one of: {valid_features}")
-    
-    # Use client.ai_assistants.create() — NOT client.ai_assistants.create()
-    response = client.ai_assistants.create(
+            raise ValueError(
+                f"Invalid feature: {feature}. Must be one of: {valid_features}"
+            )
+
+    # Use client.ai.assistants.create() — NOT client.ai.assistants.create()
+    response = client.ai.assistants.create(
         name=name,
         instructions=instructions,
         model=model,
         enabled_features=enabled_features,
     )
-    
+
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {
         "id": response.data.id,
@@ -54,38 +61,42 @@ def create_assistant_endpoint():
     data = request.get_json()
     if not data:
         return jsonify({"error": "invalid request body"}), 400
-    
+
     if not data:
         return jsonify({"error": "Request body required"}), 400
-    
+
     name = data.get("name")
     instructions = data.get("instructions")
     model = data.get("model", "meta-llama/Meta-Llama-3.1-70B-Instruct")
     enabled_features = data.get("enabled_features", ["messaging"])
-    
+
     if not name or not instructions:
-        return jsonify({"error": "Missing required fields: 'name' and 'instructions'"}), 400
-    
+        return jsonify(
+            {"error": "Missing required fields: 'name' and 'instructions'"}
+        ), 400
+
     try:
         result = create_ai_assistant(name, instructions, model, enabled_features)
         return jsonify(result), 201
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
         return jsonify({"error": "Invalid request"}), 400
 
 
-
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200
+
 
 if __name__ == "__main__":
     app.run(debug=False, port=5000)

--- a/get-ai-assistant-python/app.py
+++ b/get-ai-assistant-python/app.py
@@ -19,8 +19,8 @@ def get_assistant(assistant_id: str) -> dict:
     if not assistant_id or not assistant_id.strip():
         raise ValueError("Assistant ID is required")
     
-    # Use client.ai_assistants.retrieve() — NOT client.ai_assistants.retrieve()
-    response = client.ai_assistants.retrieve(assistant_id)
+    # Use client.ai.assistants.retrieve() — NOT client.ai.assistants.retrieve()
+    response = client.ai.assistants.retrieve(assistant_id)
     
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {

--- a/hold-music-python/app.py
+++ b/hold-music-python/app.py
@@ -42,7 +42,7 @@ def start_hold_music(call_control_id: str) -> dict:
     # Use a royalty-free hold music URL or upload your own audio file
     hold_music_url = "https://www.soundjay.com/misc/sounds/bell-ringing-05.wav"
     
-    response = client.calls.actions.playback_start(
+    response = client.calls.actions.start_playback(
         call_control_id,
         audio_url=hold_music_url,
         loop=True,  # Loop the audio continuously
@@ -64,7 +64,7 @@ def stop_hold_music(call_control_id: str) -> dict:
         raise ValueError("Call not found")
     
     # Stop the current playback
-    client.calls.actions.playback_stop(call_control_id)
+    client.calls.actions.stop_playback(call_control_id)
     
     active_calls[call_control_id]["on_hold"] = False
     

--- a/inbound-sip-routing-python/app.py
+++ b/inbound-sip-routing-python/app.py
@@ -51,7 +51,7 @@ def create_sip_connection(name: str, sip_uri: str, username: str = None, passwor
             "sip_password": ""
         })
     
-    response = client.sip_connections.create(**connection_params)
+    response = client.credential_connections.create(**connection_params)
     
     # Extract serializable data from SDK response
     return {
@@ -66,7 +66,7 @@ def create_sip_connection(name: str, sip_uri: str, username: str = None, passwor
 
 def list_sip_connections() -> list:
     """Retrieve all SIP connections with routing information."""
-    response = client.sip_connections.list()
+    response = client.credential_connections.list()
     
     return [
         {
@@ -83,7 +83,7 @@ def list_sip_connections() -> list:
 
 def get_sip_connection(connection_id: str) -> dict:
     """Retrieve detailed information about a specific SIP connection."""
-    response = client.sip_connections.retrieve(connection_id)
+    response = client.credential_connections.retrieve(connection_id)
     
     return {
         "id": response.data.id,

--- a/list-ai-assistants-python/app.py
+++ b/list-ai-assistants-python/app.py
@@ -16,7 +16,7 @@ client = telnyx.Telnyx(api_key=os.getenv("TELNYX_API_KEY"))
 
 def fetch_assistants() -> list[dict]:
     """Retrieve all AI Assistants and return JSON-serializable data."""
-    response = client.ai_assistants.list()
+    response = client.ai.assistants.list()
 
     # SDK objects are NOT JSON-serializable — always unpack to plain dicts
     return [
@@ -44,15 +44,17 @@ def list_assistants():
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
-
 
 
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200
+
 
 if __name__ == "__main__":
     app.run(debug=False, port=5000)

--- a/long-code-sms-python/app.py
+++ b/long-code-sms-python/app.py
@@ -101,7 +101,7 @@ def queue_message(to_number: str, message: str, metadata: dict = None) -> dict:
 
 def send_queued_message(queue_item: dict) -> dict:
     """Send a single message from the queue via Telnyx API."""
-    response = client.messages.create(
+    response = client.messages.send(
         from_=Config.TELNYX_LONG_CODE,
         to=queue_item["to"],
         text=queue_item["text"],
@@ -161,7 +161,7 @@ def send_sms_endpoint():
         return jsonify({"error": "Missing required fields: 'to' and 'message'"}), 400
     
     try:
-        response = client.messages.create(
+        response = client.messages.send(
             from_=Config.TELNYX_LONG_CODE,
             to=to_number,
             text=message,

--- a/make-outbound-phone-call-python/app.py
+++ b/make-outbound-phone-call-python/app.py
@@ -18,16 +18,16 @@ def initiate_call(to_number: str) -> dict:
     """Initiate an outbound call via Telnyx and return JSON-serializable response data."""
     from_number = os.getenv("TELNYX_PHONE_NUMBER")
     connection_id = os.getenv("TELNYX_CONNECTION_ID")
-    
+
     if not from_number:
         raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
     if not connection_id:
         raise ValueError("TELNYX_CONNECTION_ID environment variable not set")
-    
+
     # Validate E.164 format to prevent API errors
     if not to_number.startswith("+"):
         raise ValueError("Phone number must be in E.164 format (e.g., +15551234567)")
-    
+
     # Use client.calls.dial() to initiate the call
     # connection_id is REQUIRED and links the call to your Call Control Application
     # call_control_id is RETURNED in the response — do NOT pass it as input
@@ -36,13 +36,13 @@ def initiate_call(to_number: str) -> dict:
         to=to_number,
         connection_id=connection_id,
     )
-    
+
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {
         "call_control_id": response.data.call_control_id,
         "from": from_number,
         "to": to_number,
-        "state": response.data.state,
+        "is_alive": response.data.is_alive,
     }
 
 
@@ -52,35 +52,37 @@ def dial_call_endpoint():
     data = request.get_json()
     if not data:
         return jsonify({"error": "invalid request body"}), 400
-    
+
     if not data:
         return jsonify({"error": "Request body required"}), 400
-    
+
     to_number = data.get("to")
-    
+
     if not to_number:
         return jsonify({"error": "Missing required field: 'to'"}), 400
-    
+
     try:
         result = initiate_call(to_number)
         return jsonify(result), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
         return jsonify({"error": "Invalid request"}), 400
 
 
-
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200
+
 
 if __name__ == "__main__":
     app.run(debug=False, port=5000)

--- a/media-stream-live-transcription-python/app.py
+++ b/media-stream-live-transcription-python/app.py
@@ -49,7 +49,7 @@ def handle_voice():
         client.calls.actions.answer(ccid)
         return jsonify({"status": "answering"}), 200
     elif event_type == "call.answered":
-        client.calls.actions.transcription_start(ccid, language="en")
+        client.calls.actions.start_transcription(ccid, language="en")
         client.calls.actions.speak(ccid, payload="This call is being transcribed in real time. Go ahead and speak.", voice="female", language_code="en-US")
         return jsonify({"status": "streaming"}), 200
     elif event_type == "call.transcription":

--- a/monitor-iot-data-usage-python/app.py
+++ b/monitor-iot-data-usage-python/app.py
@@ -180,7 +180,7 @@ def check_health(sim_card_id: str):
 def activate_sim(sim_card_id: str):
     """Activate a SIM card."""
     try:
-        response = client.sim_cards.activate(sim_card_id)
+        response = client.sim_cards.actions.enable(sim_card_id)
         
         return jsonify({
             "id": response.data.id,

--- a/phone-number-lookup-python/app.py
+++ b/phone-number-lookup-python/app.py
@@ -54,16 +54,16 @@ def lookup_phone_number(phone_number: str) -> dict:
     # Validate E.164 format
     if not phone_number.startswith("+"):
         raise ValueError("Phone number must be in E.164 format (e.g., +15551234567)")
-    
+
     # Check cache first
     cached_result = get_cached_lookup(phone_number)
     if cached_result:
         cached_result["from_cache"] = True
         return cached_result
-    
+
     # Call Telnyx Number Lookup API
     response = client.number_lookup.retrieve(phone_number)
-    
+
     # Extract serializable data from SDK response
     lookup_data = {
         "phone_number": response.data.phone_number,
@@ -72,18 +72,30 @@ def lookup_phone_number(phone_number: str) -> dict:
             "name": response.data.carrier.name if response.data.carrier else None,
             "type": response.data.carrier.type if response.data.carrier else None,
         },
-        "line_type": response.data.line_type,
-        "number_type": response.data.number_type,
+        # line_type and ported_status live on DataPortability, not on Data
         "portability": {
-            "status": response.data.portability.status if response.data.portability else None,
-            "last_checked_at": response.data.portability.last_checked_at if response.data.portability else None,
+            "line_type": response.data.portability.line_type
+            if response.data.portability
+            else None,
+            "ported_status": response.data.portability.ported_status
+            if response.data.portability
+            else None,
+            "spid_carrier_name": response.data.portability.spid_carrier_name
+            if response.data.portability
+            else None,
+            "city": response.data.portability.city
+            if response.data.portability
+            else None,
+            "state": response.data.portability.state
+            if response.data.portability
+            else None,
         },
         "from_cache": False,
     }
-    
+
     # Cache the result
     cache_lookup_result(phone_number, lookup_data)
-    
+
     return lookup_data
 
 
@@ -91,25 +103,27 @@ def lookup_phone_number(phone_number: str) -> dict:
 def lookup_endpoint():
     """HTTP endpoint to perform number lookup."""
     data = request.get_json()
-    
+
     if not data:
         return jsonify({"error": "Request body required"}), 400
-    
+
     phone_number = data.get("phone_number")
-    
+
     if not phone_number:
         return jsonify({"error": "Missing required field: 'phone_number'"}), 400
-    
+
     try:
         result = lookup_phone_number(phone_number)
         return jsonify(result), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError:
@@ -121,17 +135,19 @@ def lookup_get_endpoint(phone_number: str):
     """HTTP GET endpoint to perform number lookup via URL parameter."""
     if not phone_number:
         return jsonify({"error": "Phone number required in URL path"}), 400
-    
+
     try:
         result = lookup_phone_number(phone_number)
         return jsonify(result), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError:
@@ -141,10 +157,12 @@ def lookup_get_endpoint(phone_number: str):
 @app.route("/cache/stats", methods=["GET"])
 def cache_stats_endpoint():
     """Return cache statistics for monitoring."""
-    return jsonify({
-        "cache_size": len(lookup_cache),
-        "cached_numbers": list(lookup_cache.keys()),
-    }), 200
+    return jsonify(
+        {
+            "cache_size": len(lookup_cache),
+            "cached_numbers": list(lookup_cache.keys()),
+        }
+    ), 200
 
 
 if __name__ == "__main__":

--- a/programmable-hold-experience-python/app.py
+++ b/programmable-hold-experience-python/app.py
@@ -72,7 +72,7 @@ def handle_voice():
                 hold["offered_callback"] = True
                 client.calls.actions.speak(ccid, payload="You've been waiting a while. Press 9 and we'll call you back when an agent is free.", voice="female", language_code="en-US")
             elif HOLD_MUSIC_URL:
-                client.calls.actions.playback_start(ccid, audio_url=HOLD_MUSIC_URL)
+                client.calls.actions.start_playback(ccid, audio_url=HOLD_MUSIC_URL)
             else:
                 tip = secrets.choice(TIPS + TRIVIA)
                 hold["tip_idx"] += 1

--- a/provision-esim-python/app.py
+++ b/provision-esim-python/app.py
@@ -50,7 +50,7 @@ def create_esim_profile(client, device_name: str, sim_card_group_id: str) -> dic
 
 def activate_esim_profile(client, sim_card_id: str) -> dict:
     """Activate an eSIM profile for network connectivity."""
-    response = client.sim_cards.activate(sim_card_id)
+    response = client.sim_cards.actions.enable(sim_card_id)
     
     return {
         "id": response.data.id,

--- a/real-time-call-intelligence-dashboard-python/app.py
+++ b/real-time-call-intelligence-dashboard-python/app.py
@@ -126,7 +126,7 @@ def handle_voice():
         return jsonify({"status": "answering"}), 200
 
     elif event_type == "call.answered":
-        client.calls.actions.transcription_start(call_control_id, language="en")
+        client.calls.actions.start_transcription(call_control_id, language="en")
         return jsonify({"status": "transcribing"}), 200
 
     elif event_type == "call.transcription":

--- a/schedule-sms-messages-python/app.py
+++ b/schedule-sms-messages-python/app.py
@@ -39,7 +39,7 @@ def send_scheduled_sms(job_id: str, to_number: str, message: str) -> None:
     from_number = os.getenv("TELNYX_PHONE_NUMBER")
     
     try:
-        response = client.messages.create(
+        response = client.messages.send(
             from_=from_number,
             to=to_number,
             text=message,

--- a/scripts/check_sdk_calls.py
+++ b/scripts/check_sdk_calls.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Validate SDK method calls in example app.py files against the installed telnyx package.
+
+AST-parses each Python example's app.py, finds ``client.X.Y(...)`` call chains
+(where ``client`` is a ``telnyx.Telnyx(...)`` instance), and resolves every link
+of the chain against the installed ``telnyx`` SDK to confirm the attribute or
+method actually exists.
+
+This catches the class of defect where an example references a SDK method or
+field that does not exist on the current package — e.g. ``client.messages.create()``
+(should be ``.send()``) or ``client.ai_assistants.create()`` (should be
+``client.ai.assistants.create()``).
+
+Usage:
+    python scripts/check_sdk_calls.py                       # Check all Python examples
+    python scripts/check_sdk_calls.py --only send-sms-python  # Check one example
+    python scripts/check_sdk_calls.py --verbose               # Show OK lines too
+"""
+
+import argparse
+import ast
+import importlib
+import inspect
+import os
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple
+
+SCRIPTS_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPTS_DIR.parent
+
+
+class SdkViolation(NamedTuple):
+    file: str
+    line: int
+    chain: str
+    problem: str
+
+
+def _instantiate_client() -> Any:
+    """Create a throwaway telnyx.Telnyx client for introspection."""
+    import telnyx  # noqa: delayed import so the script can run even if telnyx is absent
+
+    return telnyx.Telnyx(api_key="placeholder_for_introspection_only")
+
+
+def _resolve_attr(obj: Any, name: str) -> tuple[Any, str | None]:
+    """Resolve a single attribute access, returning (value, error).
+
+    ``error`` is None on success, or a human-readable reason on failure.
+    """
+    # Built-in attributes that exist on every object — don't flag these.
+    if name in ("data", "id", "model", "model_fields", "__fields__"):
+        return getattr(obj, name, None), None
+    if hasattr(obj, name):
+        return getattr(obj, name), None
+    # Pydantic models expose declared fields via model_fields/__fields__,
+    # so check there before declaring the attribute missing.
+    for fields_attr in ("model_fields", "__fields__", "__dataclass_fields__"):
+        fields = getattr(obj, fields_attr, None)
+        if isinstance(fields, dict) and name in fields:
+            return getattr(obj, name, None), None
+    return None, f"attribute '{name}' not found on {type(obj).__name__}"
+
+
+def _resolve_chain(root: Any, parts: list[str]) -> str | None:
+    """Walk ``root.a.b.c`` and return None if valid, or an error string."""
+    current = root
+    for i, part in enumerate(parts):
+        current, err = _resolve_attr(current, part)
+        if err is not None:
+            chain_so_far = ".".join(parts[: i + 1])
+            return f"{chain_so_far}: {err}"
+    return None
+
+
+class SdkCallVisitor(ast.NodeVisitor):
+    """Walk an AST and collect ``client.X.Y(...)`` chains for validation."""
+
+    def __init__(self, client_var_names: set[str]):
+        self.client_var_names = client_var_names
+        self.chains: list[tuple[int, list[str]]] = []
+
+    def _is_telnyx_client_init(self, node: ast.Call) -> str | None:
+        """Return the var name if this Call is `var = telnyx.Telnyx(...)`, else None."""
+        if not isinstance(node.func, ast.Attribute):
+            return None
+        if node.func.attr != "Telnyx":
+            return None
+        # Check the module is `telnyx` — best-effort name match
+        return None  # handled by _scan_for_client_vars instead
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Only consider calls of the form  client_var.a.b.c(...)
+        func = node.func
+        parts: list[str] = []
+        while isinstance(func, ast.Attribute):
+            parts.append(func.attr)
+            func = func.value
+        if isinstance(func, ast.Name) and func.id in self.client_var_names:
+            parts.reverse()
+            if len(parts) >= 2:  # at least "resource.method"
+                self.chains.append((node.lineno, parts))
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        # Also catch non-call attribute access like `client.foo.bar` (no call)
+        # only if it's a response.data-style access — but we focus on calls.
+        self.generic_visit(node)
+
+
+def _scan_for_client_vars(tree: ast.AST) -> set[str]:
+    """Find variable names assigned from `telnyx.Telnyx(...)` calls."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        # Match `telnyx.Telnyx(...)` or just `Telnyx(...)` at module level
+        func = call.func
+        is_telnyx_init = False
+        if isinstance(func, ast.Attribute) and func.attr == "Telnyx":
+            is_telnyx_init = True
+        elif isinstance(func, ast.Name) and func.id == "Telnyx":
+            is_telnyx_init = True
+        if not is_telnyx_init:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                names.add(target.id)
+    return names
+
+
+def check_file(file_path: Path, client: Any) -> list[SdkViolation]:
+    """Parse a single app.py and return SDK violations found."""
+    try:
+        source = file_path.read_text()
+    except OSError as e:
+        return [SdkViolation(str(file_path), 0, "(read)", str(e))]
+
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError as e:
+        return [SdkViolation(str(file_path), e.lineno or 0, "(parse)", str(e))]
+
+    client_vars = _scan_for_client_vars(tree)
+    if not client_vars:
+        return []  # No client detected — nothing to check
+
+    visitor = SdkCallVisitor(client_vars)
+    visitor.visit(tree)
+
+    violations: list[SdkViolation] = []
+    for lineno, parts in visitor.chains:
+        err = _resolve_chain(client, parts)
+        if err is not None:
+            chain_str = "client." + ".".join(parts)
+            violations.append(SdkViolation(str(file_path.name), lineno, chain_str, err))
+    return violations
+
+
+def find_python_examples() -> list[Path]:
+    """Discover every `<example>/app.py` under the repo root."""
+    results: list[Path] = []
+    for app_py in REPO_ROOT.rglob("app.py"):
+        # Skip vendor/build dirs
+        if any(
+            part in ("node_modules", ".venv", "venv", "__pycache__")
+            for part in app_py.parts
+        ):
+            continue
+        # Only include if the parent dir looks like an example (has a README.md)
+        if (app_py.parent / "README.md").exists():
+            results.append(app_py)
+    return sorted(results)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate SDK method calls in Python example app.py files.",
+    )
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="Check only the specified example folder name.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show OK lines as well as violations.",
+    )
+    args = parser.parse_args()
+
+    # Import telnyx once; fail loudly if it isn't installed.
+    try:
+        client = _instantiate_client()
+    except ImportError as e:
+        print(f"ERROR: telnyx package not installed: {e}", file=sys.stderr)
+        print("Install with: pip install telnyx", file=sys.stderr)
+        return 2
+
+    files = find_python_examples()
+    if args.only:
+        files = [f for f in files if f.parent.name == args.only]
+
+    if not files:
+        print("No Python app.py examples found.")
+        return 0
+
+    total_violations = 0
+    checked = 0
+
+    for file_path in files:
+        checked += 1
+        violations = check_file(file_path, client)
+        folder = file_path.parent.name
+
+        if violations:
+            print(f"FAIL   {folder}/{file_path.name}")
+            for v in violations:
+                print(f"  line {v.line}: {v.chain} — {v.problem}")
+            total_violations += len(violations)
+        elif args.verbose:
+            print(f"OK     {folder}/{file_path.name}")
+
+    print()
+    print(f"Checked: {checked}  Violations: {total_violations}")
+
+    if total_violations > 0:
+        print(f"\n{total_violations} SDK call(s) reference attributes or methods")
+        print("that do not exist on the installed telnyx package.")
+        return 1
+
+    print("All SDK calls resolve against the installed telnyx package.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/send-bulk-sms-python/app.py
+++ b/send-bulk-sms-python/app.py
@@ -45,7 +45,7 @@ def send_single_sms(to_number: str, message: str) -> Dict[str, Any]:
     if not validate_phone_number(to_number):
         raise ValueError(f"Invalid phone number format: {to_number}. Use E.164 format (e.g., +15551234567)")
     
-    response = client.messages.create(
+    response = client.messages.send(
         from_=TELNYX_PHONE_NUMBER,
         to=to_number,
         text=message,

--- a/send-mms-picture-message-python/app.py
+++ b/send-mms-picture-message-python/app.py
@@ -54,8 +54,8 @@ def send_mms(to_number: str, message: str, media_urls: list) -> dict:
         if not validate_media_url(url):
             raise ValueError(f"Invalid media URL format: {url}")
     
-    # Use client.messages.create() with media_urls parameter for MMS
-    response = client.messages.create(
+    # Use client.messages.send() with media_urls parameter for MMS
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,

--- a/send-sms-notifications-python/app.py
+++ b/send-sms-notifications-python/app.py
@@ -102,7 +102,7 @@ def send_notification(recipient: str, message: str, notification_type: str = "al
     notification.id = notification_counter
     
     try:
-        response = client.messages.create(
+        response = client.messages.send(
             from_=from_number,
             to=recipient,
             text=message,

--- a/send-sms-python/app.py
+++ b/send-sms-python/app.py
@@ -19,18 +19,18 @@ def send_sms(to_number: str, message: str) -> dict:
     from_number = os.getenv("TELNYX_PHONE_NUMBER")
     if not from_number:
         raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
-    
+
     # Validate E.164 format to prevent API errors
     if not to_number.startswith("+"):
         raise ValueError("Phone number must be in E.164 format (e.g., +15551234567)")
-    
-    # Use client.messages.create() with proper parameters
-    response = client.messages.create(
+
+    # Use client.messages.send() with proper parameters
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,
     )
-    
+
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {
         "message_id": response.data.id,
@@ -46,36 +46,38 @@ def send_sms_endpoint():
     data = request.get_json()
     if not data:
         return jsonify({"error": "invalid request body"}), 400
-    
+
     if not data:
         return jsonify({"error": "Request body required"}), 400
-    
+
     to_number = data.get("to")
     message = data.get("message")
-    
+
     if not to_number or not message:
         return jsonify({"error": "Missing required fields: 'to' and 'message'"}), 400
-    
+
     try:
         result = send_sms(to_number, message)
         return jsonify(result), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
         return jsonify({"error": "Invalid request"}), 400
 
 
-
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200
+
 
 if __name__ == "__main__":
     app.run(debug=False, port=5000)

--- a/setup-sip-trunk-python/app.py
+++ b/setup-sip-trunk-python/app.py
@@ -19,19 +19,19 @@ def create_sip_connection(name: str, username: str, password: str) -> dict:
     # Validate input to prevent API errors
     if not name or not username or not password:
         raise ValueError("Name, username, and password are required")
-    
-    # Use client.sip_connections.create() — NOT client.sip_connections.create()
-    response = client.sip_connections.create(
-        name=name,
-        username=username,
+
+    # Use client.credential_connections.create() — NOT client.credential_connections.create()
+    response = client.credential_connections.create(
+        connection_name=name,
+        user_name=username,
         password=password,
     )
-    
+
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {
         "id": response.data.id,
-        "name": response.data.name,
-        "username": response.data.username,
+        "connection_name": response.data.connection_name,
+        "user_name": response.data.user_name,
     }
 
 
@@ -41,37 +41,41 @@ def setup_sip_endpoint():
     data = request.get_json()
     if not data:
         return jsonify({"error": "invalid request body"}), 400
-    
+
     if not data:
         return jsonify({"error": "Request body required"}), 400
-    
+
     name = data.get("name")
     username = data.get("username")
     password = data.get("password")
-    
+
     if not name or not username or not password:
-        return jsonify({"error": "Missing required fields: 'name', 'username', and 'password'"}), 400
-    
+        return jsonify(
+            {"error": "Missing required fields: 'name', 'username', and 'password'"}
+        ), 400
+
     try:
         result = create_sip_connection(name, username, password)
         return jsonify(result), 200
-        
+
     except telnyx.AuthenticationError:
         return jsonify({"error": "Invalid API key"}), 401
     except telnyx.RateLimitError:
         return jsonify({"error": "Rate limit exceeded. Please slow down."}), 429
     except telnyx.APIStatusError as e:
-        return jsonify({"error": "API request failed", "status_code": e.status_code}), e.status_code
+        return jsonify(
+            {"error": "API request failed", "status_code": e.status_code}
+        ), e.status_code
     except telnyx.APIConnectionError:
         return jsonify({"error": "Network error connecting to Telnyx"}), 503
     except ValueError as e:
         return jsonify({"error": "Invalid request"}), 400
 
 
-
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200
+
 
 if __name__ == "__main__":
     app.run(debug=False, port=5000)

--- a/shortcode-sms-python/app.py
+++ b/shortcode-sms-python/app.py
@@ -42,7 +42,7 @@ def send_shortcode_sms(to_number: str, message: str) -> dict:
         raise ValueError("Message exceeds maximum length (1600 characters)")
     
     # Send message using shortcode as from_number
-    response = client.messages.create(
+    response = client.messages.send(
         from_=TELNYX_SHORTCODE,
         to=to_number,
         text=message,

--- a/sip-cnam-lookup-python/app.py
+++ b/sip-cnam-lookup-python/app.py
@@ -56,7 +56,7 @@ def lookup_cnam(phone_number: str) -> dict:
 
 def get_sip_connections() -> list:
     """Retrieve SIP connections for reference."""
-    response = client.sip_connections.list()
+    response = client.credential_connections.list()
     return [
         {
             "id": c.id,

--- a/sip-failover-routing-python/app.py
+++ b/sip-failover-routing-python/app.py
@@ -35,7 +35,7 @@ sip_endpoints = {
 
 def create_sip_connection(name: str, endpoint_ip: str, endpoint_port: int) -> dict:
     """Create a SIP connection via Telnyx API."""
-    response = client.sip_connections.create(
+    response = client.credential_connections.create(
         connection_name=name,
         outbound_voice_profile_id=None,
         inbound_sip_credentials=[
@@ -57,7 +57,7 @@ def create_sip_connection(name: str, endpoint_ip: str, endpoint_port: int) -> di
 
 def list_sip_connections() -> list:
     """Retrieve all SIP connections from Telnyx."""
-    response = client.sip_connections.list()
+    response = client.credential_connections.list()
     
     # Extract serializable data from list
     return [
@@ -72,7 +72,7 @@ def list_sip_connections() -> list:
 
 def get_sip_connection(connection_id: str) -> dict:
     """Retrieve a specific SIP connection by ID."""
-    response = client.sip_connections.retrieve(connection_id)
+    response = client.credential_connections.retrieve(connection_id)
     
     # Extract serializable data
     return {

--- a/sip-registration-python/app.py
+++ b/sip-registration-python/app.py
@@ -20,7 +20,7 @@ def create_sip_connection(connection_name: str, username: str, password: str) ->
         raise ValueError("Connection name, username, and password are required")
     
     # Create SIP connection with credential authentication
-    response = client.sip_connections.create(
+    response = client.credential_connections.create(
         connection_name=connection_name,
         user_name=username,
         password=password,
@@ -58,7 +58,7 @@ def create_sip_connection(connection_name: str, username: str, password: str) ->
 
 def get_sip_connection(connection_id: str) -> dict:
     """Retrieve SIP connection details by ID."""
-    response = client.sip_connections.retrieve(connection_id)
+    response = client.credential_connections.retrieve(connection_id)
     
     return {
         "id": response.data.id,
@@ -74,7 +74,7 @@ def get_sip_connection(connection_id: str) -> dict:
 
 def list_sip_connections() -> list:
     """List all SIP connections for the account."""
-    response = client.sip_connections.list()
+    response = client.credential_connections.list()
     
     return [
         {

--- a/sms-auto-reply-bot-python/app.py
+++ b/sms-auto-reply-bot-python/app.py
@@ -61,7 +61,7 @@ def send_auto_reply(to_number: str, message: str) -> dict:
     if not from_number:
         raise ValueError("TELNYX_PHONE_NUMBER environment variable not set")
     
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,

--- a/sms-conversation-threading-python/app.py
+++ b/sms-conversation-threading-python/app.py
@@ -146,7 +146,7 @@ def send_message_to_contact(to_number: str, body: str) -> dict:
     
     conversation_id = get_or_create_conversation(to_number)
     
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=body,

--- a/sms-delivery-receipts-python/app.py
+++ b/sms-delivery-receipts-python/app.py
@@ -78,7 +78,7 @@ def send_sms_with_tracking(to_number: str, message: str) -> dict:
         raise ValueError("Phone number must be in E.164 format (e.g., +15551234567)")
     
     # Send message via Telnyx API
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,

--- a/sms-marketing-campaign-python/app.py
+++ b/sms-marketing-campaign-python/app.py
@@ -85,7 +85,7 @@ def send_sms_message(to_number: str, message: str, campaign_id: str = None) -> d
         raise ValueError(f"Invalid phone number format: {to_number}. Use E.164 format.")
     
     # Create message with optional campaign tracking
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,

--- a/sms-opt-out-management-python/app.py
+++ b/sms-opt-out-management-python/app.py
@@ -150,7 +150,7 @@ def send_sms(to_number: str, message: str) -> dict:
         raise ValueError(f"Recipient {to_number} has opted out of SMS messages")
     
     # Send message via Telnyx
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,

--- a/sms-survey-bot-python/app.py
+++ b/sms-survey-bot-python/app.py
@@ -57,7 +57,7 @@ def start_survey(to_number: str) -> dict:
     
     # Send the first question
     first_question = SURVEY_QUESTIONS[0]
-    response = client.messages.create(
+    response = client.messages.send(
         from_=TELNYX_PHONE_NUMBER,
         to=to_number,
         text=first_question["text"],
@@ -93,7 +93,7 @@ def process_survey_response(from_number: str, message_text: str) -> dict:
     
     # Validate response against allowed options
     if message_text.strip() not in current_question["valid_responses"]:
-        response = client.messages.create(
+        response = client.messages.send(
             from_=TELNYX_PHONE_NUMBER,
             to=from_number,
             text=f"Invalid response. {current_question['text']}",
@@ -118,7 +118,7 @@ def process_survey_response(from_number: str, message_text: str) -> dict:
             f"Thank you for completing the survey! Your responses have been recorded. "
             f"Total questions answered: {len(participant_state['responses'])}"
         )
-        response = client.messages.create(
+        response = client.messages.send(
             from_=TELNYX_PHONE_NUMBER,
             to=from_number,
             text=completion_message,
@@ -135,7 +135,7 @@ def process_survey_response(from_number: str, message_text: str) -> dict:
     next_question = SURVEY_QUESTIONS[next_q_index]
     participant_state["current_question"] = next_q_index
     
-    response = client.messages.create(
+    response = client.messages.send(
         from_=TELNYX_PHONE_NUMBER,
         to=from_number,
         text=next_question["text"],

--- a/sms-two-factor-auth-python/app.py
+++ b/sms-two-factor-auth-python/app.py
@@ -58,7 +58,7 @@ def send_otp_sms(phone_number: str, otp_code: str) -> dict:
     
     message_text = f"Your verification code is: {otp_code}. Valid for {OTP_EXPIRY_SECONDS // 60} minutes."
     
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=phone_number,
         text=message_text,

--- a/storage-voicemail-archive-python/app.py
+++ b/storage-voicemail-archive-python/app.py
@@ -59,7 +59,7 @@ def handle_voice():
         client.calls.actions.speak(ccid, payload="Please leave your message after the beep.", voice="female", language_code="en-US")
         return jsonify({"status": "greeting"}), 200
     elif event_type == "call.speak.ended":
-        client.calls.actions.record_start(ccid, format="mp3", channels="single", play_beep=True, max_length_secs=120)
+        client.calls.actions.start_recording(ccid, format="mp3", channels="single", play_beep=True, max_length_secs=120)
         return jsonify({"status": "recording"}), 200
     elif event_type == "call.recording.saved":
         recording_url = p.get("recording_urls", {}).get("mp3", "")

--- a/toll-free-sms-python/app.py
+++ b/toll-free-sms-python/app.py
@@ -72,7 +72,7 @@ def send_tollfree_sms(to_number: str, message: str, messaging_profile_id: str = 
         if messaging_profile_id:
             create_params["messaging_profile_id"] = messaging_profile_id
 
-        response = client.messages.create(**create_params)
+        response = client.messages.send(**create_params)
 
         # Extract serializable data — SDK objects are NOT JSON-serializable
         message_id = response.data.id

--- a/two-way-sms-chat-python/app.py
+++ b/two-way-sms-chat-python/app.py
@@ -33,7 +33,7 @@ def send_sms(to_number: str, message: str) -> dict:
     if not to_number.startswith("+"):
         raise ValueError("Phone number must be in E.164 format")
     
-    response = client.messages.create(
+    response = client.messages.send(
         from_=from_number,
         to=to_number,
         text=message,

--- a/update-ai-assistant-python/app.py
+++ b/update-ai-assistant-python/app.py
@@ -50,8 +50,8 @@ def update_assistant(
     if not update_params:
         raise ValueError("At least one field must be provided for update")
     
-    # Use client.ai_assistants.update() — NOT client.ai_assistants.update()
-    response = client.ai_assistants.update(assistant_id, **update_params)
+    # Use client.ai.assistants.update() — NOT client.ai.assistants.update()
+    response = client.ai.assistants.update(assistant_id, **update_params)
     
     # Extract serializable data — SDK objects are NOT JSON-serializable
     return {

--- a/webrtc-ai-interpreter-live-calls-python/app.py
+++ b/webrtc-ai-interpreter-live-calls-python/app.py
@@ -72,7 +72,7 @@ def handle_voice():
         client.calls.actions.speak(ccid, payload="AI interpreter connected. I will translate between English and Spanish. Go ahead and speak.", voice="female", language_code="en-US")
         return jsonify({"status": "ready"}), 200
     elif event_type == "call.speak.ended" and call:
-        client.calls.actions.transcription_start(ccid, language="en")
+        client.calls.actions.start_transcription(ccid, language="en")
         return jsonify({"status": "listening"}), 200
     elif event_type == "call.transcription" and call:
         text = p.get("transcription_data", {}).get("transcript", "")


### PR DESCRIPTION
## Summary

A third-party friction audit found 7 Python examples using non-existent `telnyx` SDK methods. A new SDK call resolution checker found **41 more broken examples** — **48 total** fixed in this PR.

## What was broken

| Pattern | Files | Fix |
|---|---|---|
| `messages.create()` | 20 | → `messages.send()` |
| `calls.actions.transcription_start()` | 7 | → `start_transcription()` |
| `calls.actions.record_start()` | 6 | → `start_recording()` |
| `calls.actions.playback_start()` | 3 | → `start_playback()` |
| `calls.actions.playback_stop()` | 1 | → `stop_playback()` |
| `sip_connections.*` | 5 | → `credential_connections.*` |
| `ai_assistants.*` | 6 | → `ai.assistants.*` |
| `sim_cards.activate()` | 2 | → `sim_cards.actions.enable()` |
| `response.data.state` | 1 | → `response.data.is_alive` |
| `response.data.line_type` / `number_type` | 1 | → `portability.line_type` / `ported_status` |
| `credential_connections.create` params | 1 | `name`→`connection_name`, `username`→`user_name` |

## What's new

- **`scripts/check_sdk_calls.py`** — AST-parses each `app.py`, finds `client.X.Y(...)` call chains, resolves every link against the installed `telnyx.Client` to verify the attribute/method exists
- **`.github/workflows/api-contract-check.yml`** — new `sdk-call-check` job using a ratchet pattern:
  - **PRs**: only checks `app.py` files changed in the PR (avoids blocking on pre-existing issues)
  - **Scheduled/manual**: checks all 262 Python examples

## Verification

```
$ python scripts/check_sdk_calls.py
Checked: 262  Violations: 0
All SDK calls resolve against the installed telnyx package.
```

All method names verified against `telnyx==4.170.0` via SDK introspection.

## Test plan

- [x] `check_sdk_calls.py` reports 0 violations across all 262 Python examples
- [x] All 48 modified `app.py` files pass individually (`--only <folder>`)
- [x] CI workflow updated with ratchet pattern for PRs