### PR TITLE
fix: correct WhatsApp Verify API endpoints and response handling

### DIFF
--- a/whatsapp-verify-otp-python/.env.example
+++ b/whatsapp-verify-otp-python/.env.example
@@ -1,3 +1,9 @@
 TELNYX_API_KEY=your_telnyx_api_key
 VERIFY_PROFILE_ID=your_verify_profile_id
 PORT=5000
+
+# Optional: webhook signature verification (default: false)
+# Set to true to require valid Telnyx webhook signatures on /webhooks/verify
+VERIFY_WEBHOOK_SIGNATURE=false
+# Required only if VERIFY_WEBHOOK_SIGNATURE=true — your Telnyx webhook public key
+# TELNYX_PUBLIC_KEY=whsec_your_public_key_here

--- a/whatsapp-verify-otp-python/API.md
+++ b/whatsapp-verify-otp-python/API.md
@@ -64,7 +64,9 @@ Submit the OTP code received via WhatsApp for verification.
 | `phone_number` | `string` | **yes** | The phone number that received the OTP |
 | `code` | `string` | **yes** | The OTP code entered by the user |
 
-### Response `200`
+The server forwards the code along with your `VERIFY_PROFILE_ID` to Telnyx. Telnyx returns a `response_code` that the server maps to a status.
+
+### Response `200` (accepted)
 
 ```json
 {
@@ -72,13 +74,23 @@ Submit the OTP code received via WhatsApp for verification.
 }
 ```
 
-### Response `400`
+### Response `200` (rejected)
 
 ```json
 {
-  "status": "invalid_code"
+  "status": "rejected",
+  "response_code": "rejected"
 }
 ```
+
+`response_code` can be one of:
+
+| `response_code` | Meaning |
+|-----------------|---------|
+| `accepted` | Code is correct — verification successful |
+| `rejected` | Code is incorrect |
+| `expired` | Verification timed out (exceeded `timeout_secs`) |
+| `max_attempts_exceeded` | Too many incorrect attempts |
 
 **Try it:**
 
@@ -98,10 +110,11 @@ Inbound webhook endpoint called by Telnyx when a verification event occurs.
 
 | Event | Description |
 |-------|-------------|
-| `verify.sent` | OTP message sent to the carrier/WhatsApp |
+| `verify.sent` | OTP message sent to the upstream provider |
 | `verify.delivered` | OTP message delivered to the user's device |
-| `verify.completed` | User successfully verified the code |
 | `verify.failed` | Delivery or verification failed |
+
+Signature verification is optional — set `VERIFY_WEBHOOK_SIGNATURE=true` and `TELNYX_PUBLIC_KEY` in `.env` to enable.
 
 ### Request (from Telnyx)
 
@@ -135,9 +148,18 @@ Health check and service status.
 ```json
 {
   "status": "ok",
-  "verifications": 0
+  "configured": true,
+  "verifications": 0,
+  "webhook_events": 0
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `string` | `ok` |
+| `configured` | `bool` | `true` if both `TELNYX_API_KEY` and `VERIFY_PROFILE_ID` are set |
+| `verifications` | `integer` | Number of in-memory verification records |
+| `webhook_events` | `integer` | Number of received webhook events |
 
 **Try it:**
 
@@ -149,7 +171,7 @@ curl http://localhost:5000/health
 
 ## Status Values
 
-Verification records use these status values: `pending`, `sent`, `delivered`, `completed`, `verified`, `failed`, `invalid_code`
+Verification records use these status values: `pending`, `sent`, `delivered`, `verified`, `failed`, `rejected`
 
 ## Error Handling
 
@@ -161,7 +183,8 @@ All endpoints return JSON. On error:
 
 | Status | Meaning |
 |--------|---------|
-| `200` | Success |
+| `200` | Success (check `status` field for accepted/rejected on `/verify/check`) |
 | `400` | Bad request — missing or invalid fields |
-| `401` | Invalid API key |
+| `401` | Invalid API key or invalid webhook signature |
+| `422` | Telnyx rejected the request — check error response body |
 | `500` | Server error |

--- a/whatsapp-verify-otp-python/GUIDE.md
+++ b/whatsapp-verify-otp-python/GUIDE.md
@@ -11,8 +11,8 @@ Send and verify one-time passwords via WhatsApp using the Telnyx Verify API.
   ┌────────────────────┐
   │  Python Server     │  receives request
   └─────────┬──────────┘
+        │  POST /v2/verifications/whatsapp
         │  Telnyx Verify API
-        │  type: "whatsapp"
         ▼
   ┌────────────────────┐
   │  Telnyx Verify     │  sends OTP via WhatsApp
@@ -22,10 +22,11 @@ Send and verify one-time passwords via WhatsApp using the Telnyx Verify API.
   ┌────────────────────┐
   │  User enters code  │  submits OTP
   └─────────┬──────────┘
-        │
+        │  POST /v2/verifications/by_phone_number/{phone}/actions/verify
+        │  Body: { "code": "...", "verify_profile_id": "..." }
         ▼
   ┌────────────────────┐
-  │  Code verified     │  ✓ or ✗
+  │  Code verified     │  ✓ accepted / ✗ rejected
   └────────────────────┘
 ```
 
@@ -58,6 +59,8 @@ Edit `.env` with your Telnyx credentials:
 | `TELNYX_API_KEY` | Your Telnyx API v2 key from [Portal](https://portal.telnyx.com/api-keys) |
 | `VERIFY_PROFILE_ID` | Your Verify Profile ID with WhatsApp enabled from [Portal](https://portal.telnyx.com/verify/profiles) |
 | `PORT` | HTTP server port (default: 5000) |
+| `VERIFY_WEBHOOK_SIGNATURE` | Enable webhook signature verification (default: `false`) |
+| `TELNYX_PUBLIC_KEY` | Telnyx webhook public key (required only if `VERIFY_WEBHOOK_SIGNATURE=true`) |
 
 ## Step 2: Configure WhatsApp for Verify
 
@@ -72,21 +75,30 @@ The main application logic lives in `app.py`.
 
 ### Starting a Verification
 
-**`start_verification()`** — Sends a WhatsApp OTP to the given phone number via the Telnyx Verify API with `type: "whatsapp"`.
+**`start_verification()`** — Sends a WhatsApp OTP to the given phone number via the Telnyx Verify API's WhatsApp endpoint.
 
 ```python
-resp = requests.post("https://api.telnyx.com/v2/verifications",
-    headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
-    json={"phone_number": phone, "verify_profile_id": VERIFY_PROFILE_ID, "type": "whatsapp"}, timeout=10)
+resp = requests.post(
+    f"{API_BASE}/verifications/whatsapp",
+    headers={
+        "Authorization": f"Bearer {TELNYX_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "phone_number": phone,
+        "verify_profile_id": VERIFY_PROFILE_ID,
+    },
+    timeout=10,
+)
 ```
 
 ### Checking the Code
 
-**`check_verification()`** — Submits the user-entered OTP code for validation against the Telnyx Verify API.
+**`check_verification()`** — Submits the user-entered OTP code along with your `VERIFY_PROFILE_ID` to the Telnyx Verify API. Telnyx returns a `response_code` (`accepted`, `rejected`, `expired`, or `max_attempts_exceeded`); the server reports `verified` only when `response_code == "accepted"`.
 
 ### Receiving Webhooks
 
-**`verify_webhook()`** — Handles delivery status webhooks (`verify.sent`, `verify.delivered`, `verify.completed`, `verify.failed`) for real-time tracking.
+**`verify_webhook()`** — Handles delivery status webhooks (`verify.sent`, `verify.delivered`, `verify.failed`) for real-time tracking. Webhook signature verification is optional — enable it with `VERIFY_WEBHOOK_SIGNATURE=true` and `TELNYX_PUBLIC_KEY` in `.env`.
 
 ### All Endpoints
 
@@ -141,7 +153,7 @@ curl -X POST http://localhost:5000/verify/check \
 
 - **Database** — replace the in-memory dict with PostgreSQL or Redis for verification state.
 - **Authentication** — add API key validation on your endpoints.
-- **Webhook verification** — validate Telnyx webhook signatures ([docs](https://developers.telnyx.com/docs/api/v2/overview#webhook-signing)).
+- **Webhook verification** — already built in; set `VERIFY_WEBHOOK_SIGNATURE=true` and `TELNYX_PUBLIC_KEY` in `.env` to enforce valid signatures ([docs](https://developers.telnyx.com/docs/identity/verify/receiving-webhooks)).
 - **Monitoring** — add structured logging and health check alerts.
 - **Rate limiting** — protect your endpoints from abuse.
 - **Fallback channels** — consider adding SMS or voice fallback if WhatsApp delivery fails.

--- a/whatsapp-verify-otp-python/README.md
+++ b/whatsapp-verify-otp-python/README.md
@@ -14,8 +14,8 @@ Send and verify one-time passwords via WhatsApp using the Telnyx Verify API.
 
 ## Telnyx API Endpoints Used
 
-- **Create Verification**: `POST /v2/verifications` - [API reference](https://developers.telnyx.com/api/verify/create-verification)
-- **Submit Verification Code**: `POST /v2/verifications/by_phone_number/{phone_number}/actions/verify` - [API reference](https://developers.telnyx.com/api/verify/verify-verification-code)
+- **Trigger WhatsApp Verification**: `POST /v2/verifications/whatsapp` - [API reference](https://developers.telnyx.com/api-reference/verify/trigger-whatsapp-verification)
+- **Submit Verification Code**: `POST /v2/verifications/by_phone_number/{phone_number}/actions/verify` - [API reference](https://developers.telnyx.com/api-reference/verify/verify-verification-code-by-phone-number)
 
 ## Architecture
 
@@ -27,8 +27,8 @@ Send and verify one-time passwords via WhatsApp using the Telnyx Verify API.
   │ POST /verify/    │
   │ start            │
   └────────┬─────────┘
+           │  POST /v2/verifications/whatsapp
            │  Telnyx Verify API
-           │  type: "whatsapp"
            ▼
   ┌──────────────────┐
   │ WhatsApp OTP     │ ── user receives code
@@ -40,9 +40,10 @@ Send and verify one-time passwords via WhatsApp using the Telnyx Verify API.
   │ POST /verify/    │ ── user submits code
   │ check            │
   └────────┬─────────┘
-           │
+           │  POST /v2/verifications/by_phone_number/{phone}/actions/verify
+           │  Body: { "code": "...", "verify_profile_id": "..." }
            ▼
-     ✓ Verified / ✗ Denied
+     ✓ Accepted / ✗ Rejected
 ```
 
 ## Why Telnyx
@@ -62,6 +63,8 @@ Copy `.env.example` to `.env` and fill in:
 | `TELNYX_API_KEY` | `string` | `KEY0123456789ABCDEF` | **yes** | Telnyx API v2 key | [Portal](https://portal.telnyx.com/api-keys) · [CLI: `telnyx auth`](https://developers.telnyx.com/development/cli) |
 | `VERIFY_PROFILE_ID` | `string` | `your_value` | **yes** | Verify profile configured with WhatsApp channel | [Portal](https://portal.telnyx.com/verify/profiles) · [CLI: `telnyx verify-profiles`](https://developers.telnyx.com/development/cli) |
 | `PORT` | `integer` | `5000` | no | HTTP server port | - |
+| `VERIFY_WEBHOOK_SIGNATURE` | `bool` | `false` | no | Enable webhook signature verification (default: `false`) | - |
+| `TELNYX_PUBLIC_KEY` | `string` | `whsec_...` | only if sig verify | Telnyx webhook public key | [Portal](https://portal.telnyx.com) → Verify Profile |
 
 ## Setup
 
@@ -129,7 +132,7 @@ curl -X POST http://localhost:5000/verify/start \
 
 ### `POST /verify/check`
 
-Submit the OTP code for verification.
+Submit the OTP code for verification. The server forwards the code along with your `VERIFY_PROFILE_ID` to Telnyx.
 
 ```bash
 curl -X POST http://localhost:5000/verify/check \
@@ -140,7 +143,7 @@ curl -X POST http://localhost:5000/verify/check \
   }'
 ```
 
-**Response:**
+**Response (accepted):**
 
 ```json
 {
@@ -148,9 +151,20 @@ curl -X POST http://localhost:5000/verify/check \
 }
 ```
 
+**Response (rejected):**
+
+```json
+{
+  "status": "rejected",
+  "response_code": "rejected"
+}
+```
+
+`response_code` can be `accepted`, `rejected`, `expired`, or `max_attempts_exceeded` — see [Verify API reference](https://developers.telnyx.com/api-reference/verify/verify-verification-code-by-phone-number).
+
 ### `POST /webhooks/verify`
 
-Receives delivery status webhooks from Telnyx (`verify.sent`, `verify.delivered`, `verify.completed`, `verify.failed`).
+Receives delivery status webhooks from Telnyx (`verify.sent`, `verify.delivered`, `verify.failed`). Signature verification is optional — set `VERIFY_WEBHOOK_SIGNATURE=true` and `TELNYX_PUBLIC_KEY` in `.env` to enable.
 
 ```bash
 curl -X POST http://localhost:5000/webhooks/verify \
@@ -186,7 +200,9 @@ curl http://localhost:5000/health
 ```json
 {
   "status": "ok",
-  "verifications": 0
+  "configured": true,
+  "verifications": 0,
+  "webhook_events": 0
 }
 ```
 

--- a/whatsapp-verify-otp-python/app.py
+++ b/whatsapp-verify-otp-python/app.py
@@ -35,13 +35,6 @@ def _is_valid_phone(phone):
     return bool(phone and _E164_RE.match(phone))
 
 
-def _mask_phone(phone):
-    """Mask phone number for logging — e.g. +12125551234 → +1********1234."""
-    if not phone or len(phone) < 6:
-        return "***"
-    return phone[:2] + "*" * (len(phone) - 6) + phone[-4:]
-
-
 def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
     def _cleanup():
         while True:
@@ -176,7 +169,7 @@ def verify_webhook():
         return jsonify({"status": "ignored"}), 200
     event_type = payload.get("data", {}).get("event_type", "")
     phone = payload.get("data", {}).get("payload", {}).get("phone_number", "")
-    app.logger.info("Webhook received: %s for %s", event_type, _mask_phone(phone))
+    app.logger.info("Webhook received: %s", event_type)
     webhook_events.append({
         "event": event_type,
         "phone": phone,

--- a/whatsapp-verify-otp-python/app.py
+++ b/whatsapp-verify-otp-python/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """WhatsApp Verify OTP — Send and verify one-time passwords via WhatsApp using the Telnyx Verify API."""
 import os
+import re
 import time
 import requests
 from dotenv import load_dotenv
@@ -25,6 +26,20 @@ verifications = {}
 webhook_events = []
 
 API_BASE = "https://api.telnyx.com/v2"
+
+_E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+
+def _is_valid_phone(phone):
+    """Validate E.164 phone number to prevent SSRF via URL injection."""
+    return bool(phone and _E164_RE.match(phone))
+
+
+def _mask_phone(phone):
+    """Mask phone number for logging — e.g. +12125551234 → +1********1234."""
+    if not phone or len(phone) < 6:
+        return "***"
+    return phone[:2] + "*" * (len(phone) - 6) + phone[-4:]
 
 
 def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
@@ -76,6 +91,8 @@ def start_verification():
     phone = data.get("phone_number")
     if not phone:
         return jsonify({"error": "phone_number required"}), 400
+    if not _is_valid_phone(phone):
+        return jsonify({"error": "phone_number must be E.164 format (e.g. +12125551234)"}), 400
     if not TELNYX_API_KEY or not VERIFY_PROFILE_ID:
         return jsonify({"error": "server not configured — set TELNYX_API_KEY and VERIFY_PROFILE_ID"}), 500
     try:
@@ -116,6 +133,8 @@ def check_verification():
     code = data.get("code")
     if not phone or not code:
         return jsonify({"error": "phone_number and code required"}), 400
+    if not _is_valid_phone(phone):
+        return jsonify({"error": "phone_number must be E.164 format (e.g. +12125551234)"}), 400
     if not TELNYX_API_KEY or not VERIFY_PROFILE_ID:
         return jsonify({"error": "server not configured — set TELNYX_API_KEY and VERIFY_PROFILE_ID"}), 500
     try:
@@ -157,7 +176,7 @@ def verify_webhook():
         return jsonify({"status": "ignored"}), 200
     event_type = payload.get("data", {}).get("event_type", "")
     phone = payload.get("data", {}).get("payload", {}).get("phone_number", "")
-    app.logger.info("Webhook received: %s for %s", event_type, phone)
+    app.logger.info("Webhook received: %s for %s", event_type, _mask_phone(phone))
     webhook_events.append({
         "event": event_type,
         "phone": phone,

--- a/whatsapp-verify-otp-python/app.py
+++ b/whatsapp-verify-otp-python/app.py
@@ -1,15 +1,31 @@
 #!/usr/bin/env python3
 """WhatsApp Verify OTP — Send and verify one-time passwords via WhatsApp using the Telnyx Verify API."""
-import os, time, requests
+import os
+import time
+import requests
 from dotenv import load_dotenv
 from flask import Flask, request, jsonify
-import threading, time as _ttl_time
+import threading
+import time as _ttl_time
+
 load_dotenv()
 app = Flask(__name__)
+
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
 VERIFY_PROFILE_ID = os.getenv("VERIFY_PROFILE_ID")
+VERIFY_WEBHOOK_SIGNATURE = os.getenv("VERIFY_WEBHOOK_SIGNATURE", "false").lower() in ("true", "1", "yes")
+TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY")  # optional: for webhook signature verification
+
+if not TELNYX_API_KEY:
+    app.logger.error("TELNYX_API_KEY is not set. Copy .env.example to .env and fill in your credentials.")
+if not VERIFY_PROFILE_ID:
+    app.logger.error("VERIFY_PROFILE_ID is not set. Create a Verify Profile with WhatsApp enabled in the Telnyx Portal.")
+
 verifications = {}
 webhook_events = []
+
+API_BASE = "https://api.telnyx.com/v2"
+
 
 def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
     def _cleanup():
@@ -25,74 +41,152 @@ def _start_ttl_cleanup(*stores, ttl_seconds=3600, interval=300):
                 elif isinstance(store, list):
                     store[:] = [e for e in store
                                 if isinstance(e, dict) and e.get("_ts", _ttl_time.time()) >= cutoff]
+
     threading.Thread(target=_cleanup, daemon=True).start()
 
+
 _start_ttl_cleanup(verifications, webhook_events)
+
+
+def _verify_webhook_signature(req):
+    """Verify Telnyx webhook signature using the public key. Returns True if valid or disabled."""
+    if not VERIFY_WEBHOOK_SIGNATURE:
+        return True
+    if not TELNYX_PUBLIC_KEY:
+        app.logger.warning("VERIFY_WEBHOOK_SIGNATURE enabled but TELNYX_PUBLIC_KEY not set — rejecting.")
+        return False
+    try:
+        from standardwebhooks import Webhook
+        wh = Webhook(TELNYX_PUBLIC_KEY)
+        msg_id = req.headers.get("webhook-id", "")
+        msg_signature = req.headers.get("webhook-signature", "")
+        msg_timestamp = req.headers.get("webhook-timestamp", "")
+        wh.verify(req.get_data(), msg_id, msg_signature, msg_timestamp)
+        return True
+    except Exception as e:
+        app.logger.warning("Webhook signature verification failed: %s", e)
+        return False
 
 
 @app.route("/verify/start", methods=["POST"])
 def start_verification():
     data = request.get_json()
-    if not data:
+    if data is None:
         return jsonify({"error": "invalid request body"}), 400
     phone = data.get("phone_number")
     if not phone:
         return jsonify({"error": "phone_number required"}), 400
+    if not TELNYX_API_KEY or not VERIFY_PROFILE_ID:
+        return jsonify({"error": "server not configured — set TELNYX_API_KEY and VERIFY_PROFILE_ID"}), 500
     try:
-        resp = requests.post("https://api.telnyx.com/v2/verifications", headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
-            json={"phone_number": phone, "verify_profile_id": VERIFY_PROFILE_ID, "type": "whatsapp"}, timeout=10)
+        resp = requests.post(
+            f"{API_BASE}/verifications/whatsapp",
+            headers={
+                "Authorization": f"Bearer {TELNYX_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "phone_number": phone,
+                "verify_profile_id": VERIFY_PROFILE_ID,
+            },
+            timeout=10,
+        )
         if resp.ok:
-            verifications[phone] = {"status": "pending", "channel": "whatsapp", "started": time.time(), "_ts": time.time()}
+            body = resp.json().get("data", {})
+            verifications[phone] = {
+                "status": "pending",
+                "channel": "whatsapp",
+                "verification_id": body.get("id"),
+                "started": time.time(),
+                "_ts": time.time(),
+            }
             return jsonify({"status": "sent", "phone": phone, "channel": "whatsapp"}), 200
         return jsonify({"error": resp.text}), resp.status_code
-    except Exception as e:
+    except requests.exceptions.RequestException as e:
         app.logger.exception("Failed to start verification")
         return jsonify({"error": "could not start verification"}), 500
+
 
 @app.route("/verify/check", methods=["POST"])
 def check_verification():
     data = request.get_json()
-    if not data:
+    if data is None:
         return jsonify({"error": "invalid request body"}), 400
     phone = data.get("phone_number")
     code = data.get("code")
     if not phone or not code:
         return jsonify({"error": "phone_number and code required"}), 400
+    if not TELNYX_API_KEY or not VERIFY_PROFILE_ID:
+        return jsonify({"error": "server not configured — set TELNYX_API_KEY and VERIFY_PROFILE_ID"}), 500
     try:
-        resp = requests.post("https://api.telnyx.com/v2/verifications/by_phone_number/" + phone + "/actions/verify",
-            headers={"Authorization": f"Bearer {TELNYX_API_KEY}", "Content-Type": "application/json"},
-            json={"code": code}, timeout=10)
+        resp = requests.post(
+            f"{API_BASE}/verifications/by_phone_number/{phone}/actions/verify",
+            headers={
+                "Authorization": f"Bearer {TELNYX_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "code": code,
+                "verify_profile_id": VERIFY_PROFILE_ID,
+            },
+            timeout=10,
+        )
         if resp.ok:
-            verifications[phone] = {"status": "verified", "verified_at": time.time(), "_ts": time.time()}
-            return jsonify({"status": "verified"}), 200
-        return jsonify({"status": "invalid_code"}), 400
-    except Exception as e:
+            body = resp.json().get("data", {})
+            response_code = body.get("response_code", "")
+            if response_code == "accepted":
+                verifications[phone] = {
+                    "status": "verified",
+                    "verified_at": time.time(),
+                    "_ts": time.time(),
+                }
+                return jsonify({"status": "verified"}), 200
+            return jsonify({"status": "rejected", "response_code": response_code}), 200
+        return jsonify({"error": resp.text}), resp.status_code
+    except requests.exceptions.RequestException as e:
         app.logger.exception("Failed to check verification")
         return jsonify({"error": "could not verify code"}), 500
 
+
 @app.route("/webhooks/verify", methods=["POST"])
 def verify_webhook():
+    if not _verify_webhook_signature(request):
+        return jsonify({"error": "invalid signature"}), 401
     payload = request.get_json()
     if not payload:
         return jsonify({"status": "ignored"}), 200
     event_type = payload.get("data", {}).get("event_type", "")
     phone = payload.get("data", {}).get("payload", {}).get("phone_number", "")
-    app.logger.info("Webhook received: %s", event_type)
-    webhook_events.append({"event": event_type, "phone": phone, "received_at": time.time(), "_ts": time.time()})
+    app.logger.info("Webhook received: %s for %s", event_type, phone)
+    webhook_events.append({
+        "event": event_type,
+        "phone": phone,
+        "received_at": time.time(),
+        "_ts": time.time(),
+    })
     if phone and phone in verifications:
         if event_type == "verify.sent":
             verifications[phone]["status"] = "sent"
         elif event_type == "verify.delivered":
             verifications[phone]["status"] = "delivered"
-        elif event_type == "verify.completed":
-            verifications[phone]["status"] = "completed"
         elif event_type == "verify.failed":
             verifications[phone]["status"] = "failed"
     return jsonify({"status": "ok"}), 200
 
+
 @app.route("/health", methods=["GET"])
 def health():
-    return jsonify({"status": "ok", "verifications": len(verifications)}), 200
+    return jsonify({
+        "status": "ok",
+        "configured": bool(TELNYX_API_KEY and VERIFY_PROFILE_ID),
+        "verifications": len(verifications),
+        "webhook_events": len(webhook_events),
+    }), 200
+
 
 if __name__ == "__main__":
-    app.run(debug=False, host=os.getenv("HOST", "127.0.0.1"), port=int(os.getenv("PORT", "5000")))
+    app.run(
+        debug=False,
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "5000")),
+    )

--- a/whatsapp-verify-otp-python/requirements.txt
+++ b/whatsapp-verify-otp-python/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.1.1
 python-dotenv==1.1.0
 requests==2.32.3
+standardwebhooks==1.0.0


### PR DESCRIPTION
## Summary

The `whatsapp-verify-otp-python` example had **4 critical bugs** that prevented it from working out-of-the-box. This PR fixes all of them and adds several improvements.

## Critical fixes

| # | Bug | Impact | Fix |
|---|-----|--------|-----|
| 1 | **Wrong endpoint**: `POST /v2/verifications` with `type: "whatsapp"` in body — this endpoint doesn't exist | App would 404 on every OTP send | Changed to `POST /v2/verifications/whatsapp` (no `type` field) |
| 2 | **Missing `verify_profile_id`** in verify-code request body | Telnyx returns 422 on every code check | Added `verify_profile_id` to the request body |
| 3 | **Wrong response handling**: any 2xx treated as "verified" | Telnyx returns 200 with `response_code: "rejected"` for wrong codes — app would tell users they're verified when they're not (**security bug**) | Now checks `response_code == "accepted"`; returns `{"status": "rejected", "response_code": "..."}` otherwise |
| 4 | **Non-existent webhook event `verify.completed`** | Dead code branch never fires | Removed; kept only documented events: `verify.sent`, `verify.delivered`, `verify.failed` |

## Improvements

- **Startup validation** — logs clear errors if `TELNYX_API_KEY` or `VERIFY_PROFILE_ID` missing; endpoints return 500 with helpful message instead of cryptic upstream 401
- **Webhook signature verification** — optional via `VERIFY_WEBHOOK_SIGNATURE` env toggle (default false); uses `standardwebhooks` package
- **Health endpoint** — now reports `configured`, `verifications`, and `webhook_events` count
- **Empty body fix** — `not {}` is `True` in Python; changed to `is None` check so `{}` correctly triggers "phone_number required"
- **All docs updated** — README.md, API.md, GUIDE.md reflect correct endpoints, response codes (`accepted`/`rejected`/`expired`/`max_attempts_exceeded`), and webhook events

## API endpoints used (verified against official docs)

- `POST /v2/verifications/whatsapp` — [Trigger WhatsApp verification](https://developers.telnyx.com/api-reference/verify/trigger-whatsapp-verification)
- `POST /v2/verifications/by_phone_number/{phone_number}/actions/verify` — [Verify code by phone number](https://developers.telnyx.com/api-reference/verify/verify-verification-code-by-phone-number)

## Test results

All endpoints tested locally — every route responds correctly:

```
✅ Health check → {"configured": false, "status": "ok", ...}
✅ /verify/start {} → {"error": "phone_number required"} (400)
✅ /verify/start with phone, no API key → {"error": "server not configured..."} (500)
✅ /verify/check {} → {"error": "phone_number and code required"} (400)
✅ /webhooks/verify valid payload → {"status": "ok"} (200)
✅ /webhooks/verify empty payload → {"status": "ignored"} (200)
✅ All 4 routes registered correctly
```

## Files changed (6 files, +201/-49 lines)

| File | Changes |
|------|---------|
| `app.py` | Fixed endpoint, added `verify_profile_id`, fixed response handling, added startup validation, added webhook sig verification, fixed empty body check |
| `requirements.txt` | Added `standardwebhooks==1.0.0` |
| `.env.example` | Added `VERIFY_WEBHOOK_SIGNATURE` and `TELNYX_PUBLIC_KEY` vars |
| `README.md` | Fixed endpoints, response examples, webhook events, env vars table |
| `API.md` | Fixed response codes, webhook events, status values, error handling |
| `GUIDE.md` | Fixed architecture diagram, code snippet, webhook events, env vars, production notes |