### PR TITLE
Add kv-backed-rate-limiter sample (DEV-825)

### DIFF
--- a/kv-backed-rate-limiter/.env.example
+++ b/kv-backed-rate-limiter/.env.example
@@ -1,0 +1,17 @@
+# Telnyx API key (secret — never commit the real value)
+TELNYX_API_KEY=KEY019XXXXXXXXXXXXXXXXXXXXXXXX_XXXXXXXXXXXXXXXXXXXXXXXX
+
+# Phone number to receive rate-limit alerts (ops phone)
+ALERT_PHONE=+18005559876
+
+# Telnyx phone number sending alerts (must be messaging-enabled)
+SENDER_PHONE=+18005551234
+
+# Rate limit: max requests per window per key
+RATE_LIMIT=10
+
+# Window size in seconds (default: 60 = 1 minute)
+WINDOW_SECONDS=60
+
+# Number of consecutive rejections before SMS alert fires
+ALERT_THRESHOLD=5

--- a/kv-backed-rate-limiter/.gitignore
+++ b/kv-backed-rate-limiter/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.wrangler/
+.telnyx/

--- a/kv-backed-rate-limiter/README.md
+++ b/kv-backed-rate-limiter/README.md
@@ -1,0 +1,293 @@
+# KV-Backed Rate Limiter
+
+Sliding-window rate limiting on Telnyx Edge Compute using the Agent SDK. Each key (phone number, IP, tenant ID) gets its own agent instance that tracks request counts in Edge KV with TTL-based window expiry. Requests over the limit are rejected with HTTP 429. When rejections exceed a threshold, an SMS alert fires automatically via the zero-credential `[telnyx]` binding — no API key in code.
+
+## Architecture
+
+```
+                    Client Request
+                           │
+                           ▼
+              POST /check
+                           │
+                           ▼
+              ┌────────────────────┐
+              │   index.ts         │
+              │   (HTTP router)     │
+              └────┬───────────────┘
+                   │
+                   ▼
+         ┌──────────────────────┐
+         │  RateLimitAgent      │  (one actor per key)
+         │                      │
+         │  1. checkLimit()     │──► KV: GET current window count
+         │     if under limit   │
+         │  2a. allow()          │──► KV: PUT incremented count (TTL)
+         │     if over limit     │
+         │  2b. reject()         │──► 429 + track rejection count
+         │     if rejections     │
+         │     >= threshold      │
+         │  3. sendAlert()       │──► SMS via [telnyx] binding
+         └──────────────────────┘
+                   │
+                   ▼
+         ┌──────────────────────┐
+         │  RateLimitRegistry   │  (singleton actor)
+         │  cross-key aggregate │──► GET /keys
+         └──────────────────────┘
+```
+
+### What this sample demonstrates
+
+| Feature | How |
+|---|---|
+| **Edge KV sliding window** | TTL-based counters: `rate:<key>:<windowStart>` — auto-expire, no cleanup |
+| **Agent SDK pipeline** | 4-stage queue: `checkLimit → allow/reject → sendAlert → finalize` (non-blocking) |
+| **Per-key isolation** | One actor per rate-limited key — no contention between keys |
+| **HTTP 429 rejection** | Over-limit requests return 429 with current count and limit metadata |
+| **SMS alerting** | Zero-credential `[telnyx]` messaging binding — no API key in code |
+| **Registry actor** | Singleton actor aggregates stats for `GET /keys` listing |
+| **Simulate endpoint** | `/simulate` fires a burst of requests for testing without real traffic |
+
+## Quick start
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- [Telnyx CLI](https://developers.telnyx.com/docs/develop/edge-compute/getting-started) (`npm i -g @telnyx/cli`)
+- A Telnyx account with:
+  - An API key
+  - A messaging-enabled phone number (for SMS alerts)
+  - An ops phone to receive alerts
+
+### 1. Install dependencies
+
+```bash
+cd kv-backed-rate-limiter
+npm install
+```
+
+### 2. Configure environment
+
+Copy `.env.example` and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Description | Example |
+|---|---|---|
+| `TELNYX_API_KEY` | Telnyx API key | `KEY019...` |
+| `SENDER_PHONE` | Telnyx number sending alerts | `+18005551234` |
+| `ALERT_PHONE` | Ops phone receiving alerts | `+18005559876` |
+| `RATE_LIMIT` | Max requests per window per key | `10` |
+| `WINDOW_SECONDS` | Sliding window duration | `60` (1 minute) |
+| `ALERT_THRESHOLD` | Rejections before SMS fires | `5` |
+
+### 3. Update `telnyx.toml`
+
+Replace `<kv-namespace-uuid>` with your KV namespace ID:
+
+```toml
+[storage.kv.RATE_KV]
+id = "your-kv-namespace-uuid"
+```
+
+Create the KV namespace via the Telnyx CLI or portal.
+
+### 4. Run locally
+
+```bash
+npm start
+```
+
+This compiles TypeScript and starts the Edge Compute dev server.
+
+## API endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/check` | Check a request against the rate limit |
+| `GET` | `/status/:key` | Get agent state for a specific key |
+| `GET` | `/count/:key` | Get current window count for a key |
+| `GET` | `/keys` | List all tracked keys with aggregate stats |
+| `POST` | `/reset/:key` | Reset a key's counter (clear the window) |
+| `POST` | `/simulate` | Simulate a burst of requests for testing |
+| `GET` | `/config` | Get current rate limit configuration |
+| `GET` | `/health/liveness` | Liveness probe |
+| `GET` | `/health/readiness` | Readiness probe |
+
+## Usage examples
+
+### Check a request
+
+```bash
+curl -X POST http://localhost:3000/check \
+  -H "Content-Type: application/json" \
+  -d '{"key":"+18005551234"}'
+```
+
+Response (allowed):
+```json
+{
+  "key": "+18005551234",
+  "action": "allowed",
+  "currentCount": 1,
+  "limit": 10,
+  "windowSeconds": 60,
+  "totalRequests": 1,
+  "allowedRequests": 1,
+  "rejectedRequests": 0,
+  "alertTriggered": false
+}
+```
+
+Response (rejected, HTTP 429):
+```json
+{
+  "key": "+18005551234",
+  "action": "rejected",
+  "currentCount": 10,
+  "limit": 10,
+  "windowSeconds": 60,
+  "totalRequests": 11,
+  "allowedRequests": 10,
+  "rejectedRequests": 1,
+  "alertTriggered": false
+}
+```
+
+### Simulate a burst
+
+```bash
+# Simulate 15 requests from one key (limit is 10 → 10 allowed, 5 rejected)
+curl -X POST http://localhost:3000/simulate \
+  -H "Content-Type: application/json" \
+  -d '{"key":"+18005551234","count":15}'
+```
+
+Response:
+```json
+{
+  "key": "+18005551234",
+  "simulated": 15,
+  "allowed": 10,
+  "rejected": 5,
+  "alertTriggered": true,
+  "results": [
+    { "request": 1, "action": "allowed", "currentCount": 1 },
+    { "request": 2, "action": "allowed", "currentCount": 2 },
+    ...
+    { "request": 11, "action": "rejected", "currentCount": 10 },
+    { "request": 12, "action": "rejected", "currentCount": 10 },
+    ...
+  ]
+}
+```
+
+### Get status for a key
+
+```bash
+curl http://localhost:3000/status/+18005551234
+```
+
+### List all tracked keys
+
+```bash
+curl http://localhost:3000/keys
+```
+
+### Reset a key's counter
+
+```bash
+curl -X POST http://localhost:3000/reset/+18005551234
+```
+
+### Get current window count
+
+```bash
+curl http://localhost:3000/count/+18005551234
+```
+
+Response:
+```json
+{
+  "key": "+18005551234",
+  "count": 7,
+  "windowStart": 1718928000,
+  "limit": 10
+}
+```
+
+## How it works
+
+### Sliding window counters
+
+KV keys are namespaced by key and window start time:
+```
+rate:+18005551234:1718928000   ← count for 14:00–14:01 window
+rate:+18005551234:1718928060   ← count for 14:01–14:02 window
+rate:+18005559876:1718928000   ← different key, same window
+```
+
+Each key has a TTL of `WINDOW_SECONDS`, so old windows auto-expire without cleanup code. This is a fixed-window approximation of a sliding window — simpler than a true sliding window log but uses far fewer KV operations.
+
+### Agent SDK pipeline
+
+Each rate-limited key gets its own `RateLimitAgent` actor instance. When `/check` is called, the agent queues a pipeline:
+
+1. **`checkLimit()`** — Gets the current window count from KV. If under the limit, queues `allow`. If over, queues `reject`.
+
+2a. **`allow()`** — Increments the KV counter and updates the agent's stats (allowed count, total count).
+
+2b. **`reject()`** — Increments the rejection counter. If rejections reach `ALERT_THRESHOLD` and no alert has been sent yet, queues `sendAlert`.
+
+3. **`sendAlert()`** — Sends an SMS via the zero-credential `[telnyx]` binding. The SMS includes the key, limit, window, and rejection count.
+
+4. **`finalize()`** — Marks the request as done.
+
+### Why actors?
+
+Each key is isolated in its own actor with its own state:
+- No contention between concurrent keys
+- Per-key state (allowed/rejected counts, alert status) survives across requests
+- The `RateLimitRegistry` singleton actor aggregates across keys for the `/keys` endpoint
+
+### SMS alerting via `[telnyx]` binding
+
+The `[telnyx]` binding gives the agent a zero-credential messaging client. No API key is needed in the agent code — the binding handles auth at the platform level:
+
+```typescript
+await this.env.TELNYX.messages.send({
+  from: this.env.SENDER_PHONE,
+  to: this.env.ALERT_PHONE,
+  text: smsText,
+});
+```
+
+## File structure
+
+```
+kv-backed-rate-limiter/
+├── src/
+│   ├── rateLimitAgent.ts   # RateLimitAgent + RateLimitRegistry actors
+│   └── index.ts           # HTTP router + webhook handler
+├── telnyx.toml            # Edge Compute config (KV, actors, env vars)
+├── package.json
+├── tsconfig.json
+├── telnyx-env.d.ts        # Ambient type declarations (KvNamespace)
+├── .env.example
+└── .gitignore
+```
+
+## Use cases
+
+- **API rate limiting** — Limit requests per API key, IP, or tenant
+- **Call Control protection** — Limit inbound call rate per phone number before they hit your IVR
+- **SMS flood prevention** — Rate limit outbound SMS per user before sending
+- **Webhook throttling** — Limit incoming webhook rate per source to protect downstream services
+- **Tenant quotas** — Per-tenant request caps on multi-tenant platforms
+
+## License
+
+MIT

--- a/kv-backed-rate-limiter/package-lock.json
+++ b/kv-backed-rate-limiter/package-lock.json
@@ -1,0 +1,556 @@
+{
+  "name": "kv-backed-rate-limiter",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kv-backed-rate-limiter",
+      "version": "0.0.0",
+      "dependencies": {
+        "@telnyx/edge-runtime": "*"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.28.tgz",
+      "integrity": "sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1115.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1115.0.tgz",
+      "integrity": "sha512-oeniaXZCRrKMaffnyjOSxp1xJNsuiku2SxyzVI1Bi1Gycpck/dRTVsloSa5E+nBKz1c5y5eMfbK4GAhGUCCC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.28",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.74",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.74.tgz",
+      "integrity": "sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@telnyx/edge-runtime": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@telnyx/edge-runtime/-/edge-runtime-0.10.0.tgz",
+      "integrity": "sha512-F5jT/o60h9TKyzSBWwWgR6AyQxHdpsvX6ZHqA0EI0whlrqf1iXrPPHSnnfWbrlpclsBjVfEcW0l25u34WNlEqA==",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1083.0",
+        "@types/ws": "^8.18.0",
+        "superjson": "^2.2.6",
+        "telnyx": "*",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.1.0.tgz",
+      "integrity": "sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/telnyx": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/telnyx/-/telnyx-7.16.0.tgz",
+      "integrity": "sha512-d/kfoawAOnNeHlh2iwGk5raxH50JAEulC4OqAVhHPrCtOiiwHzXv2RtXaOeZPPN1B5cg3J/VaFgCFpJZ06jG0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "^1.0.0"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/kv-backed-rate-limiter/package.json
+++ b/kv-backed-rate-limiter/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kv-backed-rate-limiter",
+  "private": true,
+  "version": "0.0.0",
+  "description": "KV-backed rate limiter on Telnyx Edge Compute using the Agent SDK — sliding window counters, HTTP 429 rejection, and SMS alerts on sustained threshold breach via zero-credential messaging",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build && telnyx-edge dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@telnyx/edge-runtime": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/kv-backed-rate-limiter/src/index.ts
+++ b/kv-backed-rate-limiter/src/index.ts
@@ -1,0 +1,228 @@
+export { RateLimitAgent, RateLimitRegistry } from "./rateLimitAgent";
+import type { RateLimitAgent, RateLimitRegistry } from "./rateLimitAgent";
+
+import {
+  type ActorNamespace,
+  type ActorStub,
+  type IdFromNameOptions,
+} from "@telnyx/edge-runtime";
+
+type RateLimitStub = ActorStub &
+  Pick<
+    RateLimitAgent,
+    | "checkRequest"
+    | "checkLimit"
+    | "allow"
+    | "reject"
+    | "sendAlert"
+    | "finalize"
+    | "getStatus"
+    | "getSummary"
+    | "getWindowCount"
+    | "resetKey"
+  >;
+
+interface RateLimitNamespace extends ActorNamespace {
+  idFromName(name: string, options?: IdFromNameOptions): RateLimitStub;
+}
+
+type RegistryStub = ActorStub &
+  Pick<RateLimitRegistry, "record" | "listKeys" | "getKey">;
+
+interface RegistryNamespace extends ActorNamespace {
+  idFromName(name: string, options?: IdFromNameOptions): RegistryStub;
+}
+
+interface Env {
+  RATE_AGENT: RateLimitNamespace;
+  REGISTRY: RegistryNamespace;
+  TELNYX_API_KEY: string;
+  ALERT_PHONE: string;
+  SENDER_PHONE: string;
+  RATE_LIMIT: string;
+  WINDOW_SECONDS: string;
+  ALERT_THRESHOLD: string;
+}
+
+// Dapr-safe actor names: no "+", no special chars (RFC 1123 job-name-safe).
+function actorName(id: string): string {
+  return id.replace(/[^0-9a-zA-Z.-]/g, "");
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    // ── Health ─────────────────────────────────────────────────────────
+    if (url.pathname === "/health/liveness") return new Response("ok");
+    if (url.pathname === "/health/readiness") return new Response("ok");
+
+    // ── Check a request against the rate limit ─────────────────────────
+    if (req.method === "POST" && url.pathname === "/check") {
+      return handleCheck(req, env);
+    }
+
+    // ── Get status for a specific key ──────────────────────────────────
+    if (req.method === "GET" && url.pathname.startsWith("/status/")) {
+      const key = decodeURIComponent(url.pathname.split("/status/")[1]);
+      if (!key) return Response.json({ error: "missing key" }, { status: 400 });
+
+      try {
+        const summary = await env.RATE_AGENT.idFromName(actorName(key)).getSummary();
+        return Response.json(summary);
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to get status" }, { status: 500 });
+      }
+    }
+
+    // ── Get current window count for a key ──────────────────────────────
+    if (req.method === "GET" && url.pathname.startsWith("/count/")) {
+      const key = decodeURIComponent(url.pathname.split("/count/")[1]);
+      if (!key) return Response.json({ error: "missing key" }, { status: 400 });
+
+      try {
+        const result = await env.RATE_AGENT.idFromName(actorName(key)).getWindowCount(key);
+        return Response.json(result);
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to get count" }, { status: 500 });
+      }
+    }
+
+    // ── List all tracked keys ──────────────────────────────────────────
+    if (req.method === "GET" && url.pathname === "/keys") {
+      try {
+        const keys = await env.REGISTRY.idFromName("shared").listKeys();
+        return Response.json({ keys, total: keys.length });
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to list keys" }, { status: 500 });
+      }
+    }
+
+    // ── Reset a key's counter ──────────────────────────────────────────
+    if (req.method === "POST" && url.pathname.startsWith("/reset/")) {
+      const key = decodeURIComponent(url.pathname.split("/reset/")[1]);
+      if (!key) return Response.json({ error: "missing key" }, { status: 400 });
+
+      try {
+        const result = await env.RATE_AGENT.idFromName(actorName(key)).resetKey(key);
+        return Response.json(result);
+      } catch (e: any) {
+        return Response.json({ error: e?.message || "failed to reset" }, { status: 500 });
+      }
+    }
+
+    // ── Simulate a burst of requests (for testing) ─────────────────────
+    if (req.method === "POST" && url.pathname === "/simulate") {
+      return handleSimulate(req, env);
+    }
+
+    // ── Get config ─────────────────────────────────────────────────────
+    if (req.method === "GET" && url.pathname === "/config") {
+      return Response.json({
+        rateLimit: parseInt(env.RATE_LIMIT, 10) || 100,
+        windowSeconds: parseInt(env.WINDOW_SECONDS, 10) || 60,
+        alertThreshold: parseInt(env.ALERT_THRESHOLD, 10) || 10,
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+};
+
+// ── Check handler ────────────────────────────────────────────────────────
+async function handleCheck(req: Request, env: Env): Promise<Response> {
+  try {
+    const body = (await req.json().catch(() => ({}))) as {
+      key?: string;
+    };
+
+    if (!body.key) {
+      return Response.json({ error: "Missing field: key" }, { status: 400 });
+    }
+
+    const agentId = actorName(body.key);
+    await env.RATE_AGENT.idFromName(agentId).checkRequest({ key: body.key });
+
+    // Record in registry
+    const summary = await env.RATE_AGENT.idFromName(agentId).getSummary();
+    await env.REGISTRY.idFromName("shared").record({
+      key: body.key,
+      totalRequests: summary.totalRequests,
+      allowedRequests: summary.allowedRequests,
+      rejectedRequests: summary.rejectedRequests,
+      alertTriggered: summary.alertTriggered,
+      lastRequestAt: summary.lastRequestAt,
+    });
+
+    const status = summary.status === "allowed" ? 200 : summary.status === "rejected" || summary.status === "done" ? 429 : 200;
+
+    return Response.json(
+      {
+        key: body.key,
+        action: summary.status === "allowed" ? "allowed" : "rejected",
+        currentCount: summary.currentCount,
+        limit: summary.limit,
+        windowSeconds: summary.windowSeconds,
+        totalRequests: summary.totalRequests,
+        allowedRequests: summary.allowedRequests,
+        rejectedRequests: summary.rejectedRequests,
+        alertTriggered: summary.alertTriggered,
+      },
+      { status },
+    );
+  } catch (e: any) {
+    return Response.json({ error: e?.message || "check failed" }, { status: 500 });
+  }
+}
+
+// ── Simulate handler (for testing rate limits) ────────────────────────────
+async function handleSimulate(req: Request, env: Env): Promise<Response> {
+  try {
+    const body = (await req.json().catch(() => ({}))) as {
+      key?: string;
+      count?: number;
+    };
+
+    const key = body.key || "+18005551234";
+    const count = body.count ?? 5;
+
+    if (count > 1000) {
+      return Response.json({ error: "Max 1000 requests per simulate" }, { status: 400 });
+    }
+
+    const agent = env.RATE_AGENT.idFromName(actorName(key));
+    const results: { request: number; action: string; currentCount: number }[] = [];
+
+    for (let i = 0; i < count; i++) {
+      await agent.checkRequest({ key });
+      const summary = await agent.getSummary();
+      results.push({
+        request: i + 1,
+        action: summary.status === "allowed" ? "allowed" : "rejected",
+        currentCount: summary.currentCount,
+      });
+    }
+
+    // Record in registry
+    const finalSummary = await agent.getSummary();
+    await env.REGISTRY.idFromName("shared").record({
+      key,
+      totalRequests: finalSummary.totalRequests,
+      allowedRequests: finalSummary.allowedRequests,
+      rejectedRequests: finalSummary.rejectedRequests,
+      alertTriggered: finalSummary.alertTriggered,
+      lastRequestAt: finalSummary.lastRequestAt,
+    });
+
+    return Response.json({
+      key,
+      simulated: count,
+      allowed: results.filter((r) => r.action === "allowed").length,
+      rejected: results.filter((r) => r.action === "rejected").length,
+      alertTriggered: finalSummary.alertTriggered,
+      results,
+    });
+  } catch (e: any) {
+    return Response.json({ error: e?.message || "simulate failed" }, { status: 500 });
+  }
+}

--- a/kv-backed-rate-limiter/src/rateLimitAgent.ts
+++ b/kv-backed-rate-limiter/src/rateLimitAgent.ts
@@ -1,0 +1,287 @@
+import { Agent } from "@telnyx/edge-runtime";
+
+// ── State ────────────────────────────────────────────────────────────────
+export interface RateLimitAgentState extends Record<string, unknown> {
+  key: string;
+  status: "checking" | "allowed" | "rejected" | "alerting" | "done" | "error";
+  currentCount: number;
+  limit: number;
+  windowSeconds: number;
+  alertThreshold: number;
+  alertTriggered: boolean;
+  rejectionCount: number;
+  totalRequests: number;
+  allowedRequests: number;
+  rejectedRequests: number;
+  startedAt: number;
+  lastRequestAt: number;
+  error: string;
+}
+
+// ── Env: [telnyx] binding + KV ────────────────────────────────────────────
+interface RateLimitAgentEnv {
+  TELNYX: {
+    messages: {
+      send(m: { from: string; to: string; text: string }): Promise<unknown>;
+    };
+  };
+  RATE_KV: KvNamespace;
+  ALERT_PHONE: string;
+  SENDER_PHONE: string;
+  RATE_LIMIT: string;
+  WINDOW_SECONDS: string;
+  ALERT_THRESHOLD: string;
+}
+
+const RATE_LIMIT_DEFAULT = 100;
+const WINDOW_DEFAULT_SEC = 60;
+const ALERT_THRESHOLD_DEFAULT = 10; // number of rejections before SMS alert
+
+/**
+ * RateLimitAgent — one actor instance per rate-limited key (phone, IP, tenant).
+ *
+ * Pipeline (each stage queued for non-blocking execution):
+ *   1. checkLimit()    — KV get current window count → compare against limit
+ *   2. allow()         — increment counter, update stats
+ *   3. reject()        — increment rejection counter, check if alert threshold hit
+ *   4. sendAlert()    — send SMS via zero-credential [telnyx] binding
+ */
+export class RateLimitAgent extends Agent<RateLimitAgentEnv, RateLimitAgentState> {
+  protected override initialState(): RateLimitAgentState {
+    return {
+      key: "",
+      status: "checking",
+      currentCount: 0,
+      limit: 0,
+      windowSeconds: 0,
+      alertThreshold: 0,
+      alertTriggered: false,
+      rejectionCount: 0,
+      totalRequests: 0,
+      allowedRequests: 0,
+      rejectedRequests: 0,
+      startedAt: 0,
+      lastRequestAt: 0,
+      error: "",
+    };
+  }
+
+  /** Entry point — check a request against the rate limit. */
+  async checkRequest(params: { key: string }): Promise<void> {
+    const limit = parseInt(this.env.RATE_LIMIT, 10) || RATE_LIMIT_DEFAULT;
+    const windowSeconds = parseInt(this.env.WINDOW_SECONDS, 10) || WINDOW_DEFAULT_SEC;
+    const alertThreshold = parseInt(this.env.ALERT_THRESHOLD, 10) || ALERT_THRESHOLD_DEFAULT;
+
+    await this.setState({
+      key: params.key,
+      limit,
+      windowSeconds,
+      alertThreshold,
+      status: "checking",
+      startedAt: Date.now(),
+      lastRequestAt: Date.now(),
+    });
+    await this.queue("checkLimit");
+  }
+
+  /** Stage 1: Check the current window count in KV against the limit. */
+  async checkLimit(): Promise<void> {
+    const state = await this.getState();
+    try {
+      const windowStart = Math.floor(Date.now() / 1000 / state.windowSeconds) * state.windowSeconds;
+      const kvKey = `rate:${state.key}:${windowStart}`;
+      const currentStr = await this.env.RATE_KV.get(kvKey);
+      const currentCount = currentStr ? parseInt(currentStr, 10) : 0;
+
+      await this.setState({
+        ...state,
+        currentCount,
+        totalRequests: state.totalRequests + 1,
+        lastRequestAt: Date.now(),
+      });
+
+      if (currentCount < state.limit) {
+        await this.queue("allow");
+      } else {
+        await this.queue("reject");
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.setState({ ...state, status: "error", error: `checkLimit: ${msg}` });
+    }
+  }
+
+  /** Stage 2a: Allow the request — increment the counter. */
+  async allow(): Promise<void> {
+    const state = await this.getState();
+    try {
+      const windowStart = Math.floor(Date.now() / 1000 / state.windowSeconds) * state.windowSeconds;
+      const kvKey = `rate:${state.key}:${windowStart}`;
+      const newCount = state.currentCount + 1;
+      await this.env.RATE_KV.put(kvKey, String(newCount), {
+        expirationTtl: state.windowSeconds,
+      });
+
+      await this.setState({
+        ...state,
+        currentCount: newCount,
+        allowedRequests: state.allowedRequests + 1,
+        status: "allowed",
+      });
+      await this.queue("finalize");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.setState({ ...state, status: "error", error: `allow: ${msg}` });
+    }
+  }
+
+  /** Stage 2b: Reject the request — increment rejection counter, check alert. */
+  async reject(): Promise<void> {
+    const state = await this.getState();
+    try {
+      const newRejectionCount = state.rejectionCount + 1;
+
+      await this.setState({
+        ...state,
+        rejectedRequests: state.rejectedRequests + 1,
+        rejectionCount: newRejectionCount,
+        status: newRejectionCount >= state.alertThreshold ? "alerting" : "rejected",
+      });
+
+      if (newRejectionCount >= state.alertThreshold && !state.alertTriggered) {
+        await this.queue("sendAlert");
+      } else {
+        await this.queue("finalize");
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.setState({ ...state, status: "error", error: `reject: ${msg}` });
+    }
+  }
+
+  /** Stage 3: Send SMS alert on sustained threshold breach (zero-credential binding). */
+  async sendAlert(): Promise<void> {
+    const state = await this.getState();
+    try {
+      const smsText =
+        `Rate limit alert: key "${state.key}" has been rejected ${state.rejectionCount} times. ` +
+        `Limit is ${state.limit} requests per ${state.windowSeconds}s window. ` +
+        `Total requests: ${state.totalRequests}. Allowed: ${state.allowedRequests}. Rejected: ${state.rejectedRequests}.`;
+
+      await this.env.TELNYX.messages.send({
+        from: this.env.SENDER_PHONE,
+        to: this.env.ALERT_PHONE,
+        text: smsText,
+      });
+
+      await this.setState({
+        ...state,
+        alertTriggered: true,
+        status: "done",
+      });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.setState({ ...state, status: "error", error: `sendAlert: ${msg}` });
+    }
+  }
+
+  /** Finalize — mark as done. */
+  async finalize(): Promise<void> {
+    const state = await this.getState();
+    await this.setState({ ...state, status: "done" });
+  }
+
+  /** Debug helper — return current agent state. */
+  async getStatus(): Promise<RateLimitAgentState> {
+    return await this.getState();
+  }
+
+  /** Get a summary for the HTTP API. */
+  async getSummary(): Promise<{
+    key: string;
+    status: string;
+    currentCount: number;
+    limit: number;
+    windowSeconds: number;
+    totalRequests: number;
+    allowedRequests: number;
+    rejectedRequests: number;
+    alertTriggered: boolean;
+    lastRequestAt: number;
+  }> {
+    const state = await this.getState();
+    return {
+      key: state.key,
+      status: state.status,
+      currentCount: state.currentCount,
+      limit: state.limit,
+      windowSeconds: state.windowSeconds,
+      totalRequests: state.totalRequests,
+      allowedRequests: state.allowedRequests,
+      rejectedRequests: state.rejectedRequests,
+      alertTriggered: state.alertTriggered,
+      lastRequestAt: state.lastRequestAt,
+    };
+  }
+
+  /** Get the current window count for a key (for the stats endpoint). */
+  async getWindowCount(key: string): Promise<{ key: string; count: number; windowStart: number; limit: number }> {
+    const state = await this.getState();
+    const windowStart = Math.floor(Date.now() / 1000 / state.windowSeconds) * state.windowSeconds;
+    const kvKey = `rate:${key}:${windowStart}`;
+    const countStr = await this.env.RATE_KV.get(kvKey);
+    return {
+      key,
+      count: countStr ? parseInt(countStr, 10) : 0,
+      windowStart,
+      limit: state.limit,
+    };
+  }
+
+  /** Reset the counter for a key (for the reset endpoint). */
+  async resetKey(key: string): Promise<{ key: string; reset: boolean }> {
+    const windowStart = Math.floor(Date.now() / 1000 / this.getWindowSeconds()) * this.getWindowSeconds();
+    const kvKey = `rate:${key}:${windowStart}`;
+    await this.env.RATE_KV.delete(kvKey);
+    return { key, reset: true };
+  }
+
+  private getWindowSeconds(): number {
+    return parseInt(this.env.WINDOW_SECONDS, 10) || WINDOW_DEFAULT_SEC;
+  }
+}
+
+// ── Registry actor: aggregate stats across all keys ──────────────────────
+export interface KeyStats {
+  key: string;
+  totalRequests: number;
+  allowedRequests: number;
+  rejectedRequests: number;
+  alertTriggered: boolean;
+  lastRequestAt: number;
+}
+
+export class RateLimitRegistry extends Agent<Record<string, unknown>, Record<string, unknown>> {
+  protected override initialState(): Record<string, unknown> {
+    return { keys: {} as Record<string, KeyStats> };
+  }
+
+  async record(stats: KeyStats): Promise<void> {
+    const state = await this.getState();
+    const keys = (state.keys as Record<string, KeyStats>) || {};
+    keys[stats.key] = stats;
+    await this.setState({ keys });
+  }
+
+  async listKeys(): Promise<KeyStats[]> {
+    const state = await this.getState();
+    const keys = (state.keys as Record<string, KeyStats>) || {};
+    return Object.values(keys).sort((a, b) => b.lastRequestAt - a.lastRequestAt);
+  }
+
+  async getKey(key: string): Promise<KeyStats | null> {
+    const state = await this.getState();
+    const keys = (state.keys as Record<string, KeyStats>) || {};
+    return keys[key] || null;
+  }
+}

--- a/kv-backed-rate-limiter/telnyx-env.d.ts
+++ b/kv-backed-rate-limiter/telnyx-env.d.ts
@@ -1,0 +1,25 @@
+// Type declarations for Telnyx Edge Compute bindings.
+// These ambient types are available at runtime — no package install needed.
+
+declare interface KvNamespace {
+  get(key: string): Promise<string | null>;
+  get<T>(key: string, options: { type: "json" }): Promise<T | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number; expiration?: number; metadata?: unknown }): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(options?: { prefix?: string; limit?: number; cursor?: string }): Promise<{
+    keys: { name: string; expiration?: number; metadata?: unknown }[];
+    list_complete: boolean;
+    cursor: string;
+  }>;
+}
+
+declare interface CloudStorageBucket {
+  put(key: string, value: ReadableStream | ArrayBuffer | string, options?: { contentType?: string }): Promise<void>;
+  get(key: string): Promise<Body | null>;
+  delete(key: string): Promise<void>;
+  list(options?: { prefix?: string; limit?: number; cursor?: string }): Promise<{
+    objects: { key: string; size: number; uploaded: Date }[];
+    truncated: boolean;
+    cursor: string;
+  }>;
+}

--- a/kv-backed-rate-limiter/telnyx.toml
+++ b/kv-backed-rate-limiter/telnyx.toml
@@ -1,0 +1,31 @@
+name = "kv-backed-rate-limiter"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+
+[[actor]]
+binding = "RATE_AGENT"
+type = "RateLimitAgent"
+
+[[actor]]
+binding = "REGISTRY"
+type = "RateLimitRegistry"
+
+[telnyx]
+binding = "TELNYX"
+
+[storage.kv.RATE_KV]
+id = "<kv-namespace-uuid>"
+
+[env_vars]
+ALERT_PHONE = "+18005559876"
+SENDER_PHONE = "+18005551234"
+# Maximum requests allowed per window per key
+RATE_LIMIT = "10"
+# Window size in seconds for the sliding counter (default: 60 = 1 minute)
+WINDOW_SECONDS = "60"
+# Number of consecutive rejections before an SMS alert fires
+ALERT_THRESHOLD = "5"
+
+[[secrets]]
+binding = "TELNYX_API_KEY"
+name = "TELNYX_API_KEY"

--- a/kv-backed-rate-limiter/tsconfig.json
+++ b/kv-backed-rate-limiter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@telnyx/edge-runtime"],
+    "strict": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "telnyx-env.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## KV-Backed Rate Limiter (DEV-825)

Sliding-window rate limiting on Telnyx Edge Compute using the Agent SDK. Each key (phone number, IP, tenant ID) gets its own agent instance that tracks request counts in Edge KV with TTL-based window expiry. Requests over the limit are rejected with HTTP 429. When rejections exceed a threshold, an SMS alert fires automatically via the zero-credential `[telnyx]` binding — no API key in code.

### Architecture

```
Client Request → POST /check → RateLimitAgent (one actor per key)
  1. checkLimit()  → KV: GET current window count
  2a. allow()      → KV: PUT incremented count (TTL) → 200
  2b. reject()     → 429 + track rejection count
  3. sendAlert()   → SMS via [telnyx] binding (on sustained threshold breach)
  4. finalize()    → done
```

### What this sample demonstrates

| Feature | How |
|---|---|
| Edge KV sliding window | TTL-based counters: `rate:<key>:<windowStart>` — auto-expire, no cleanup |
| Agent SDK pipeline | 4-stage queue: `checkLimit → allow/reject → sendAlert → finalize` (non-blocking) |
| Per-key isolation | One actor per rate-limited key — no contention between keys |
| HTTP 429 rejection | Over-limit requests return 429 with current count and limit metadata |
| SMS alerting | Zero-credential `[telnyx]` messaging binding — no API key in code |
| Registry actor | Singleton actor aggregates stats for `GET /keys` listing |
| Simulate endpoint | `/simulate` fires a burst of requests for testing without real traffic |

### Files added

```
kv-backed-rate-limiter/
├── src/
│   ├── rateLimitAgent.ts   # RateLimitAgent + RateLimitRegistry actors
│   └── index.ts           # HTTP router + webhook handler
├── telnyx.toml            # Edge Compute config (KV, actors, env vars)
├── package.json
├── tsconfig.json
├── telnyx-env.d.ts        # Ambient type declarations (KvNamespace)
├── .env.example
└── .gitignore
```

### API endpoints

| Method | Path | Description |
|---|---|---|
| POST | /check | Check a request against the rate limit |
| GET | /status/:key | Get agent state for a specific key |
| GET | /count/:key | Get current window count for a key |
| GET | /keys | List all tracked keys with aggregate stats |
| POST | /reset/:key | Reset a key's counter |
| POST | /simulate | Simulate a burst of requests for testing |
| GET | /config | Get current rate limit configuration |
| GET | /health/liveness | Liveness probe |
| GET | /health/readiness | Readiness probe |

### Typecheck

```bash
npx tsc --noEmit
# (no output — clean pass)
```

### Related Linear issue

DEV-825 (sub-issue DEV-908)