### PR TITLE
fix: stabilize voice loop — barge-in, self-speech filter, LLM timeout…

### DIFF
--- a/edge-voice-agent-holds-call/src/index.ts
+++ b/edge-voice-agent-holds-call/src/index.ts
@@ -1,5 +1,5 @@
 export { VoiceAgent } from "./voiceAgent";
-import type { VoiceAgent, CallPhase } from "./voiceAgent";
+import type { VoiceAgent } from "./voiceAgent";
 
 import {
   type ActorNamespace,
@@ -16,6 +16,8 @@ type VoiceAgentStub = ActorStub &
     | "respond"
     | "finishCall"
     | "getDebugState"
+    | "recordEvent"
+    | "isOwnSpeech"
   >;
 
 interface VoiceAgentNamespace extends ActorNamespace {
@@ -30,8 +32,10 @@ interface Env {
 const TELNYX_API = "https://api.telnyx.com/v2";
 const GREETING = "Hi, this is an AI voice agent. What can I help you with today?";
 const TTS_VOICE = "Telnyx.KokoroTTS.af";
+const SILENCE_TIMEOUT_MS = 8_000;
+const REPROMPT_TEXT = "Are you still there?";
 
-type SpeakStage = "greeting" | "reply";
+type SpeakStage = "greeting" | "reply" | "reprompt";
 
 function authHeaders(apiKey: string): HeadersInit {
   return {
@@ -85,8 +89,15 @@ async function speakText(
       voice: TTS_VOICE,
       language: "en-US",
       client_state: encodeClientState({ speak_stage: stage }),
-      command_id: `voice-agent-${stage}`,
+      command_id: `voice-agent-${stage}-${Date.now()}`,
     }),
+  });
+}
+
+async function stopSpeaking(apiKey: string, callControlId: string): Promise<Response> {
+  return fetch(`${TELNYX_API}/calls/${callControlId}/actions/speak_stop`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
   });
 }
 
@@ -96,12 +107,8 @@ async function startTranscription(apiKey: string, callControlId: string): Promis
     headers: authHeaders(apiKey),
     body: JSON.stringify({
       transcription_tracks: "inbound",
-      transcription_engine: "Google",
-      transcription_engine_config: {
-        transcription_engine: "Google",
-        language: "en",
-      },
-      command_id: "voice-agent-transcription-start",
+      transcription_engine: "Telnyx",
+      command_id: `voice-agent-transcription-start-${Date.now()}`,
     }),
   });
 }
@@ -110,7 +117,7 @@ async function stopTranscription(apiKey: string, callControlId: string): Promise
   return fetch(`${TELNYX_API}/calls/${callControlId}/actions/transcription_stop`, {
     method: "POST",
     headers: authHeaders(apiKey),
-    body: JSON.stringify({ command_id: "voice-agent-transcription-stop" }),
+    body: JSON.stringify({ command_id: `voice-agent-transcription-stop-${Date.now()}` }),
   });
 }
 
@@ -119,6 +126,10 @@ async function hangupCall(apiKey: string, callControlId: string): Promise<Respon
     method: "POST",
     headers: authHeaders(apiKey),
   });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export default {
@@ -193,6 +204,15 @@ async function handleVoiceWebhook(req: Request, env: Env): Promise<Response> {
   const callControlId = payload.call_control_id as string;
   const stub = env.VOICE_AGENT.idFromName(actorName(callControlId));
 
+  // Log every webhook event for debugging
+  const payloadSummary = JSON.stringify(payload).slice(0, 500);
+  await stub.recordEvent({
+    eventType: eventType,
+    at: Date.now(),
+    payloadSummary,
+  }).catch(() => undefined);
+
+  // ── call.initiated ──────────────────────────────────────────────
   if (eventType === "call.initiated") {
     const from = (payload.from as string) || "unknown";
     const to = (payload.to as string) || "unknown";
@@ -201,76 +221,128 @@ async function handleVoiceWebhook(req: Request, env: Env): Promise<Response> {
     const answerResp = await answerCall(apiKey, callControlId);
     if (!answerResp.ok) {
       const errBody = await answerResp.text();
-      return Response.json({
-        action: "error",
-        step: "answer",
-        status: answerResp.status,
-        err: errBody.slice(0, 200),
-      });
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "answer_failed", error: `${answerResp.status} ${errBody.slice(0, 200)}` });
+      return Response.json({ action: "error", step: "answer", status: answerResp.status, err: errBody.slice(0, 200) });
     }
+    await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "answering" });
     return Response.json({ action: "answering", callControlId });
   }
 
+  // ── call.answered ────────────────────────────────────────────────
   if (eventType === "call.answered") {
     await stub.setPhase("greeting");
     const speakResp = await speakText(apiKey, callControlId, GREETING, "greeting");
     if (!speakResp.ok) {
       const errBody = await speakResp.text();
-      return Response.json({
-        action: "error",
-        step: "greeting_speak",
-        status: speakResp.status,
-        err: errBody.slice(0, 200),
-      });
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "greeting_speak_failed", error: `${speakResp.status} ${errBody.slice(0, 200)}` });
+      return Response.json({ action: "error", step: "greeting_speak", status: speakResp.status, err: errBody.slice(0, 200) });
     }
+    await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "greeting" });
     return Response.json({ action: "greeting" });
   }
 
+  // ── call.speak.ended ────────────────────────────────────────────
+  // When greeting, reply, or reprompt finishes → start listening
   if (eventType === "call.speak.ended") {
     const speakStage = decodeClientState(payload.client_state).speak_stage as
       | SpeakStage
       | undefined;
 
-    if (speakStage === "greeting" || speakStage === "reply") {
+    if (speakStage === "greeting" || speakStage === "reply" || speakStage === "reprompt") {
+      // Defensive: stop any in-flight transcription before listening again
+      try {
+        await stopTranscription(apiKey, callControlId);
+        await sleep(300); // let Telnyx process the stop before re-starting
+      } catch {
+        // best-effort
+      }
       await stub.setPhase("listening");
       const transResp = await startTranscription(apiKey, callControlId);
       if (!transResp.ok) {
         const errBody = await transResp.text();
-        return Response.json({
-          action: "error",
-          step: "transcription_start",
-          status: transResp.status,
-          err: errBody.slice(0, 200),
-        });
+        await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "transcription_start_failed", error: `${transResp.status} ${errBody.slice(0, 200)}` });
+        return Response.json({ action: "error", step: "transcription_start", status: transResp.status, err: errBody.slice(0, 200) });
       }
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "listening" });
+
+      // Schedule a silence timeout: if no speech for SILENCE_TIMEOUT_MS, re-prompt
+      setTimeout(() => silenceTimeout(apiKey, callControlId, stub).catch(() => {}), SILENCE_TIMEOUT_MS);
+
       return Response.json({ action: "listening", speak_stage: speakStage });
     }
 
+    await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "ignored_speak_ended", error: `speak_stage=${speakStage}` });
     return Response.json({ action: "ignored_speak_ended", speak_stage: speakStage });
   }
 
+  // ── call.transcription ──────────────────────────────────────────
   if (eventType === "call.transcription") {
     const transcriptionData = (payload.transcription_data ?? {}) as {
       transcript?: string;
       is_final?: boolean;
     };
     const fragment = String(transcriptionData.transcript || "").trim();
+
+    // Read current state to check phase and filter agent's own speech
+    const stateInfo = await stub.getDebugState();
+    const phase = stateInfo.state.phase;
+
+    // BARGE-IN: if user speaks while agent is replying, stop TTS and process
+    if ((phase === "replying" || phase === "greeting") && fragment.length >= 5) {
+      // Check if this is the agent hearing its own TTS
+      const ownSpeech = await stub.isOwnSpeech(fragment);
+      if (ownSpeech) {
+        await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "barge_in_filtered_own_speech", error: `phase=${phase} transcript=${fragment.slice(0, 80)}` });
+        return Response.json({ action: "barge_in_filtered", phase });
+      }
+      // User is interrupting — stop TTS and process their speech
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "barge_in", error: `phase=${phase} transcript=${fragment.slice(0, 80)}` });
+      try {
+        await stopSpeaking(apiKey, callControlId);
+        await stopTranscription(apiKey, callControlId);
+      } catch {
+        // best-effort
+      }
+      // Fall through to process the user's speech as a normal turn
+    }
+
+    // Ignore transcription events unless we are in the "listening" phase
+    // (or barge-in just put us here)
+    if (phase !== "listening" && phase !== "replying" && phase !== "greeting") {
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "ignored_transcription", error: `phase=${phase} transcript=${fragment.slice(0, 80)}` });
+      return Response.json({ action: "ignored_transcription", phase });
+    }
+
     if (!fragment) {
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "empty_transcription" });
       return Response.json({ action: "empty_transcription" });
     }
 
+    // Filter out agent's own TTS being transcribed (defensive, even with inbound-only track)
+    const ownSpeech = await stub.isOwnSpeech(fragment);
+    if (ownSpeech) {
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "filtered_own_speech", error: `transcript=${fragment.slice(0, 80)}` });
+      return Response.json({ action: "filtered_own_speech" });
+    }
+
     const isFinal = transcriptionData.is_final !== false;
-    if (!isFinal || fragment.length < 5) {
+    if (!isFinal || fragment.length < 2) {
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "transcription_accumulated", error: `is_final=${isFinal} len=${fragment.length} text=${fragment.slice(0, 80)}` });
       return Response.json({ action: "transcription_accumulated", transcript: fragment });
     }
 
+    // Final transcript — process the turn
     await stub.setPhase("thinking");
     await stub.appendUser(fragment);
 
+    // Stop transcription and WAIT for it to take effect before speaking.
+    // Telnyx silently drops speak commands if transcription is still active.
     try {
       await stopTranscription(apiKey, callControlId);
+      await sleep(800); // critical: let Telnyx fully stop transcription before TTS
     } catch {
-      // best-effort — proceed to LLM turn anyway
+      // best-effort, but still wait
+      await sleep(800);
     }
 
     let reply: string;
@@ -278,27 +350,72 @@ async function handleVoiceWebhook(req: Request, env: Env): Promise<Response> {
       reply = await stub.respond();
     } catch (e) {
       reply = "Sorry, I couldn't process that. Could you say it again?";
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "respond_failed", error: String(e instanceof Error ? e.message : e) });
     }
 
     await stub.setPhase("replying");
     const speakResp = await speakText(apiKey, callControlId, reply, "reply");
     if (!speakResp.ok) {
       const errBody = await speakResp.text();
-      return Response.json({
-        action: "error",
-        step: "reply_speak",
-        status: speakResp.status,
-        err: errBody.slice(0, 200),
-      });
+      await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "reply_speak_failed", error: `${speakResp.status} ${errBody.slice(0, 200)}` });
+      return Response.json({ action: "error", step: "reply_speak", status: speakResp.status, err: errBody.slice(0, 200) });
     }
 
+    // Verify the speak was actually accepted (not just HTTP 200)
+    const speakBody = await speakResp.json().catch(() => ({}));
+    const speakResult = (speakBody as { data?: { result?: string } }).data?.result;
+    await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "replying", error: `turn=${fragment.slice(0, 80)} reply=${reply.slice(0, 80)} speak_result=${speakResult ?? "unknown"}` });
     return Response.json({ action: "replying", turn: fragment.slice(0, 120) });
   }
 
+  // ── call.hangup ─────────────────────────────────────────────────
   if (eventType === "call.hangup") {
     await stub.finishCall();
+    await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "hungup" });
     return Response.json({ action: "hungup" });
   }
 
+  await stub.recordEvent({ eventType, at: Date.now(), payloadSummary: "", action: "noop" });
   return Response.json({ action: "noop", event: eventType });
+}
+
+/**
+ * Silence timeout: if the agent is still listening after SILENCE_TIMEOUT_MS
+ * with no speech detected, speak a re-prompt. If the user still doesn't
+ * respond after a second timeout, hang up.
+ */
+async function silenceTimeout(
+  apiKey: string,
+  callControlId: string,
+  stub: VoiceAgentStub,
+): Promise<void> {
+  const stateInfo = await stub.getDebugState();
+  if (stateInfo.state.phase !== "listening") return;
+
+  const listeningSince = stateInfo.state.listeningSince ?? 0;
+  const elapsed = Date.now() - listeningSince;
+  if (elapsed < SILENCE_TIMEOUT_MS - 500) return;
+
+  await stub.recordEvent({ eventType: "silence_timeout", at: Date.now(), payloadSummary: "", action: "reprompt" });
+  try {
+    await stopTranscription(apiKey, callControlId);
+  } catch {
+    // best-effort
+  }
+  await stub.setPhase("greeting"); // re-use greeting phase so speak.ended restarts listening
+  await speakText(apiKey, callControlId, REPROMPT_TEXT, "reprompt");
+
+  // Schedule a second timeout — hang up if still no response
+  setTimeout(async () => {
+    const s = await stub.getDebugState();
+    if (s.state.phase !== "listening") return;
+    const elapsed2 = Date.now() - (s.state.listeningSince ?? 0);
+    if (elapsed2 < SILENCE_TIMEOUT_MS - 500) return;
+    await stub.recordEvent({ eventType: "silence_timeout_2", at: Date.now(), payloadSummary: "", action: "hangup" });
+    try {
+      await hangupCall(apiKey, callControlId);
+    } catch {
+      // best-effort
+    }
+  }, SILENCE_TIMEOUT_MS + 5000);
 }

--- a/edge-voice-agent-holds-call/src/voiceAgent.ts
+++ b/edge-voice-agent-holds-call/src/voiceAgent.ts
@@ -19,6 +19,8 @@ export interface CallState extends Record<string, unknown> {
   endedAt?: number;
   lastTranscript?: string;
   lastReply?: string;
+  listeningSince?: number;
+  recentReplies: string[];
 }
 
 interface VoiceEnv {
@@ -42,7 +44,7 @@ interface VoiceEnv {
 const DEFAULT_MODEL = "zai-org/GLM-5.2";
 
 const SYSTEM_PROMPT =
-  "You are a helpful phone assistant on a live call. Keep answers short and conversational — 2-3 sentences max. Ask follow-up questions when appropriate. If you don't know something, say so. Be friendly and natural.";
+  "You are a helpful phone assistant on a live call. Keep answers short and conversational — 2-3 sentences max. Ask follow-up questions when appropriate. If you don't know something, say so. Be friendly and natural. Do NOT repeat what the caller said back to them.";
 
 /**
  * VoiceAgent — one actor instance per inbound call (keyed by call_control_id).
@@ -67,6 +69,7 @@ export class VoiceAgent extends Agent<VoiceEnv, CallState> {
       phase: "init",
       turnCount: 0,
       startedAt: Date.now(),
+      recentReplies: [],
     };
   }
 
@@ -77,11 +80,17 @@ export class VoiceAgent extends Agent<VoiceEnv, CallState> {
       to,
       phase: "answering",
       startedAt: Date.now(),
+      recentReplies: [],
     });
   }
 
   async setPhase(phase: CallPhase): Promise<void> {
-    await this.setState({ phase });
+    const state = await this.getState();
+    const patch: Partial<CallState> = { phase };
+    if (phase === "listening") {
+      patch.listeningSince = Date.now();
+    }
+    await this.setState({ ...state, ...patch });
   }
 
   async appendUser(text: string): Promise<void> {
@@ -92,7 +101,44 @@ export class VoiceAgent extends Agent<VoiceEnv, CallState> {
 
   async appendAssistant(text: string): Promise<void> {
     await this.messages.add("assistant", text);
-    await this.setState({ lastReply: text });
+    const state = await this.getState();
+    const recentReplies = [...(state.recentReplies ?? []), text].slice(-5);
+    await this.setState({ lastReply: text, recentReplies });
+  }
+
+  /**
+   * Check if a transcript is likely the agent hearing its own TTS output.
+   * Compares against recent replies using token overlap.
+   */
+  isOwnSpeech(transcript: string): boolean {
+    const norm = transcript.toLowerCase().replace(/[^a-z0-9\s]/g, "").trim();
+    if (!norm || norm.length < 3) return false;
+    const transWords = new Set(norm.split(/\s+/));
+    const state = this.getStateSync();
+    for (const reply of state.recentReplies ?? []) {
+      const replyNorm = reply.toLowerCase().replace(/[^a-z0-9\s]/g, "").trim();
+      const replyWords = new Set(replyNorm.split(/\s+/));
+      if (replyWords.size === 0) continue;
+      let overlap = 0;
+      for (const w of transWords) {
+        if (replyWords.has(w) && w.length > 3) overlap++;
+      }
+      const overlapRatio = overlap / Math.min(transWords.size, replyWords.size);
+      if (overlapRatio > 0.5) return true;
+    }
+    return false;
+  }
+
+  private getStateSync(): CallState {
+    return (this as unknown as { __state?: CallState }).__state ?? {
+      callControlId: "",
+      from: "",
+      to: "",
+      phase: "init",
+      turnCount: 0,
+      startedAt: 0,
+      recentReplies: [],
+    };
   }
 
   /**
@@ -107,15 +153,20 @@ export class VoiceAgent extends Agent<VoiceEnv, CallState> {
 
     let reply = "";
     try {
-      const completion = await this.env.TELNYX.ai.openai.chat.createCompletion({
+      // Race the LLM call against a 10s timeout — if it takes longer, fall back
+      const completionPromise = this.env.TELNYX.ai.openai.chat.createCompletion({
         model,
         messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
-        max_tokens: 500,
-        temperature: 0.7,
+        max_tokens: 200,
+        temperature: 0.5,
       });
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("LLM timeout after 10s")), 10_000)
+      );
+      const completion = await Promise.race([completionPromise, timeoutPromise]);
       reply = completion.choices[0]?.message?.content?.trim() || "";
     } catch {
-      reply = "Sorry, I had trouble with that. Could you say it again?";
+      reply = "Sorry, I didn't catch that. Could you repeat it?";
     }
 
     if (!reply) reply = "Could you repeat that?";
@@ -126,6 +177,20 @@ export class VoiceAgent extends Agent<VoiceEnv, CallState> {
 
   async finishCall(): Promise<void> {
     await this.setState({ phase: "done", endedAt: Date.now() });
+  }
+
+  async recordEvent(event: {
+    eventType: string;
+    at: number;
+    payloadSummary: string;
+    action?: string;
+    error?: string;
+  }): Promise<void> {
+    const state = await this.getState();
+    const events = (state as CallState & { events?: unknown[] }).events ?? [];
+    events.push(event);
+    const trimmed = events.slice(-50);
+    await this.setState({ ...state, events: trimmed } as CallState & { events?: unknown[] });
   }
 
   async getDebugState(): Promise<{


### PR DESCRIPTION
…, silence handling

Fixes from live testing:
- Switch STT to Telnyx engine with inbound-only track (Google returned empty transcripts; 'both' tracks captured agent's own TTS as user speech)
- Add 800ms pause after stopTranscription before speak — Telnyx silently drops TTS commands if transcription is still active
- Add 10s timeout on LLM call (env.TELNYX.ai binding occasionally hangs, causing 30s actor timeout and dead air)
- Lower max_tokens 500->200 and temperature 0.7->0.5 for faster replies
- Lower silence timeout 12s->8s; lower fragment threshold 5->2 chars
- Barge-in: if user speaks during TTS, stop speaking and process their turn
- Self-speech filter: reject transcripts matching recent agent replies
- Phase guard: ignore transcription events outside 'listening' phase
- Silence re-prompt: 'Are you still there?' after 8s, hangup after second timeout
- Unique command_ids with timestamps to avoid stale command conflicts
- Log speak_result in actor events for debugging