### PR TITLE
Improve AI PCI payment collection prompts

### DIFF
--- a/ai-pci-protected-payment-collection-python/app.py
+++ b/ai-pci-protected-payment-collection-python/app.py
@@ -32,7 +32,7 @@ app = Flask(__name__)
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY", "")
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY", "")
 PAY_CONNECTOR_NAME = os.getenv("PAY_CONNECTOR_NAME", "Default")
-PAYMENT_DESCRIPTION = os.getenv("PAYMENT_DESCRIPTION", "past-due payment plan")
+PAYMENT_DESCRIPTION = os.getenv("PAYMENT_DESCRIPTION", "pci protected payment collection")
 TELNYX_ASSISTANT_ID = os.getenv("TELNYX_ASSISTANT_ID", "")
 TOOL_SECRET = os.getenv("TOOL_SECRET", "")
 DEMO_CUSTOMER_ID = os.getenv("DEMO_CUSTOMER_ID", "acct_1042")
@@ -202,10 +202,10 @@ def start_pay_session(
             "demo": "ai-pci-protected-payment-collection-python",
         },
         "prompts": {
-            "payment-card-number": "please enter your card number using the keypad.",
-            "expiration-date": "please enter the expiration date as four digits, month first.",
-            "postal-code": "please enter your billing zip code.",
-            "security-code": "please enter your security code.",
+            "payment-card-number": "please enter your card number now using the keypad.",
+            "expiration-date": "please enter the expiration date as four digits, month first. for example, zero eight two seven for august twenty twenty seven.",
+            "postal-code": "please enter your billing zip code using the keypad.",
+            "security-code": "please enter the three digit security code from the back of your card.",
         },
         "client_state": encode_state({"call_control_id": call_control_id, "phase": "pay"}),
     }

--- a/ai-pci-protected-payment-collection-python/provision_assistant.py
+++ b/ai-pci-protected-payment-collection-python/provision_assistant.py
@@ -51,21 +51,27 @@ def instructions(customer: dict[str, Any]) -> str:
     customer_id = customer["id"]
     dob = customer["dob"]
     days = customer["days_past_due"]
-    return f"""you are the automated billing assistant for a payment collection demo.
+    return f"""voice: voice ultra katie
+
+you are the automated billing assistant for an ai pci protected payment collection demo.
 
 you are having a live phone conversation. be warm, concise, and natural. ask one question at a time. do not sound like an ivr.
+
+opening behavior: briefly explain why the caller reached this line before asking for verification. say that you can explain the account status, answer basic billing questions, help set up a payment plan, and start a secure keypad payment collection step when the caller is ready.
 
 you are helping {name.lower()} with account {customer_id}. the account is {days} days past due with a balance of {balance} dollars. the caller's date of birth is {dob}.
 
 first, verify the caller by asking for date of birth. accept natural date formats if they match {dob}. do not disclose the balance until verified.
 
-after verification, say the account is {days} days past due with a balance of {balance} dollars. offer to take payment in full or set up a weekly payment plan.
+after verification, explain the account status in plain language. say the account is {days} days past due with a balance of {balance} dollars. offer to answer questions, take payment in full, or set up a weekly payment plan.
 
 if the caller asks for a weekly payment plan, calculate a short plan summary. ask if they agree to the plan and agree to start secure keypad card entry.
 
 only after the caller clearly agrees, use the start_secure_payment tool. pass amount_now, weekly_amount, customer_id as {customer_id}, and a short plan_summary.
 
-before using the tool, tell the caller that telnyx pay over voice will collect their card details by keypad and that they should not say card numbers out loud.
+before using the tool, say: i will start telnyx pay over voice now. for your protection, please do not say your card number out loud. the secure payment system will ask you to enter your card number, expiration date, billing zip code, and security code using your phone keypad.
+
+after the start_secure_payment tool returns, say: the secure keypad payment step is starting now. listen for each prompt and use your phone keypad for each answer. do not speak the card details out loud.
 
 during pay over voice, do not ask for card numbers, expiration dates, security codes, postal codes, or zip codes. telnyx pay over voice handles that secure step.
 
@@ -193,8 +199,8 @@ def main() -> None:
         "name": assistant_name,
         "model": os.getenv("AI_MODEL", DEFAULT_MODEL),
         "instructions": instructions(customer),
-        "greeting": "hi, this is the automated billing line. i can help with your past-due account and set up a payment plan. to protect your account, can you tell me your date of birth?",
-        "description": "pci-protected payment collection assistant that starts telnyx pay over voice for keypad card entry.",
+        "greeting": "hi, you have reached the ai pci protected payment collection line. i can explain your account status, answer basic billing questions, help set up a payment plan, and start a secure keypad payment step when you are ready. to protect your account, can you first tell me your date of birth?",
+        "description": "ai pci protected payment collection assistant that explains account status, supports payment plans, and starts telnyx pay over voice for secure keypad card entry.",
         "enabled_features": ["telephony"],
         "tool_ids": tool_ids,
     }


### PR DESCRIPTION
## Summary
- clarify the assistant greeting so callers understand the account and payment-plan flow
- make the secure Pay over Voice handoff explicit before tool invocation
- expand keypad payment prompts for card number, expiration date, billing ZIP, and security code

## Validation
- python3 -m py_compile ai-pci-protected-payment-collection-python/app.py ai-pci-protected-payment-collection-python/provision_assistant.py
- python scripts/verify.py --verbose
- python3 scripts/rewrite_repo_links.py --check
- python scripts/gen_llms_txt.py --check