### PR TITLE
fix(shipment-agent): repair inbound webhook verification and v2 payload parsing

### DIFF
--- a/shipment-agent/app.py
+++ b/shipment-agent/app.py
@@ -13,6 +13,7 @@ load_dotenv()
 app = Flask(__name__)
 
 telnyx.api_key = os.getenv("TELNYX_API_KEY")
+telnyx.public_key = os.getenv("TELNYX_PUBLIC_KEY")
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY")
 TELNYX_MESSAGING_PROFILE_ID = os.getenv("TELNYX_MESSAGING_PROFILE_ID")
 TELNYX_FROM_NUMBER = os.getenv("TELNYX_FROM_NUMBER")
@@ -163,17 +164,19 @@ def telnyx_webhook():
     """Handles inbound Telnyx webhooks (SMS replies, Call Control events)."""
     try:
         # Verify Telnyx Ed25519 signature
-        signature = request.headers.get("Telnyx-Signature-Ed25519", "")
-        timestamp = request.headers.get("Telnyx-Signature-Timestamp", "")
+        # Case-insensitive header lookup (Telnyx sends mixed casing)
+        headers_lower = {k.lower(): v for k, v in request.headers.items()}
+        signature = headers_lower.get("telnyx-signature-ed25519", "")
+        timestamp = headers_lower.get("telnyx-timestamp", "")
         raw_body = request.get_data(as_text=True)
-        
+
         if not signature or not timestamp:
-            app.logger.warning("Missing Telnyx signature headers")
+            app.logger.warning("Missing Telnyx signature headers. Got headers: %s", list(request.headers.keys()))
             abort(401, "Unauthorized")
             
         try:
             verified_event = telnyx.Webhook.construct_event(
-                raw_body, signature, timestamp, TELNYX_PUBLIC_KEY
+                raw_body, signature, timestamp
             )
         except Exception:
             app.logger.exception("Webhook signature verification failed")
@@ -186,8 +189,14 @@ def telnyx_webhook():
 
         if event_type == "message.finalized" or event_type == "message.received":
             # Handle inbound SMS reply from customer
-            from_number = payload.get("from", {}).get("phone_number")
-            to_number = payload.get("to", {}).get("phone_number")
+            # v2 payload: from is a dict, to is a list of dicts
+            from_obj = payload.get("from", {}) or payload.get("from_", {})
+            to_list = payload.get("to", [])
+            if isinstance(to_list, list) and to_list:
+                to_number = to_list[0].get("phone_number")
+            else:
+                to_number = to_list.get("phone_number") if isinstance(to_list, dict) else None
+            from_number = from_obj.get("phone_number") if isinstance(from_obj, dict) else None
             text = payload.get("text")
             
             # Route to the correct agent based on the customer's number

--- a/shipment-agent/requirements.txt
+++ b/shipment-agent/requirements.txt
@@ -1,4 +1,4 @@
 flask>=3.0
 requests>=2.31
 python-dotenv>=1.0
-telnyx>=2.0
+telnyx>=2.0,<3.0


### PR DESCRIPTION
## Problem

The Telnyx webhook handler in `shipment-agent/app.py` was broken in four ways, preventing any inbound SMS reply from being processed end-to-end. Running the demo on macOS, every customer SMS reply resulted in `401 Unauthorized` or a 500 in the Flask console.

## Root causes

1. **Public key not registered on the SDK module.** `telnyx.Webhook.construct_event` reads `telnyx.public_key` (module-level), not a positional arg. Without setting it, every verification raised `Public key not set`.
2. **Wrong signature timestamp header name.** Code looked for `Telnyx-Signature-Timestamp` but Telnyx sends `Telnyx-Timestamp`.
3. **Mis-positioned public_key arg to `construct_event`.** The 4th positional arg in SDK 2.x is `tolerance` (int seconds), not the public key. Passing a string raised `unsupported operand type(s) for -`.
4. **v2 payload shape mismatch.** In v2 webhooks, `payload.to` is a **list** of dicts (not a dict) and the SDK renames `from` to `from_`. The original parsing code assumed both were dicts, raising `'list' object has no attribute 'get'`.

Additionally, `requirements.txt` had `telnyx>=2.0` which now resolves to the v4 SDK (4.x) — a completely different API with no `telnyx.Message.create` and no 4-arg `construct_event`. The app code is written against the v2 SDK API and silently fails on every SMS send and webhook verify under v4.

## Fix

- Set `telnyx.public_key = os.getenv("TELNYX_PUBLIC_KEY")` at startup
- Case-insensitive header lookup using the correct `Telnyx-Timestamp` name
- Drop the bad 4th arg to `construct_event` (SDK reads public key from module config)
- Handle both list and dict shapes for `to`, fall back to `from_` when `from` is absent
- Pin `telnyx>=2.0,<3.0` so the demo runs against the SDK API it was written for

## Verification

Tested end-to-end on macOS:

```text
PICKED_UP carrier webhook -> proactive SMS delivered to customer
Customer SMS reply -> Ed25519 webhook signature verified
Agent matched customer_number -> AI reply SMS delivered
```

All four original failure modes (missing headers, public key not set, tolerance TypeError, list-attribute error) are resolved.

## Files changed

- `shipment-agent/app.py` — webhook verification + v2 payload parsing
- `shipment-agent/requirements.txt` — pin `telnyx` to v2.x

## Checklist

- [x] `python -m py_compile app.py` passes
- [x] End-to-end demo verified (outbound SMS + inbound reply + AI reply)
- [x] No secrets committed (`.env` stays local)
