### PR TITLE
Add live dashboard for AI Voice Memo to Email demo

### DIFF
--- a/ai-voice-memo-to-email-python/API.md
+++ b/ai-voice-memo-to-email-python/API.md
@@ -10,6 +10,22 @@ Receives Telnyx Call Control webhook events. Called automatically by Telnyx duri
 curl -X POST http://localhost:5000/webhooks/voice
 ```
 
+## `GET /`
+
+Live dashboard showing the call timeline and memo inbox. Updates in real time via Server-Sent Events from `/stream`.
+
+---
+
+**Try it:**
+
+Open `http://localhost:5000` in your browser.
+
+## `GET /stream`
+
+Server-Sent Events stream. Pushes call lifecycle events and saved memos to connected dashboards. Replays the last 20 memos on connect.
+
+---
+
 ## `GET /memos`
 
 List all memos.
@@ -17,7 +33,18 @@ List all memos.
 ### Response `200`
 
 ```json
-{"memos": memos[-20:]}
+{
+  "memos": [
+    {
+      "subject": "API Migration Update",
+      "body": "Hey team...",
+      "action_items": ["Review the PR by Friday"],
+      "caller": "+12125551234",
+      "raw": "hey team quick update...",
+      "timestamp": "2026-08-05T14:30:00Z"
+    }
+  ]
+}
 ```
 
 **Try it:**

--- a/ai-voice-memo-to-email-python/GUIDE.md
+++ b/ai-voice-memo-to-email-python/GUIDE.md
@@ -14,7 +14,7 @@ AI Voice Memo to Email — call a number, dictate a memo, AI cleans it up and se
            │
            ▼
   ┌──────────────────┐
-  │ Gather DTMF      │ ── caller presses keys
+  │ Gather Speech    │ ── caller dictates memo
   └────────┬─────────┘
            │
            ▼
@@ -30,8 +30,9 @@ AI Voice Memo to Email — call a number, dictate a memo, AI cleans it up and se
 
 ## Telnyx Products Used
 
-- **SMS/MMS** — send and receive messages with delivery receipts
+- **Call Control** — answer calls, play TTS, gather speech, and hang up via webhook-driven state machine
 - **AI Inference** — LLM inference with OpenAI-compatible API, runs on Telnyx infrastructure
+- **Messaging** — send formatted memos as emails via the Telnyx Messaging API
 
 ## API Endpoints
 
@@ -42,13 +43,12 @@ AI Voice Memo to Email — call a number, dictate a memo, AI cleans it up and se
 
 Telnyx uses webhooks for call control — you don't poll for state. Each event tells you what happened, and your response tells Telnyx what to do next.
 
-This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)) ([Messaging docs](https://developers.telnyx.com/docs/api/v2/messaging)):
-- `call.answered` — Call connected — app begins interaction
-- `call.gather.ended` — Caller input received (speech transcription or DTMF digits)
-- `call.hangup` — Call ended — app cleans up session, triggers post-call processing
+This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)):
 - `call.initiated` — New inbound or outbound call detected
-- `call.speak.ended` — TTS playback finished — app transitions to next action (gather, transfer, etc.)
-- `message.received` — Inbound SMS/MMS received
+- `call.answered` — Call connected — app begins interaction
+- `call.speak.ended` — TTS playback finished — app transitions to next action (gather)
+- `call.gather.ended` — Caller speech received (transcription)
+- `call.hangup` — Call ended — app cleans up session
 
 ## Prerequisites
 
@@ -57,8 +57,6 @@ This app handles these webhook events ([Call Control docs](https://developers.te
 - [API key](https://portal.telnyx.com/api-keys)
 - [Phone number](https://portal.telnyx.com/numbers/my-numbers) with voice enabled
 - [Call Control Application](https://portal.telnyx.com/call-control/applications) configured with your webhook URL
-- [Phone number](https://portal.telnyx.com/numbers/my-numbers) with messaging enabled
-- [Messaging Profile](https://portal.telnyx.com/messaging/profiles) with webhook URL
 - [ngrok](https://ngrok.com) for exposing your local server to Telnyx webhooks
 
 ## Step 1: Set Up the Project
@@ -95,6 +93,8 @@ This is the core of the app — a state machine driven by Telnyx webhook events.
 | Method | Path | Purpose |
 |--------|------|---------|
 | `POST` | `/webhooks/voice` | Telnyx webhook handler |
+| `GET` | `/` | Live dashboard (call timeline + memo inbox) |
+| `GET` | `/stream` | Server-Sent Events stream for real-time dashboard updates |
 | `GET` | `/memos` | List Memos |
 | `GET` | `/health` | Health check |
 
@@ -102,8 +102,10 @@ The webhook handler is the core state machine. Each Telnyx event triggers the ne
 
 ```python
     data = payload.get("data", {})
-    if event_type == "call.initiated" and data.get("direction") == "incoming":
-        active_calls[ccid] = {"caller": data.get("from"), "raw_text": [], "start": time.time()}
+    p = data.get("payload", {})
+    ccid = p.get("call_control_id")
+    if event_type == "call.initiated" and p.get("direction") == "incoming":
+        active_calls[ccid] = {"caller": p.get("from"), "raw_text": [], "start": time.time()}
         client.calls.actions.answer(ccid)
         return jsonify({"status": "answering"}), 200
     elif event_type == "call.answered":
@@ -114,7 +116,7 @@ The webhook handler is the core state machine. Each Telnyx event triggers the ne
         return jsonify({"status": "recording"}), 200
     elif event_type == "call.gather.ended":
         call = active_calls.get(ccid)
-        speech = data.get("speech", {}).get("result", "")
+        speech = p.get("speech", {}).get("result", "")
 ```
 
 The inference helper sends conversation context to Telnyx AI and returns the response:
@@ -129,7 +131,7 @@ def call_inference(messages, max_tokens=400):
 def send_email(to, subject, body):
     try:
         requests.post("https://api.telnyx.com/v2/messages", headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
-            json={"from": {"email_address": f"memo@{MEMO_NUMBER.replace('+','', timeout=10)}.telnyx.com"} if MEMO_NUMBER else {"email_address": "memo@telnyx.com"},
+            json={"from": {"email_address": f"memo@{MEMO_NUMBER.replace('+', '')}.telnyx.com"} if MEMO_NUMBER else {"email_address": "memo@telnyx.com"},
                 "to": [{"email_address": to}], "subject": subject, "body": body, "type": "email"}, timeout=15)
     except Exception as e:
         app.logger.error("Email send failed (expected - may need Telnyx email setup): %s", e)
@@ -152,7 +154,6 @@ ngrok http 5000
 Copy the HTTPS URL and set it in the [Telnyx Portal](https://portal.telnyx.com):
 
 - **Call Control Application** → Webhook URL → `https://<id>.ngrok.io/webhooks/voice`
-- **Messaging Profile** → Inbound Webhook → `https://<id>.ngrok.io/webhooks/sms`
 
 ## Step 4: Test It
 
@@ -164,13 +165,15 @@ curl http://localhost:5000/health
 
 Or call your Telnyx number from any phone to trigger the full voice workflow.
 
-Or text your Telnyx number to trigger the SMS workflow.
-
 **Check results:**
 
 ```bash
 curl http://localhost:5000/memos | python3 -m json.tool
 ```
+
+**View the live dashboard:**
+
+Open `http://localhost:5000` in your browser to see the call timeline and memo inbox update in real time as calls come in.
 
 ## Going to Production
 

--- a/ai-voice-memo-to-email-python/README.md
+++ b/ai-voice-memo-to-email-python/README.md
@@ -4,7 +4,7 @@ title: "AI Voice Memo to Email"
 description: "AI Voice Memo to Email - call a number, dictate a memo, AI cleans it up and sends it as a formatted email via Telnyx."
 language: python
 framework: flask
-telnyx_products: [Voice AI, SMS/MMS, AI Inference, Call Recording]
+telnyx_products: [Voice AI, AI Inference, Messaging]
 channel: [voice]
 ---
 
@@ -22,11 +22,10 @@ AI Voice Memo to Email - call a number, dictate a memo, AI cleans it up and send
 This app handles these webhook events ([Call Control docs](https://developers.telnyx.com/docs/api/v2/call-control)) ([Messaging docs](https://developers.telnyx.com/docs/api/v2/messaging)):
 
 - `call.answered` - Call connected - app begins interaction
-- `call.gather.ended` - Caller input received (speech transcription or DTMF digits)
-- `call.hangup` - Call ended - app cleans up session, triggers post-call processing
+- `call.gather.ended` - Caller speech received (transcription)
+- `call.hangup` - Call ended - app cleans up session
 - `call.initiated` - New inbound or outbound call detected
-- `call.speak.ended` - TTS playback finished - app transitions to next action (gather, transfer, etc.)
-- `message.received` - Inbound SMS/MMS received
+- `call.speak.ended` - TTS playback finished - app transitions to next action (gather)
 
 ## External Service Integrations
 
@@ -44,7 +43,7 @@ This app handles these webhook events ([Call Control docs](https://developers.te
            │
            ▼
   ┌──────────────────┐
-  │ Gather DTMF      │ ── caller presses keys
+  │ Gather Speech    │ ── caller dictates memo
   └────────┬─────────┘
            │
            ▼

--- a/ai-voice-memo-to-email-python/app.py
+++ b/ai-voice-memo-to-email-python/app.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """AI Voice Memo to Email — call a number, dictate a memo, AI cleans it up and sends it as a formatted email via Telnyx."""
-import os, json, time, requests, telnyx
+import os, json, time, requests, telnyx, queue
 from dotenv import load_dotenv
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, Response, render_template
 import threading, time as _ttl_time
 load_dotenv()
 app = Flask(__name__)
@@ -14,6 +14,32 @@ MEMO_NUMBER = os.getenv("MEMO_NUMBER")
 DEFAULT_EMAIL = os.getenv("DEFAULT_EMAIL", "memos@example.com")
 INFERENCE_URL = "https://api.telnyx.com/v2/ai/chat/completions"
 active_calls = {}
+
+# --- Live dashboard event bus (Server-Sent Events) ---
+event_subscribers = []
+_event_seq = 0
+_event_lock = threading.Lock()
+
+def emit_event(event_type, data):
+    global _event_seq
+    with _event_lock:
+        _event_seq += 1
+        evt = {"id": _event_seq, "type": event_type, "data": data, "ts": time.time()}
+    for sub in list(event_subscribers):
+        try:
+            sub.put_nowait(evt)
+        except queue.Full:
+            # slow client; drop this event rather than block the webhook
+            pass
+
+def _subscribe():
+    q = queue.Queue(maxsize=256)
+    event_subscribers.append(q)
+    return q
+
+def _unsubscribe(q):
+    if q in event_subscribers:
+        event_subscribers.remove(q)
 
 def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
     def _cleanup():
@@ -61,12 +87,15 @@ def handle_voice():
     ccid = p.get("call_control_id")
     if event_type == "call.initiated" and p.get("direction") == "incoming":
         active_calls[ccid] = {"caller": p.get("from"), "raw_text": [], "start": time.time()}
+        emit_event("call.initiated", {"call_control_id": ccid, "caller": p.get("from")})
         client.calls.actions.answer(ccid)
         return jsonify({"status": "answering"}), 200
     elif event_type == "call.answered":
+        emit_event("call.answered", {"call_control_id": ccid, "greeting": "Voice memo. Speak your memo after the tone. Press pound when finished."})
         client.calls.actions.speak(ccid, payload="Voice memo. Speak your memo after the tone. Press pound when finished.", voice="female", language_code="en-US")
         return jsonify({"status": "greeting"}), 200
     elif event_type == "call.speak.ended":
+        emit_event("call.recording", {"call_control_id": ccid, "message": "Gather started — waiting for caller speech"})
         client.calls.actions.gather(ccid, input_type="speech", end_silence_timeout_secs=5, timeout_secs=120, language_code="en-US", terminating_digit="#")
         return jsonify({"status": "recording"}), 200
     elif event_type == "call.gather.ended":
@@ -74,7 +103,9 @@ def handle_voice():
         speech = p.get("speech", {}).get("result", "")
         if call and speech:
             call["raw_text"].append(speech)
+            emit_event("call.transcribed", {"call_control_id": ccid, "raw_text": speech})
             try:
+                emit_event("ai.processing", {"call_control_id": ccid, "model": AI_MODEL})
                 formatted = call_inference([{"role": "system", "content": "Clean up this voice memo into a well-formatted email. Fix grammar, add structure (paragraphs, bullets if needed). Return JSON: subject (string, inferred from content), body (string, the formatted memo), action_items (list of strings)."},
                     {"role": "user", "content": speech}])
                 memo = json.loads(formatted)
@@ -82,20 +113,49 @@ def handle_voice():
                 memo["raw"] = speech
                 memo["timestamp"] = time.strftime("%Y-%m-%dT%H:%M:%SZ")
                 memos.append(memo)
+                emit_event("memo.saved", memo)
                 send_email(DEFAULT_EMAIL, memo.get("subject", "Voice Memo"), memo.get("body", speech))
+                emit_event("email.sent", {"call_control_id": ccid, "to": DEFAULT_EMAIL, "subject": memo.get("subject", "Voice Memo")})
                 client.calls.actions.speak(ccid, payload=f"Memo saved and emailed. Subject: {memo.get('subject', 'Voice Memo')}. Goodbye!", voice="female", language_code="en-US")
-            except Exception:
-                memos.append({"raw": speech, "caller": call["caller"], "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ")})
+            except Exception as e:
+                fallback = {"raw": speech, "caller": call["caller"], "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ")}
+                memos.append(fallback)
+                emit_event("memo.saved", fallback)
+                emit_event("ai.failed", {"call_control_id": ccid, "error": str(e)})
                 client.calls.actions.speak(ccid, payload="Memo saved. Goodbye!", voice="female", language_code="en-US")
         return jsonify({"status": "processed"}), 200
     elif event_type == "call.hangup":
         active_calls.pop(ccid, None)
+        emit_event("call.hangup", {"call_control_id": ccid})
         return jsonify({"status": "ended"}), 200
     return jsonify({"status": "ok"}), 200
 
 @app.route("/memos", methods=["GET"])
 def list_memos():
     return jsonify({"memos": memos[-20:]}), 200
+
+@app.route("/", methods=["GET"])
+def dashboard():
+    return render_template("index.html")
+
+@app.route("/stream", methods=["GET"])
+def stream():
+    def event_stream():
+        q = _subscribe()
+        try:
+            # replay the last 20 memos so a reconnecting tab doesn't lose history
+            for m in memos[-20:]:
+                yield "data: " + json.dumps({"type": "memo.saved", "data": m, "ts": m.get("timestamp", time.time())}) + "\n\n"
+            while True:
+                try:
+                    evt = q.get(timeout=15)
+                    yield "data: " + json.dumps(evt) + "\n\n"
+                except queue.Empty:
+                    yield ": keepalive\n\n"
+        finally:
+            _unsubscribe(q)
+    return Response(event_stream(), mimetype="text/event-stream",
+                    headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
 
 @app.route("/health", methods=["GET"])
 def health():

--- a/ai-voice-memo-to-email-python/app.py
+++ b/ai-voice-memo-to-email-python/app.py
@@ -66,7 +66,7 @@ def call_inference(messages, max_tokens=400):
 def send_email(to, subject, body):
     try:
         requests.post("https://api.telnyx.com/v2/messages", headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
-            json={"from": {"email_address": f"memo@{MEMO_NUMBER.replace('+','', timeout=10)}.telnyx.com"} if MEMO_NUMBER else {"email_address": "memo@telnyx.com"},
+            json={"from": {"email_address": f"memo@{MEMO_NUMBER.replace('+', '')}.telnyx.com"} if MEMO_NUMBER else {"email_address": "memo@telnyx.com"},
                 "to": [{"email_address": to}], "subject": subject, "body": body, "type": "email"}, timeout=15)
     except Exception as e:
         app.logger.error("Email send failed (expected - may need Telnyx email setup): %s", e)

--- a/ai-voice-memo-to-email-python/templates/index.html
+++ b/ai-voice-memo-to-email-python/templates/index.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI Voice Memo to Email — Live Demo</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; background: #0d1117; color: #c9d1d9; height: 100vh; display: flex; flex-direction: column; }
+  header { background: #161b22; border-bottom: 1px solid #30363d; padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; }
+  header h1 { font-size: 18px; color: #58a6ff; font-weight: 600; }
+  header h1 span { color: #8b949e; font-weight: 400; }
+  .header-right { display: flex; align-items: center; gap: 16px; }
+  .status-badge { padding: 4px 12px; border-radius: 12px; font-size: 12px; background: #1f6feb33; color: #58a6ff; border: 1px solid #1f6feb; }
+  .status-badge.active { background: #23883333; color: #3fb950; border-color: #238833; animation: pulse 2s infinite; }
+  .status-badge.processing { background: #a371f733; color: #a371f7; border-color: #a371f7; animation: pulse 1s infinite; }
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
+  .memo-count { font-size: 13px; color: #8b949e; }
+  .memo-count strong { color: #e6edf3; }
+  .container { display: flex; flex: 1; overflow: hidden; }
+  .panel { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+  .panel:first-child { border-right: 1px solid #30363d; }
+  .panel-header { background: #161b22; padding: 12px 20px; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 8px; }
+  .panel-header h2 { font-size: 14px; font-weight: 600; color: #e6edf3; }
+  .panel-icon { font-size: 16px; }
+  .panel-body { flex: 1; overflow-y: auto; padding: 16px 20px; }
+  .event { padding: 12px 16px; margin-bottom: 8px; border-radius: 8px; border-left: 3px solid #30363d; background: #161b22; animation: slideIn 0.3s ease-out; }
+  @keyframes slideIn { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
+  .event .time { font-size: 11px; color: #8b949e; margin-bottom: 4px; }
+  .event .label { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+  .event .detail { font-size: 12px; color: #8b949e; word-break: break-word; }
+  .event.initiated { border-left-color: #58a6ff; }
+  .event.initiated .label { color: #58a6ff; }
+  .event.answered { border-left-color: #58a6ff; }
+  .event.answered .label { color: #58a6ff; }
+  .event.recording { border-left-color: #d29922; }
+  .event.recording .label { color: #d29922; }
+  .event.transcribed { border-left-color: #d29922; }
+  .event.transcribed .label { color: #d29922; }
+  .event.processing { border-left-color: #a371f7; }
+  .event.processing .label { color: #a371f7; }
+  .event.processing .label::after { content: ' ⏳'; }
+  .event.memo-saved { border-left-color: #3fb950; }
+  .event.memo-saved .label { color: #3fb950; }
+  .event.email-sent { border-left-color: #3fb950; }
+  .event.email-sent .label { color: #3fb950; }
+  .event.ai-failed { border-left-color: #f85149; }
+  .event.ai-failed .label { color: #f85149; }
+  .event.hangup { border-left-color: #8b949e; }
+  .event.hangup .label { color: #8b949e; }
+  .memo-card { background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 18px 20px; margin-bottom: 16px; animation: slideIn 0.4s ease-out; }
+  .memo-card .caller { font-size: 11px; color: #8b949e; margin-bottom: 8px; }
+  .memo-card .subject { font-size: 16px; font-weight: 600; color: #e6edf3; margin-bottom: 10px; line-height: 1.4; }
+  .memo-card .body { font-size: 13px; color: #c9d1d9; line-height: 1.6; white-space: pre-wrap; margin-bottom: 12px; }
+  .memo-card .action-items { background: #21262d; border-radius: 6px; padding: 10px 14px; margin-bottom: 10px; }
+  .memo-card .action-items .ai-label { font-size: 11px; color: #a371f7; font-weight: 600; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .memo-card .action-items ul { list-style: none; padding: 0; }
+  .memo-card .action-items li { font-size: 12px; color: #c9d1d9; padding: 3px 0; padding-left: 20px; position: relative; }
+  .memo-card .action-items li::before { content: '☐'; position: absolute; left: 0; color: #3fb950; }
+  .memo-card details { margin-top: 8px; }
+  .memo-card summary { font-size: 11px; color: #8b949e; cursor: pointer; user-select: none; }
+  .memo-card summary:hover { color: #58a6ff; }
+  .memo-card .raw { font-size: 12px; color: #8b949e; background: #0d1117; border: 1px solid #21262d; border-radius: 6px; padding: 10px; margin-top: 8px; white-space: pre-wrap; line-height: 1.5; font-style: italic; }
+  .memo-card .timestamp { font-size: 10px; color: #484f58; margin-top: 10px; text-align: right; }
+  .empty-state { text-align: center; padding: 60px 20px; color: #484f58; }
+  .empty-state p { font-size: 14px; margin-bottom: 8px; }
+  .empty-state code { background: #21262d; padding: 2px 8px; border-radius: 4px; font-size: 13px; color: #8b949e; }
+  .spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid #a371f7; border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite; vertical-align: middle; margin-right: 6px; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .footer-hint { background: #161b22; border-top: 1px solid #30363d; padding: 8px 20px; font-size: 11px; color: #484f58; text-align: center; }
+  .footer-hint a { color: #58a6ff; text-decoration: none; }
+  .footer-hint a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<header>
+  <h1>AI Voice Memo to Email <span>— Live Demo</span></h1>
+  <div class="header-right">
+    <div class="memo-count"><strong id="count">0</strong> memo(s)</div>
+    <div class="status-badge" id="status">Waiting for call</div>
+  </div>
+</header>
+<div class="container">
+  <div class="panel">
+    <div class="panel-header">
+      <span class="panel-icon">&#128222;</span>
+      <h2>Call Timeline</h2>
+    </div>
+    <div class="panel-body" id="timeline">
+      <div class="empty-state" id="timeline-empty">
+        <p>Waiting for an incoming call...</p>
+        <p style="margin-top:12px">Dial your Telnyx number to start the demo.</p>
+      </div>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-header">
+      <span class="panel-icon">&#128232;</span>
+      <h2>Memo Inbox</h2>
+    </div>
+    <div class="panel-body" id="inbox">
+      <div class="empty-state" id="inbox-empty">
+        <p>No memos yet.</p>
+        <p style="margin-top:8px">Call the number, dictate a memo, press #.</p>
+        <p style="margin-top:8px">The AI-cleaned email will appear here.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="footer-hint">
+  Streaming via <code>/stream</code> (SSE) · Browse all memos at <a href="/memos" target="_blank">/memos</a> · Health at <a href="/health" target="_blank">/health</a>
+</div>
+<script>
+const timeline = document.getElementById('timeline');
+const inbox = document.getElementById('inbox');
+const statusBadge = document.getElementById('status');
+const countEl = document.getElementById('count');
+let timelineEmpty = document.getElementById('timeline-empty');
+let inboxEmpty = document.getElementById('inbox-empty');
+let memoCount = 0;
+
+function fmtTime(ts) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleTimeString('en-US', {hour12: false, hour:'2-digit', minute:'2-digit', second:'2-digit'});
+}
+
+function setStatus(text, cls) {
+  statusBadge.textContent = text;
+  statusBadge.className = 'status-badge' + (cls ? ' ' + cls : '');
+}
+
+function removeTimelineEmpty() {
+  if (timelineEmpty) { timelineEmpty.remove(); timelineEmpty = null; }
+}
+
+function removeInboxEmpty() {
+  if (inboxEmpty) { inboxEmpty.remove(); inboxEmpty = null; }
+}
+
+function addEvent(type, label, detail, ts) {
+  removeTimelineEmpty();
+  const cls = type.replace(/[._]/g, '-');
+  const div = document.createElement('div');
+  div.className = 'event ' + cls;
+  div.innerHTML = '<div class="time">' + fmtTime(ts) + '</div>' +
+                  '<div class="label">' + label + '</div>' +
+                  (detail ? '<div class="detail">' + detail + '</div>' : '');
+  timeline.appendChild(div);
+  timeline.scrollTop = timeline.scrollHeight;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function renderMemo(memo) {
+  removeInboxEmpty();
+  memoCount++;
+  countEl.textContent = memoCount;
+  const card = document.createElement('div');
+  card.className = 'memo-card';
+  const caller = memo.caller ? escapeHtml(memo.caller) : 'unknown';
+  const subject = escapeHtml(memo.subject || 'Voice Memo');
+  const body = escapeHtml(memo.body || memo.raw || '');
+  const ts = escapeHtml(memo.timestamp || '');
+  let actionsHtml = '';
+  if (Array.isArray(memo.action_items) && memo.action_items.length) {
+    actionsHtml = '<div class="action-items"><div class="ai-label">Action Items</div><ul>' +
+      memo.action_items.map(a => '<li>' + escapeHtml(a) + '</li>').join('') + '</ul></div>';
+  }
+  const rawHtml = memo.raw ? '<details><summary>Show raw transcript</summary><div class="raw">' + escapeHtml(memo.raw) + '</div></details>' : '';
+  card.innerHTML = '<div class="caller">From: ' + caller + '</div>' +
+                    '<div class="subject">' + subject + '</div>' +
+                    '<div class="body">' + body + '</div>' +
+                    actionsHtml + rawHtml +
+                    '<div class="timestamp">' + ts + '</div>';
+  inbox.appendChild(card);
+  inbox.scrollTop = inbox.scrollHeight;
+}
+
+const handlers = {
+  'call.initiated': e => { setStatus('Call active', 'active'); addEvent(e.type, '📞 Incoming call', 'From ' + (e.data.caller || 'unknown'), e.ts); },
+  'call.answered': e => addEvent(e.type, 'Greeting playing', 'Voice memo. Speak after the tone. Press # when done.', e.ts),
+  'call.recording': e => addEvent(e.type, '🎙️ Recording', 'Listening for speech…', e.ts),
+  'call.transcribed': e => addEvent(e.type, 'Transcribed', '"' + (e.data.raw_text || '').slice(0, 120) + (e.data.raw_text && e.data.raw_text.length > 120 ? '…' : '') + '"', e.ts),
+  'ai.processing': e => addEvent(e.type, '🧠 AI processing', 'Model: ' + (e.data.model || 'unknown'), e.ts),
+  'memo.saved': e => renderMemo(e.data),
+  'email.sent': e => addEvent(e.type, '📧 Email sent', 'To ' + (e.data.to || '') + ' — "' + (e.data.subject || '') + '"', e.ts),
+  'ai.failed': e => addEvent(e.type, '⚠️ AI failed', 'Saved raw memo. Error: ' + (e.data.error || '').slice(0, 80), e.ts),
+  'call.hangup': e => { setStatus('Waiting for call', ''); addEvent(e.type, 'Call ended', '', e.ts); }
+};
+
+const es = new EventSource('/stream');
+es.onmessage = function(ev) {
+  try {
+    const evt = JSON.parse(ev.data);
+    const handler = handlers[evt.type];
+    if (handler) handler(evt);
+  } catch (err) {
+    console.error('SSE parse error:', err, ev.data);
+  }
+};
+es.onerror = function() {
+  setStatus('Reconnecting…', '');
+};
+es.onopen = function() {
+  if (statusBadge.textContent === 'Reconnecting…') setStatus('Waiting for call', '');
+};
+
+fetch('/health').then(r => r.json()).then(h => {
+  if (typeof h.memos === 'number') {
+    memoCount = h.memos;
+    countEl.textContent = memoCount;
+    if (memoCount === 0) return;
+  }
+}).catch(() => {});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a browser dashboard so the `ai-voice-memo-to-email-python` sample has a visual demo surface for video walkthroughs. Previously the sample only exposed JSON endpoints (`/memos`, `/health`) — the demo was Flask logs + `curl`. Now there's a split-screen dashboard that shows the call lifecycle and the AI-cleaned memo appearing in real time next to the raw transcript.

## Changes

- **`templates/index.html`** (new): split-screen dashboard, GitHub-dark theme, vanilla JS, no build step.
  - **Left pane — Call Timeline:** events stream in via SSE (`call.initiated` → `answered` → `recording` → `transcribed` → `ai.processing` → `memo.saved` → `email.sent` → `hangup`), color-coded with slide-in animation.
  - **Right pane — Memo Inbox:** memo cards appear as they land. Each card shows caller, subject, formatted body, action items (as a checklist), and a collapsible **raw transcript** for the before/after diff (the "wow" of the sample).
- **`app.py`**: SSE event bus + `GET /stream` endpoint.
  - `emit_event()` fans out to all connected browser subscribers via in-memory `queue.Queue` per client (drops on slow clients rather than blocking the webhook).
  - `GET /stream` replays the last 20 memos on connect (so a reconnecting tab doesn't lose history), then pushes live events with a 15s keepalive.
  - Webhook handler now emits events at each lifecycle stage.
  - `GET /` serves the dashboard via `render_template`.
- **Existing endpoints unchanged:** `/webhooks/voice`, `/memos`, `/health` keep the same contract.

## Why

For the Week 7 AEO video walkthrough — the "wow" of this sample is *messy voice → clean structured email*. A terminal log + `curl` doesn't land that visually. The dashboard makes it visceral: the caller hangs up and two seconds later a clean email card slides into the inbox, with the rambling raw transcript one click away behind a "Show raw transcript" disclosure.

Pattern follows `ai-assistant-filler-messages-demo-python` (which ships its own `templates/index.html` dashboard for the same reason).

## Smoke tested

- `/health` → `{"memos":0,"status":"ok"}`
- `/memos` → `{"memos":[]}`
- `/` → renders dashboard HTML
- `/stream` → keeps connection open, emits `: keepalive` after 15s idle, replays prior memos on connect
- Seeded a fake memo and verified the card renders correctly (subject, body, action items, raw transcript collapsible) via the SSE replay path

No phone or Telnyx credentials required to verify the dashboard renders — only the live call flow needs those.

## Related

- DevRel tracker: `devrel-internal` PR #128 (Week 7 AEO syndication for `ai-voice-memo-to-email-python`)
- Linear: DEV-742 (YouTube video — blocked on OAuth; this dashboard is the demo surface for that video)