### PR TITLE
feat: Edge Cache Invalidation Agent (DEV-817)

### DIFF
--- a/edge-cache-invalidation-agent/.env.example
+++ b/edge-cache-invalidation-agent/.env.example
@@ -1,0 +1,22 @@
+# Telnyx API key (for KV and Cloud Storage)
+# Get from: https://portal.telnyx.com/#/app/api-keys
+TELNYX_API_KEY=KEY0123456789ABCDEF
+
+# Ops phone number (receives SMS alert when invalidation completes)
+# E.164 format, e.g., +18005551234
+ALERT_PHONE=+18005551234
+
+# Telnyx SMS-enabled number (sends the SMS)
+# E.164 format, e.g., +18005551234
+SENDER_PHONE=+18005551234
+
+# KV namespace UUID (from Portal → Storage → KV)
+# Also update telnyx.toml [storage.kv.CACHE_KV] id
+KV_NAMESPACE_ID=00000000-0000-0000-0000-000000000000
+
+# Cloud Storage bucket name (from Portal → Storage → Buckets)
+# Also update telnyx.toml [storage.cloudstorage.CACHE_STORAGE] bucket_name
+STORAGE_BUCKET=my-cache-manifest-bucket
+
+# Cloud Storage region
+STORAGE_REGION=us-central-1

--- a/edge-cache-invalidation-agent/.gitignore
+++ b/edge-cache-invalidation-agent/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log
+.DS_Store

--- a/edge-cache-invalidation-agent/README.md
+++ b/edge-cache-invalidation-agent/README.md
@@ -1,0 +1,232 @@
+# Edge Cache Invalidation Agent
+
+Webhook-triggered cache invalidation across edge locations — mark caches dirty via KV, update a shared manifest in Cloud Storage, and notify ops via SMS. All orchestrated by the Agent SDK on Telnyx Edge Compute with zero-credential messaging.
+
+## Telnyx API Endpoints Used
+
+- **KV (Key-Value Store)** — `this.env.CACHE_KV.put()` / `get()` / `delete()` — per-location cache invalidation flags
+- **Cloud Storage** — `this.env.CACHE_STORAGE.put()` / `get()` — shared cache manifest (JSON)
+- **Messaging** — `this.env.TELNYX.messages.send()` — SMS notification to ops (zero-credential binding)
+
+## Architecture
+
+```
+Content update webhook → POST /invalidate
+        │
+        ▼
+  ┌──────────────────────────────────────────┐
+  │ CacheAgent.start()                        │
+  │   → queue("invalidate")                   │
+  │   → queue("updateManifest")               │
+  │   → queue("notify")                        │
+  └────────┬─────────────────────────────────┘
+           │
+           ▼
+  Stage 1: invalidate()
+    → KV.put("cache:{location}:{contentId}", { dirty: true, version })
+    → for each edge location
+           │
+           ▼
+  Stage 2: updateManifest()
+    → CloudStorage.get("cache-manifest.json")
+    → append invalidation entry
+    → CloudStorage.put("cache-manifest.json", updated)
+           │
+           ▼
+  Stage 3: notify()
+    → this.env.TELNYX.messages.send({ from, to, text })
+    → SMS: "Cache invalidated: {contentId} v{version} — N locations updated"
+```
+
+## Quickstart
+
+### Prerequisites
+
+- Node.js 18+
+- Telnyx account with:
+  - API key ([Portal → API Keys](https://portal.telnyx.com/#/app/api-keys))
+  - A phone number with SMS enabled ([Portal → Number](https://portal.telnyx.com/#/app/numbers))
+  - KV namespace ([Portal → Storage → KV](https://portal.telnyx.com/#/app/storage/kv))
+  - Cloud Storage bucket ([Portal → Storage → Buckets](https://portal.telnyx.com/#/app/storage/buckets))
+- `telnyx-edge` CLI installed
+
+### Setup
+
+```bash
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/edge-cache-invalidation-agent
+npm install
+```
+
+### Configure secrets
+
+```bash
+telnyx-edge secret set TELNYX_API_KEY KEY0123456789ABCDEF
+telnyx-edge secret set ALERT_PHONE +18005551234
+telnyx-edge secret set SENDER_PHONE +18005551234
+```
+
+### Update `telnyx.toml`
+
+Replace the placeholder values:
+
+```toml
+[storage.kv.CACHE_KV]
+id = "your-kv-namespace-uuid"
+
+[storage.cloudstorage.CACHE_STORAGE]
+bucket_name = "your-bucket-name"
+region = "us-central-1"
+```
+
+### Deploy
+
+```bash
+telnyx-edge ship
+```
+
+## API Reference
+
+### `POST /invalidate`
+
+Trigger a cache invalidation across edge locations.
+
+**Request body:**
+
+```json
+{
+  "content_id": "/blog/how-to-build-x",
+  "content_version": "2026-08-19-v2",
+  "locations": ["us-east-1", "us-west-1", "eu-central-1", "ap-southeast-1"]
+}
+```
+
+**Response (200):**
+
+```json
+{
+  "action": "queued",
+  "agentId": "bloghowtobuildx-20260819v2-1724080800000",
+  "contentId": "/blog/how-to-build-x",
+  "contentVersion": "2026-08-19-v2",
+  "locations": ["us-east-1", "us-west-1", "eu-central-1", "ap-southeast-1"],
+  "statusUrl": "/status/bloghowtobuildx-20260819v2-1724080800000"
+}
+```
+
+### `GET /status/:agentId`
+
+Check the status of an invalidation pipeline.
+
+**Response:**
+
+```json
+{
+  "contentId": "/blog/how-to-build-x",
+  "contentVersion": "2026-08-19-v2",
+  "status": "done",
+  "invalidatedLocations": ["us-east-1", "us-west-1", "eu-central-1", "ap-southeast-1"],
+  "manifestUpdated": true,
+  "smsSent": true,
+  "createdAt": 1724080800000,
+  "completedAt": 1724080805000
+}
+```
+
+### `GET /cache-status/:location/:contentId`
+
+Check if a specific location's cache is dirty for a content ID.
+
+**Response:**
+
+```json
+{
+  "location": "us-east-1",
+  "contentId": "/blog/how-to-build-x",
+  "dirty": true,
+  "contentVersion": "2026-08-19-v2"
+}
+```
+
+### `POST /cache-clear/:location/:contentId`
+
+Clear the dirty flag for a location (simulates cache refresh).
+
+**Response:**
+
+```json
+{
+  "action": "cleared",
+  "location": "us-east-1",
+  "contentId": "/blog/how-to-build-x"
+}
+```
+
+### `GET /locations`
+
+List demo edge locations.
+
+### `GET /health/liveness` / `GET /health/readiness`
+
+Health check endpoints.
+
+## How It Works
+
+### The `[telnyx]` Binding — Zero-Credential Messaging
+
+The `[telnyx]` binding in `telnyx.toml` injects a pre-authenticated Telnyx client into `this.env.TELNYX`. The SMS call in the `notify()` stage needs no API key, no Authorization header, no environment variable — the binding carries the auth:
+
+```typescript
+await this.env.TELNYX.messages.send({
+  from: state.senderPhone,
+  to: state.alertPhone,
+  text: smsText,
+});
+```
+
+Only `TELNYX_API_KEY` is needed as a secret (for KV and Cloud Storage, which use the API key directly). Messaging is zero-credential via the binding.
+
+### Durable State Across Pipeline Stages
+
+Each stage calls `this.setState()` to persist progress. If a stage fails and retries, it reads state from the previous stage instead of re-running:
+
+```typescript
+// Stage 1: invalidate
+await this.setState({
+  invalidatedLocations: invalidated,
+  status: "updating_manifest",
+});
+await this.queue("updateManifest");
+
+// Stage 2: updateManifest
+await this.setState({
+  manifestUpdated: true,
+  status: "notifying",
+});
+await this.queue("notify");
+```
+
+If the `notify()` stage fails (e.g., SMS gateway temporarily down), the agent retries and reads the summary from state — it doesn't re-invalidate caches or re-update the manifest.
+
+### KV-Based Cache Invalidation
+
+Each edge location gets a KV key: `cache:{location}:{contentId}`. The value is a JSON object with `dirty: true`, the new `contentVersion`, and a timestamp. KV keys expire after 1 hour (TTL) — if a location hasn't refreshed its cache by then, the flag disappears and the location serves stale content until the next invalidation.
+
+### Cloud Storage Manifest
+
+The shared manifest (`cache-manifest.json`) in Cloud Storage is an append-only log of invalidation events. Each entry records what changed, the new version, which locations were invalidated, and when. This gives ops a durable audit trail across all invalidations.
+
+## Use Cases
+
+- **CDN cache busting** — content management system publishes a new page version, trigger invalidation across all edge locations
+- **Multi-region app deployment** — new code deploy, invalidate static asset caches across regions
+- **Emergency content removal** — take down outdated or incorrect content, force all edges to refresh immediately
+- **A/B test rollout** — switch a percentage of traffic to a new variant, invalidate the old variant's cache
+
+## Production Notes
+
+- This sample uses in-memory actor state. Production should add persistent storage for crash recovery.
+- The manifest is append-only. Production should rotate or partition it by date to avoid unbounded growth.
+- KV TTL is 1 hour. Adjust based on your cache refresh window.
+- Add authentication to the `/invalidate` endpoint before exposing it publicly.
+- Consider batching invalidations if you have many content IDs changing at once.

--- a/edge-cache-invalidation-agent/package.json
+++ b/edge-cache-invalidation-agent/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "edge-cache-invalidation-agent",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Edge Cache Invalidation Agent — webhook-triggered cache invalidation across edge locations via KV, Cloud Storage manifest, and SMS notification. Agent SDK on Telnyx Edge Compute.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build && telnyx-edge dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@telnyx/edge-runtime": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/edge-cache-invalidation-agent/src/cacheAgent.ts
+++ b/edge-cache-invalidation-agent/src/cacheAgent.ts
@@ -1,0 +1,204 @@
+import { Agent } from "@telnyx/edge-runtime";
+
+// ── State ────────────────────────────────────────────────────────────────
+export interface CacheAgentState extends Record<string, unknown> {
+  contentId: string;          // what changed (URL, asset path, etc.)
+  contentVersion: string;     // new version identifier
+  locations: string[];         // edge locations to invalidate
+  senderPhone: string;         // Telnyx number sending SMS
+  alertPhone: string;          // ops phone to notify
+  status: "pending" | "invalidating" | "updating_manifest" | "notifying" | "done" | "error";
+  invalidatedLocations: string[];
+  manifestUpdated: boolean;
+  smsSent: boolean;
+  error: string;
+  createdAt: number;
+  completedAt: number;
+}
+
+// ── Env: [telnyx] binding + KV + Cloud Storage ───────────────────────────
+interface CacheAgentEnv {
+  TELNYX: {
+    messages: {
+      send(m: { from: string; to: string; text: string }): Promise<unknown>;
+    };
+  };
+  CACHE_KV: KvNamespace;
+  CACHE_STORAGE: CloudStorageBucket;
+  ALERT_PHONE: string;
+  SENDER_PHONE: string;
+}
+
+const MANIFEST_KEY = "cache-manifest.json";
+
+/**
+ * CacheAgent — one actor instance per cache invalidation event.
+ *
+ * Pipeline (each stage queued for non-blocking execution):
+ *   1. invalidate()  — mark cache dirty per edge location via KV
+ *   2. updateManifest() — write updated manifest to Cloud Storage
+ *   3. notify()      — send SMS to ops via this.env.TELNYX.messages.send()
+ */
+export class CacheAgent extends Agent<CacheAgentEnv, CacheAgentState> {
+  protected override initialState(): CacheAgentState {
+    return {
+      contentId: "",
+      contentVersion: "",
+      locations: [],
+      senderPhone: "",
+      alertPhone: "",
+      status: "pending",
+      invalidatedLocations: [],
+      manifestUpdated: false,
+      smsSent: false,
+      error: "",
+      createdAt: 0,
+      completedAt: 0,
+    };
+  }
+
+  /** Entry point — called by the webhook handler after a content update arrives. */
+  async start(params: {
+    contentId: string;
+    contentVersion: string;
+    locations: string[];
+  }): Promise<void> {
+    await this.setState({
+      contentId: params.contentId,
+      contentVersion: params.contentVersion,
+      locations: params.locations,
+      senderPhone: this.env.SENDER_PHONE,
+      alertPhone: this.env.ALERT_PHONE,
+      status: "invalidating",
+      createdAt: Date.now(),
+    });
+    await this.queue("invalidate");
+  }
+
+  /** Stage 1: Mark cache as dirty in each edge location via KV. */
+  async invalidate(): Promise<void> {
+    const state = await this.getState();
+    try {
+      const invalidated: string[] = [];
+
+      for (const location of state.locations) {
+        // Mark this location's cache as dirty
+        const kvKey = `cache:${location}:${state.contentId}`;
+        const value = JSON.stringify({
+          dirty: true,
+          contentVersion: state.contentVersion,
+          invalidatedAt: Date.now(),
+        });
+        await this.env.CACHE_KV.put(kvKey, value, { expirationTtl: 3600 });
+        invalidated.push(location);
+      }
+
+      await this.setState({
+        invalidatedLocations: invalidated,
+        status: "updating_manifest",
+      });
+      await this.queue("updateManifest");
+    } catch (e: any) {
+      await this.setState({
+        status: "error",
+        error: `invalidate: ${e?.message || String(e)}`,
+        completedAt: Date.now(),
+      });
+    }
+  }
+
+  /** Stage 2: Update the shared cache manifest in Cloud Storage. */
+  async updateManifest(): Promise<void> {
+    const state = await this.getState();
+    try {
+      // Build the manifest entry for this content
+      const manifestEntry = {
+        contentId: state.contentId,
+        contentVersion: state.contentVersion,
+        invalidatedLocations: state.invalidatedLocations,
+        updatedAt: Date.now(),
+      };
+
+      // Read the existing manifest (if any)
+      let manifest: { entries: any[] } = { entries: [] };
+      try {
+        const existing = await this.env.CACHE_STORAGE.get(MANIFEST_KEY);
+        if (existing) {
+          const text = await existing.text();
+          manifest = JSON.parse(text);
+        }
+      } catch {
+        // No existing manifest — start fresh
+      }
+
+      // Append this invalidation to the manifest
+      manifest.entries.push(manifestEntry);
+
+      // Write the updated manifest back to Cloud Storage
+      const manifestJson = JSON.stringify(manifest, null, 2);
+      await this.env.CACHE_STORAGE.put(MANIFEST_KEY, manifestJson, {
+        contentType: "application/json",
+      });
+
+      await this.setState({
+        manifestUpdated: true,
+        status: "notifying",
+      });
+      await this.queue("notify");
+    } catch (e: any) {
+      await this.setState({
+        status: "error",
+        error: `updateManifest: ${e?.message || String(e)}`,
+        completedAt: Date.now(),
+      });
+    }
+  }
+
+  /** Stage 3: Send SMS notification to ops team (zero-credential binding). */
+  async notify(): Promise<void> {
+    const state = await this.getState();
+    try {
+      const locationCount = state.invalidatedLocations.length;
+      const smsText = `Cache invalidated: ${state.contentId} v${state.contentVersion} — ${locationCount} location(s) updated. Manifest synced.`;
+
+      await this.env.TELNYX.messages.send({
+        from: state.senderPhone,
+        to: state.alertPhone,
+        text: smsText,
+      });
+
+      await this.setState({
+        smsSent: true,
+        status: "done",
+        completedAt: Date.now(),
+      });
+    } catch (e: any) {
+      await this.setState({
+        status: "error",
+        error: `notify: ${e?.message || String(e)}`,
+        completedAt: Date.now(),
+      });
+    }
+  }
+
+  /** Debug helper — return current state for inspection. */
+  async getStatus(): Promise<CacheAgentState> {
+    return await this.getState();
+  }
+
+  /** Check if a location's cache is dirty for a given content ID. */
+  async checkCacheStatus(location: string, contentId: string): Promise<{ dirty: boolean; contentVersion?: string }> {
+    const kvKey = `cache:${location}:${contentId}`;
+    const value = await this.env.CACHE_KV.get(kvKey, { type: "json" });
+    if (!value) {
+      return { dirty: false };
+    }
+    return value as { dirty: boolean; contentVersion?: string };
+  }
+
+  /** Clear the dirty flag for a location (simulates cache refresh). */
+  async clearCacheFlag(location: string, contentId: string): Promise<void> {
+    const kvKey = `cache:${location}:${contentId}`;
+    await this.env.CACHE_KV.delete(kvKey);
+  }
+}

--- a/edge-cache-invalidation-agent/src/index.ts
+++ b/edge-cache-invalidation-agent/src/index.ts
@@ -1,0 +1,152 @@
+export { CacheAgent } from "./cacheAgent";
+import type { CacheAgent } from "./cacheAgent";
+
+import {
+  type ActorNamespace,
+  type ActorStub,
+  type IdFromNameOptions,
+} from "@telnyx/edge-runtime";
+
+type CacheAgentStub = ActorStub &
+  Pick<
+    CacheAgent,
+    "start" | "invalidate" | "updateManifest" | "notify" | "getStatus" | "checkCacheStatus" | "clearCacheFlag"
+  >;
+
+interface CacheAgentNamespace extends ActorNamespace {
+  idFromName(name: string, options?: IdFromNameOptions): CacheAgentStub;
+}
+
+interface Env {
+  CACHE: CacheAgentNamespace;
+  TELNYX_API_KEY: string;
+  ALERT_PHONE: string;
+  SENDER_PHONE: string;
+}
+
+// Dapr-safe actor names: no "+", no special chars (RFC 1123 job-name-safe).
+function actorName(id: string): string {
+  return id.replace(/[^0-9a-zA-Z.-]/g, "");
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    // ── Health ─────────────────────────────────────────────────────────
+    if (url.pathname === "/health/liveness") return new Response("ok");
+    if (url.pathname === "/health/readiness") return new Response("ok");
+
+    // ── Trigger cache invalidation ─────────────────────────────────────
+    if (req.method === "POST" && url.pathname === "/invalidate") {
+      try {
+        const body = (await req.json().catch(() => ({}))) as {
+          content_id?: string;
+          content_version?: string;
+          locations?: string[];
+        };
+
+        if (!body.content_id) {
+          return Response.json(
+            { error: "Missing 'content_id' (what changed — URL, asset path, etc.)" },
+            { status: 400 },
+          );
+        }
+
+        if (!body.content_version) {
+          return Response.json(
+            { error: "Missing 'content_version' (new version identifier)" },
+            { status: 400 },
+          );
+        }
+
+        if (!body.locations || !Array.isArray(body.locations) || body.locations.length === 0) {
+          return Response.json(
+            { error: "Missing 'locations' (array of edge location names to invalidate)" },
+            { status: 400 },
+          );
+        }
+
+        const agentId = actorName(`${body.content_id}-${body.content_version}-${Date.now()}`);
+        await env.CACHE.idFromName(agentId).start({
+          contentId: body.content_id,
+          contentVersion: body.content_version,
+          locations: body.locations,
+        });
+
+        return Response.json({
+          action: "queued",
+          agentId,
+          contentId: body.content_id,
+          contentVersion: body.content_version,
+          locations: body.locations,
+          statusUrl: `/status/${agentId}`,
+        });
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "invalidation failed" }, { status: 500 });
+      }
+    }
+
+    // ── Check invalidation status ──────────────────────────────────────
+    if (req.method === "GET" && url.pathname.startsWith("/status/")) {
+      const agentId = url.pathname.split("/status/")[1];
+      if (!agentId) return Response.json({ error: "missing agent id" }, { status: 400 });
+
+      try {
+        const state = await env.CACHE.idFromName(agentId).getStatus();
+        return Response.json(state);
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to get state" }, { status: 500 });
+      }
+    }
+
+    // ── Check cache status for a specific location ─────────────────────
+    if (req.method === "GET" && url.pathname.startsWith("/cache-status/")) {
+      const parts = url.pathname.split("/cache-status/")[1];
+      const [location, contentId] = parts.split("/").map(decodeURIComponent);
+
+      if (!location || !contentId) {
+        return Response.json({ error: "Missing location or contentId" }, { status: 400 });
+      }
+
+      try {
+        const agentId = actorName(`status-${contentId}`);
+        const status = await env.CACHE.idFromName(agentId).checkCacheStatus(location, contentId);
+        return Response.json({ location, contentId, ...status });
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to check cache status" }, { status: 500 });
+      }
+    }
+
+    // ── Clear cache flag for a location (simulate cache refresh) ──────
+    if (req.method === "POST" && url.pathname.startsWith("/cache-clear/")) {
+      const parts = url.pathname.split("/cache-clear/")[1];
+      const [location, contentId] = parts.split("/").map(decodeURIComponent);
+
+      if (!location || !contentId) {
+        return Response.json({ error: "Missing location or contentId" }, { status: 400 });
+      }
+
+      try {
+        const agentId = actorName(`clear-${contentId}`);
+        await env.CACHE.idFromName(agentId).clearCacheFlag(location, contentId);
+        return Response.json({ action: "cleared", location, contentId });
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to clear cache flag" }, { status: 500 });
+      }
+    }
+
+    // ── List all edge locations (demo) ────────────────────────────────
+    if (req.method === "GET" && url.pathname === "/locations") {
+      const demoLocations = [
+        "us-east-1",
+        "us-west-1",
+        "eu-central-1",
+        "ap-southeast-1",
+      ];
+      return Response.json({ locations: demoLocations });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+};

--- a/edge-cache-invalidation-agent/telnyx.toml
+++ b/edge-cache-invalidation-agent/telnyx.toml
@@ -1,0 +1,25 @@
+name = "edge-cache-invalidation-agent"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+
+[[actors]]
+binding = "CACHE"
+type = "CacheAgent"
+
+[telnyx]
+binding = "TELNYX"
+
+[storage.kv.CACHE_KV]
+id = "<kv-namespace-uuid>"
+
+[storage.cloudstorage.CACHE_STORAGE]
+bucket_name = "<storage-bucket-name>"
+region = "us-central-1"
+
+[env_vars]
+ALERT_PHONE = "+18005551234"
+SENDER_PHONE = "+18005551234"
+
+[[secrets]]
+binding = "TELNYX_API_KEY"
+name = "TELNYX_API_KEY"

--- a/edge-cache-invalidation-agent/tsconfig.json
+++ b/edge-cache-invalidation-agent/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@telnyx/edge-runtime"],
+    "strict": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "telnyx-env.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Edge Cache Invalidation Agent (DEV-817)

Webhook-triggered cache invalidation across edge locations via KV, Cloud Storage manifest, and SMS notification. Agent SDK on Telnyx Edge Compute with zero-credential messaging binding.

## What it does

Content update webhook → CacheAgent pipeline:
1. **invalidate()** — Mark cache dirty per edge location via KV
2. **updateManifest()** — Append invalidation entry to shared manifest in Cloud Storage
3. **notify()** — Send SMS to ops via `this.env.TELNYX.messages.send()` (zero-credential binding)

## Primitives used

- **Agent SDK** — `class CacheAgent extends Agent` with durable state across pipeline stages
- **KV** — Per-location cache invalidation flags with TTL (`cache:{location}:{contentId}`)
- **Cloud Storage** — Shared append-only manifest (`cache-manifest.json`)
- **Webhooks** — `POST /invalidate` triggers the pipeline
- **Messaging** — Zero-credential SMS via `[telnyx]` binding

## API endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | /invalidate | Trigger cache invalidation |
| GET | /status/:agentId | Check pipeline status |
| GET | /cache-status/:location/:contentId | Check if location cache is dirty |
| POST | /cache-clear/:location/:contentId | Clear dirty flag (simulate refresh) |
| GET | /locations | List demo edge locations |
| GET | /health/liveness, /health/readiness | Health checks |

## Linear

Closes DEV-817