### PR TITLE
chore: add @anusha-telnyx and @sonamg-droid as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @harpreetTelnyx @ireither @somemothersson
+* @harpreetTelnyx @ireither @somemothersson @anusha-telnyx @sonamg-droid


### PR DESCRIPTION
## What
Add @anusha-telnyx and @sonamg-droid to `.github/CODEOWNERS`.

## Why
Expand the set of reviewers automatically requested on PRs across the repo.

## Changes
- `.github/CODEOWNERS`: appended two new handles to the existing `*` rule