### PR TITLE
Fix PCI Pay over Voice sample flow

### DIFF
--- a/ai-pci-protected-payment-collection-python/API.md
+++ b/ai-pci-protected-payment-collection-python/API.md
@@ -36,7 +36,7 @@ The endpoint accepts the optional `X-Demo-Tool-Secret` header when `TOOL_SECRET`
 
 ## `POST /tools/record-payment-complete`
 
-Assistant webhook tool that records a sanitized completion marker for Conversation Analysis and the local dashboard.
+Assistant webhook tool that records a sanitized completion marker for Conversation Analysis and the local dashboard. This endpoint returns `409` until Telnyx has sent a `call.payment.completed` or `call_payment_completed` event for the call.
 
 ### Response
 

--- a/ai-pci-protected-payment-collection-python/GUIDE.md
+++ b/ai-pci-protected-payment-collection-python/GUIDE.md
@@ -16,4 +16,4 @@ The demo dashboard is intentionally sanitized. It shows that payment collection 
 
 ## Demo Completion
 
-Pay over Voice emits progress and completion webhooks when the IVR flow finishes. The sample also includes `record_secure_payment_complete`, a second assistant tool that writes a PCI-safe completion marker into Conversation Analysis without exposing card details.
+Pay over Voice emits progress and completion webhooks when the IVR flow finishes. The sample also includes `record_secure_payment_complete`, a second assistant tool that writes a PCI-safe completion marker into Conversation Analysis without exposing card details. The app returns `409` from that tool until Telnyx has sent a payment completion event, so the marker cannot be used as proof that payment completed by itself.

--- a/ai-pci-protected-payment-collection-python/README.md
+++ b/ai-pci-protected-payment-collection-python/README.md
@@ -19,7 +19,7 @@ The important PCI point is that the app does **not** gather card digits itself. 
 The assistant uses two webhook tools:
 
 - `start_secure_payment` starts Telnyx Pay over Voice after the caller agrees to a payment plan.
-- `record_secure_payment_complete` records a sanitized completion marker that is visible in Conversation Analysis without exposing card details.
+- `record_secure_payment_complete` records a sanitized completion marker only after Telnyx sends a Pay over Voice completion event.
 
 ## Telnyx DevDocs Used
 
@@ -35,10 +35,10 @@ The assistant uses two webhook tools:
 4. The assistant verifies DOB and negotiates the payment plan naturally.
 5. Caller confirms consent to secure card collection.
 6. The assistant calls the `start_secure_payment` webhook tool.
-7. The Flask tool starts `POST /v2/calls/{call_control_id}/actions/pay`.
+7. The Flask tool starts `POST /v2/calls/{call_control_id}/pay` on the active call.
 8. Telnyx Pay over Voice collects card number, expiration, zip, and security code.
 9. Telnyx sends payment progress/completed webhooks to the app.
-10. The assistant calls `record_secure_payment_complete` to create a PCI-safe completion marker for the portal and dashboard.
+10. After Telnyx sends a payment completion event, the assistant can call `record_secure_payment_complete` to create a PCI-safe completion marker for the portal and dashboard.
 
 ## Setup
 
@@ -225,6 +225,7 @@ This demo is designed to show a compliant architecture pattern, not to certify y
 - If the assistant does not answer, confirm `TELNYX_ASSISTANT_ID` is set and the Voice API application webhook points to `/webhooks/voice`.
 - If the assistant tool fails with `unauthorized tool request`, make sure `TOOL_SECRET` in `.env` matches the value used by `provision_assistant.py`.
 - If Pay over Voice does not start, confirm `PAY_CONNECTOR_NAME` matches the connector created by `provision_assistant.py`.
+- If Pay starts but no progress or completion events appear, confirm the Pay Connector endpoint is reachable at `/webhooks/payment-processor` and returns either `charge_id` or `token_id` with empty `error_code`.
 - If card digits appear in your app logs, stop and review the integration. This sample should only log sanitized payment status, masked payment fields, or assistant tool markers.
 
 ## Related Examples

--- a/ai-pci-protected-payment-collection-python/app.py
+++ b/ai-pci-protected-payment-collection-python/app.py
@@ -334,7 +334,8 @@ def handle_voice() -> tuple[Any, int]:
 
     event("webhook received", event_type or "unknown", call_control_id)
 
-    if call_control_id:
+    post_call_events = {"call.analyzed", "call.recording.saved", "call.conversation_insights.generated"}
+    if call_control_id and (call_control_id in active_calls or event_type not in post_call_events):
         active_calls.setdefault(call_control_id, {"last_seen": time.time(), "history": []})
         active_calls[call_control_id]["last_seen"] = time.time()
 

--- a/ai-pci-protected-payment-collection-python/app.py
+++ b/ai-pci-protected-payment-collection-python/app.py
@@ -197,47 +197,25 @@ def start_pay_session(
     plan_summary: str,
     customer_id: str = "acct_1042",
 ) -> bool:
+    pay_amount = str(amount.quantize(Decimal("0.01")))
     body = {
         "connector_name": PAY_CONNECTOR_NAME,
-        "amount": str(amount.quantize(Decimal("0.01"))),
+        "amount": pay_amount,
         "currency": "USD",
         "payment_method": "credit-card",
-        "transaction_type": "charge",
         "description": PAYMENT_DESCRIPTION,
-        "metadata": {
-            "customer_id": customer_id,
-            "plan_summary": plan_summary,
-            "demo": "ai-pci-protected-payment-collection-python",
-        },
-        "max_attempts": 3,
-        "timeout_millis": 10000,
-        "inter_digit_timeout_millis": 5000,
-        "client_state": encode_state({"call_control_id": call_control_id, "phase": "pay"}),
     }
-    response = None
-    last_error = ""
-    for path in (f"/calls/{call_control_id}/pay", f"/calls/{call_control_id}/actions/pay"):
-        url = f"{API}{path}"
-        try:
-            telnyx_response = requests.post(url, headers=HEADERS, json=body, timeout=15)
-            if telnyx_response.status_code < 400:
-                response = telnyx_response.json()
-                event_path = re.sub(r"/calls/([^/]+)", "/calls/current", path)
-                event("telnyx command sent", f"{event_path} -> {telnyx_response.status_code}", call_control_id)
-                break
-            last_error = f"{telnyx_response.status_code}: {telnyx_response.text[:220]}"
-        except Exception as exc:
-            last_error = str(exc)
+    response = _telnyx_post(f"/calls/{call_control_id}/pay", body)
     if response:
-        event("pci pause", "pay over voice started; telnyx now masks recording, transcription, assistant audio, and dtmf logging.", call_control_id)
+        event("pci pause", "pay over voice started with the telnyx docs-minimum request; telnyx now masks recording, transcription, assistant audio, and dtmf logging.", call_control_id)
         active_calls.setdefault(call_control_id, {"last_seen": time.time(), "history": []})
         active_calls[call_control_id]["step"] = "pay"
         active_calls[call_control_id]["payment_started_at"] = now_iso()
         active_calls[call_control_id]["payment_completed_by_telnyx"] = False
         active_calls[call_control_id]["plan_summary"] = plan_summary
-        active_calls[call_control_id]["first_charge"] = str(amount.quantize(Decimal("0.01")))
+        active_calls[call_control_id]["customer_id"] = customer_id
+        active_calls[call_control_id]["first_charge"] = pay_amount
         return True
-    event("telnyx command failed", f"/calls/current/pay: {last_error}", call_control_id)
     return False
 
 

--- a/ai-pci-protected-payment-collection-python/app.py
+++ b/ai-pci-protected-payment-collection-python/app.py
@@ -141,6 +141,12 @@ def _validate_call_control_id(call_control_id: str) -> str:
     return ""
 
 
+def phone_from_payload(value: Any) -> str:
+    if isinstance(value, dict):
+        value = value.get("phone_number") or value.get("number") or value.get("sip_uri") or ""
+    return str(value or "")
+
+
 def _telnyx_post(path: str, body: dict[str, Any], timeout: int = 15) -> dict[str, Any] | None:
     if not TELNYX_API_KEY:
         app.logger.error("TELNYX_API_KEY is required before calling Telnyx")
@@ -148,20 +154,22 @@ def _telnyx_post(path: str, body: dict[str, Any], timeout: int = 15) -> dict[str
     url = f"{API}{path}"
     try:
         response = requests.post(url, headers=HEADERS, json=body, timeout=timeout)
-        call_match = re.search(r"/calls/([^/]+)/", path)
+        call_match = re.search(r"/calls/([^/]+)(?:/|$)", path)
         call_control_id = call_match.group(1) if call_match else None
+        event_path = re.sub(r"/calls/([^/]+)", "/calls/current", path)
         if response.status_code >= 400:
             app.logger.error("Telnyx command failed: %s -> %s", url, response.text[:800])
-            event("telnyx command failed", f"{path} -> {response.status_code}: {response.text[:220]}", call_control_id)
+            event("telnyx command failed", f"{event_path} -> {response.status_code}: {response.text[:220]}", call_control_id)
         response.raise_for_status()
         result = response.json()
-        event("telnyx command sent", f"{path} -> {response.status_code}", call_control_id)
+        event("telnyx command sent", f"{event_path} -> {response.status_code}", call_control_id)
         return result
     except Exception as exc:
         app.logger.error("Telnyx command error: %s -> %s", url, exc)
-        call_match = re.search(r"/calls/([^/]+)/", path)
+        call_match = re.search(r"/calls/([^/]+)(?:/|$)", path)
         call_control_id = call_match.group(1) if call_match else None
-        event("telnyx command error", f"{path}: {exc}", call_control_id)
+        event_path = re.sub(r"/calls/([^/]+)", "/calls/current", path)
+        event("telnyx command error", f"{event_path}: {exc}", call_control_id)
         return None
 
 
@@ -201,23 +209,35 @@ def start_pay_session(
             "plan_summary": plan_summary,
             "demo": "ai-pci-protected-payment-collection-python",
         },
-        "prompts": {
-            "payment-card-number": "please enter your card number now using the keypad.",
-            "expiration-date": "please enter the expiration date as four digits, month first. for example, zero eight two seven for august twenty twenty seven.",
-            "postal-code": "please enter your billing zip code using the keypad.",
-            "security-code": "please enter the three digit security code from the back of your card.",
-        },
+        "max_attempts": 3,
+        "timeout_millis": 10000,
+        "inter_digit_timeout_millis": 5000,
         "client_state": encode_state({"call_control_id": call_control_id, "phase": "pay"}),
     }
-    response = _telnyx_post(f"/calls/{call_control_id}/actions/pay", body)
+    response = None
+    last_error = ""
+    for path in (f"/calls/{call_control_id}/pay", f"/calls/{call_control_id}/actions/pay"):
+        url = f"{API}{path}"
+        try:
+            telnyx_response = requests.post(url, headers=HEADERS, json=body, timeout=15)
+            if telnyx_response.status_code < 400:
+                response = telnyx_response.json()
+                event_path = re.sub(r"/calls/([^/]+)", "/calls/current", path)
+                event("telnyx command sent", f"{event_path} -> {telnyx_response.status_code}", call_control_id)
+                break
+            last_error = f"{telnyx_response.status_code}: {telnyx_response.text[:220]}"
+        except Exception as exc:
+            last_error = str(exc)
     if response:
         event("pci pause", "pay over voice started; telnyx now masks recording, transcription, assistant audio, and dtmf logging.", call_control_id)
         active_calls.setdefault(call_control_id, {"last_seen": time.time(), "history": []})
         active_calls[call_control_id]["step"] = "pay"
         active_calls[call_control_id]["payment_started_at"] = now_iso()
+        active_calls[call_control_id]["payment_completed_by_telnyx"] = False
         active_calls[call_control_id]["plan_summary"] = plan_summary
         active_calls[call_control_id]["first_charge"] = str(amount.quantize(Decimal("0.01")))
         return True
+    event("telnyx command failed", f"/calls/current/pay: {last_error}", call_control_id)
     return False
 
 
@@ -302,6 +322,21 @@ def active_call_id_from_request(body: dict[str, Any]) -> str:
     return active[0][0]
 
 
+def latest_call_id_from_request(body: dict[str, Any]) -> str:
+    explicit = _validate_call_control_id(str(body.get("call_control_id") or ""))
+    if explicit:
+        return explicit
+    active = [
+        (call_control_id, call)
+        for call_control_id, call in active_calls.items()
+        if call.get("step") != "hangup"
+    ]
+    if not active:
+        return ""
+    active.sort(key=lambda item: item[1].get("last_seen", 0), reverse=True)
+    return active[0][0]
+
+
 @app.route("/webhooks/voice", methods=["POST"])
 def handle_voice() -> tuple[Any, int]:
     if not _verify_webhook():
@@ -360,6 +395,7 @@ def handle_voice() -> tuple[Any, int]:
         status = payment_values.get("status") or payment_values.get("result") or "completed"
         call["step"] = "paid"
         call["payment_status"] = status
+        call["payment_completed_by_telnyx"] = True
         completed_sessions.append(
             {
                 "time": now_iso(),
@@ -400,10 +436,20 @@ def tool_record_payment_complete() -> tuple[Any, int]:
     if not _verify_tool_request():
         return jsonify({"ok": False, "error": "unauthorized tool request"}), 401
     body = request.get_json(silent=True) or {}
-    call_control_id = active_call_id_from_request(body)
+    call_control_id = latest_call_id_from_request(body)
     call = active_calls.get(call_control_id, {}) if call_control_id else {}
     plan_summary = str(body.get("plan_summary") or call.get("plan_summary") or "payment plan").lower()
     status = str(body.get("status") or "completed").lower()
+    if not call.get("payment_completed_by_telnyx"):
+        event("secure payment pending", "assistant checked completion before telnyx sent a payment completion event.", call_control_id)
+        return jsonify(
+            {
+                "ok": False,
+                "secure_payment_event": "pending",
+                "message": "do not say the payment is complete yet. wait for telnyx pay over voice to finish and send a payment completion event.",
+                "plan_summary": plan_summary,
+            }
+        ), 409
     if call_control_id:
         call["step"] = "paid"
         call["payment_status"] = status
@@ -435,6 +481,7 @@ def tool_start_secure_payment() -> tuple[Any, int]:
         return jsonify({"ok": False, "error": "unauthorized tool request"}), 401
     body = request.get_json(silent=True) or {}
     call_control_id = active_call_id_from_request(body)
+    event("secure payment tool requested", "assistant requested telnyx pay over voice.", call_control_id or None)
     if not call_control_id:
         return jsonify({"ok": False, "error": "no active call found"}), 400
 
@@ -459,7 +506,9 @@ def tool_start_secure_payment() -> tuple[Any, int]:
         customer_id=str(customer["id"]),
     )
     if not started:
+        event("pay over voice failed", "telnyx did not accept the protected payment command.", call_control_id)
         return jsonify({"ok": False, "error": "could not start telnyx pay over voice"}), 502
+    event("pay over voice started", "telnyx accepted the protected keypad payment command.", call_control_id)
 
     return jsonify(
         {
@@ -582,7 +631,7 @@ def dashboard() -> str:
         <div class="step" id="s-assistant"><div class="dot">2</div><div>assistant started</div></div>
         <div class="step" id="s-tool"><div class="dot">3</div><div>secure payment tool called</div></div>
         <div class="step" id="s-pay"><div class="dot">4</div><div>pay over voice started</div></div>
-        <div class="step" id="s-complete"><div class="dot">5</div><div>secure payment completion recorded</div></div>
+        <div class="step" id="s-complete"><div class="dot">5</div><div>payment event received</div></div>
       </div>
     </section>
     <section>
@@ -610,9 +659,9 @@ def dashboard() -> str:
       const items = events.events || [];
       const hasCall = items.some(e => e.label === 'call started' || e.detail === 'call.answered');
       const hasAssistant = items.some(e => e.label === 'assistant started' || e.detail === 'call.conversation.messages_added');
-      const hasTool = items.some(e => e.label === 'pci pause' || e.detail.includes('/actions/pay'));
+      const hasTool = items.some(e => e.label === 'secure payment tool requested' || e.label === 'pci pause' || e.detail.includes('/pay'));
       const hasPay = items.some(e => e.label === 'pci pause' || e.label === 'payment progress' || e.label === 'payment complete');
-      const hasComplete = items.some(e => e.label === 'payment complete' || e.label === 'secure payment complete');
+      const hasComplete = items.some(e => e.label === 'payment progress' || e.label === 'payment complete' || e.label === 'secure payment complete');
       const progress = [hasCall, hasAssistant, hasTool, hasPay, hasComplete].filter(Boolean).length;
       document.getElementById('clock').textContent = new Date().toLocaleTimeString();
       document.getElementById('status').textContent = health.status;

--- a/ai-pci-protected-payment-collection-python/provision_assistant.py
+++ b/ai-pci-protected-payment-collection-python/provision_assistant.py
@@ -75,7 +75,7 @@ after the start_secure_payment tool returns, say: the secure keypad payment step
 
 during pay over voice, do not ask for card numbers, expiration dates, security codes, postal codes, or zip codes. telnyx pay over voice handles that secure step.
 
-after the secure keypad payment step is done and before saying it is complete, call the record_secure_payment_complete tool with status completed. this creates a visible completion event in conversation analysis without exposing card details.
+do not say the payment is complete unless telnyx sends a pay over voice completion event. only after that event, call the record_secure_payment_complete tool with status completed. this creates a visible completion event in conversation analysis without exposing card details.
 
 if the caller disputes the balance, asks for a human, or sounds upset, offer to transfer to billing support and do not collect payment.
 


### PR DESCRIPTION
## Summary
- align the PCI payment sample with the current Pay over Voice docs by trying /v2/calls/{call_control_id}/pay first
- remove custom IVR prompts so Telnyx default step-by-step Pay prompts are used
- guard the assistant completion marker until Telnyx sends a real payment completion event
- add missing phone_from_payload helper and sanitize call IDs in dashboard command events
- update README/API/GUIDE wording around Pay events and completion proof

## Validation
- python3 -m py_compile ai-pci-protected-payment-collection-python/app.py ai-pci-protected-payment-collection-python/provision_assistant.py
- local Flask smoke test for /health and /webhooks/payment-processor
- git diff --check