### PR TITLE
Migrate ai-powered-call-router to telnyx>=4.0 SDK + add transfer announcement

### DIFF
--- a/ai-powered-call-router/.env.example
+++ b/ai-powered-call-router/.env.example
@@ -1,11 +1,15 @@
 # Telnyx API credentials
 TELNYX_API_KEY=your_telnyx_api_key_here
 
-# Telnyx public key for webhook signature verification
+# Telnyx public key for webhook signature verification (GET /v2/public_key)
 TELNYX_PUBLIC_KEY=your_telnyx_public_key_here
 
-# Call Control Connection (SIP) ID for inbound calls
-TELNYX_CONNECTION_ID=your_telnyx_connection_id_here
+# Call Control Application ID for inbound calls
+TELNYX_CONNECTION_ID=your_call_control_application_id_here
+
+# Telnyx-hosted AI Inference model for intent classification (optional)
+# Telnyx-hosted models need no OpenAI key. See: client.ai.openai.list_models()
+AI_MODEL=meta-llama/Llama-3.3-70B-Instruct
 
 # Port for the Flask server (optional, defaults to 5000)
 PORT=5000

--- a/ai-powered-call-router/README.md
+++ b/ai-powered-call-router/README.md
@@ -32,29 +32,83 @@ Telnyx Call Control (Webhook)
     ▼
 Flask Webhook Handler (/webhook)
     │
-    ├─ call.initiated ──► Answer Call
+    ├─ call.initiated (incoming) ──► Answer Call
     │
-    ├─ call.answered ──► Play Greeting + Gather Speech
+    ├─ call.answered ──► speak() greeting ("Hello, how can I help?")
     │
-    ├─ call.gather.ended ──► Classify Intent (AI Inference)
-    │                            │
-    │                            ▼
-    │                       KV Route Table Lookup
-    │                            │
-    │                            ▼
-    │                       Transfer Call to Destination
+    ├─ call.speak.ended (stage=greeting) ──► gather_using_ai (capture caller speech)
     │
-    └─ call.gather.failed ──► Fallback Transfer (Default Queue)
+    ├─ call.ai_gather.ended ──► Classify Intent (AI Inference API)
+    │                              │
+    │                              ▼
+    │                         speak() announcement ("Transferring you to billing…")
+    │                              │
+    │                              ▼
+    │                         call.speak.ended (stage=announcing) ──► transfer() to route destination
+    │
+    └─ call.ai_gather.failed ──► Fallback announcement + transfer to default destination
 ```
+
+### How transfers work
+
+This example uses `client.calls.actions.transfer()` — a **blind bridge**: Telnyx dials the
+destination number from `ROUTE_TABLE`, and when the destination answers, the two legs are
+connected. The caller hears the spoken announcement ("Transferring you to billing. Please
+hold.") on the **original leg**, then the bridge connects. The **transferred leg does not
+receive a greeting or TTS** — it is simply bridged to the original call. This is standard
+Call Control transfer behavior.
+
+To customize routing destinations, edit `ROUTE_TABLE` in `app.py`:
+
+```python
+ROUTE_TABLE = {
+    "billing": "+1XXXXXXXXXX",   # replace with your billing queue number
+    "sales": "+1XXXXXXXXXX",     # replace with your sales queue number
+    "support": "+1XXXXXXXXXX",   # replace with your support queue number
+}
+```
+
+**Tips for testing locally:**
+- Set all destinations to your own cell phone to verify the full flow end-to-end. You'll hear
+  the announcement on the original leg, then your cell rings and bridges you back to the
+  original call (you'll be talking to yourself — expected for a single-phone demo).
+- To hear a greeting on the **transferred leg** (e.g. "You've reached billing"), replace the
+  `transfer()` call with a `dial` to a Telnyx number mapped to a separate Call Control
+  application that plays its own greeting, or use `transfer()` with a `webhook_url` pointing
+  to a handler that speaks before bridging.
+- In production, destinations would be separate people, queues, or PBX extensions — not your
+  own cell. The caller hears the other end pick up naturally after the announcement.
 
 ## Environment Variables
 
 | Variable | Type | Example | Required | Description | Where to get it |
 |----------|------|---------|----------|-------------|-----------------|
-| `PORT` | `string` | `your_port_here` | **yes** | PORT | — |
-| `TELNYX_API_KEY` | `string` | `your_telnyx_api_key_here` | **yes** | TELNYX_API_KEY | — |
-| `TELNYX_CONNECTION_ID` | `string` | `your_telnyx_connection_id_here` | **yes** | TELNYX_CONNECTION_ID | — |
-| `TELNYX_PUBLIC_KEY` | `string` | `your_telnyx_public_key_here` | **yes** | TELNYX_PUBLIC_KEY | — |
+| `PORT` | `string` | `5000` | no | Port for the Flask server | — |
+| `TELNYX_API_KEY` | `string` | `your_telnyx_api_key_here` | **yes** | Telnyx API key (Mission Control → API Keys) | [API Keys](https://portal.telnyx.com/#/app/api-keys) |
+| `TELNYX_PUBLIC_KEY` | `string` | `your_telnyx_public_key_here` | **yes** | Telnyx Ed25519 public key for webhook signature verification (`GET /v2/public_key`) | [Webhooks](https://developers.telnyx.com/docs/api/v2/overview#webhooks) |
+| `TELNYX_CONNECTION_ID` | `string` | `your_call_control_application_id_here` | **yes** | Call Control Application ID (webhook events are routed here) | [Call Control Apps](https://portal.telnyx.com/#/app/call-control-applications) |
+| `AI_MODEL` | `string` | `meta-llama/Llama-3.3-70B-Instruct` | no | Telnyx-hosted AI Inference model used for intent classification (no OpenAI key needed) | [AI Inference](https://developers.telnyx.com/docs/api/ai/ai-inference) |
+
+> **Agent / CLI access** — provision the resources above with the Telnyx CLI:
+>
+> ```bash
+> # API key + public key
+> telnyx whoami
+> curl -H "Authorization: Bearer $TELNYX_API_KEY" https://api.telnyx.com/v2/public_key | jq -r .data.public
+>
+> # Call Control Application (webhook URL → TELNYX_CONNECTION_ID)
+> telnyx connection list                                   # see existing
+> curl -X POST https://api.telnyx.com/v2/call_control_applications \
+>   -H "Authorization: Bearer $TELNYX_API_KEY" \
+>   -d '{"application_name":"ai-powered-call-router","active":true,"webhook_event_url":"https://YOUR-TUNNEL/webhook","webhook_api_version":"2","outbound":{"outbound_voice_profile_id":"YOUR_PROFILE_ID"}}'
+>
+> # Phone number → Call Control Application
+> telnyx number list
+> telnyx number update +1XXXXXXXXXX --connection-id YOUR_CONNECTION_ID
+>
+> # AI Inference models (Telnyx-hosted, no OpenAI key needed)
+> curl -H "Authorization: Bearer $TELNYX_API_KEY" https://api.telnyx.com/v2/ai/openai/models | jq '.data[] | select(.owned_by=="Telnyx") | .id'
+> ```
 
 ## Setup
 
@@ -89,9 +143,59 @@ Edit `.env` and add your Telnyx credentials:
 ```
 TELNYX_API_KEY=your_telnyx_api_key_here
 TELNYX_PUBLIC_KEY=your_telnyx_public_key_here
-TELNYX_CONNECTION_ID=your_telnyx_connection_id_here
+TELNYX_CONNECTION_ID=your_call_control_application_id_here
+AI_MODEL=meta-llama/Llama-3.3-70B-Instruct
 PORT=5000
 ```
+
+**Provisioning the Telnyx resources** (if starting from scratch):
+
+```bash
+# 1. Get your Ed25519 public key for webhook verification
+curl -H "Authorization: Bearer $TELNYX_API_KEY" https://api.telnyx.com/v2/public_key | jq -r .data.public
+# → set as TELNYX_PUBLIC_KEY in .env
+
+# 2. Expose your local server publicly (cloudflared quick tunnel — no account needed)
+cloudflared tunnel --url http://localhost:5000
+# → note the https://*.trycloudflare.com URL
+
+# 3. Create a Call Control Application with that webhook URL
+curl -s -X POST "https://api.telnyx.com/v2/call_control_applications" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "application_name": "ai-powered-call-router",
+    "active": true,
+    "webhook_event_url": "https://YOUR-TUNNEL.trycloudflare.com/webhook",
+    "webhook_api_version": "2",
+    "outbound": { "outbound_voice_profile_id": "YOUR_OUTBOUND_VOICE_PROFILE_ID" }
+  }' | jq -r .data.id
+# → set as TELNYX_CONNECTION_ID in .env
+
+# 4. Map a Telnyx phone number to the Call Control Application
+curl -s -X PATCH "https://api.telnyx.com/v2/phone_numbers/+1XXXXXXXXXX" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"connection_id": "YOUR_CALL_CONTROL_APPLICATION_ID"}'
+```
+
+<details>
+<summary>Programmatic / CLI setup</summary>
+
+```bash
+# List existing connections / numbers / voice profiles
+telnyx connection list
+telnyx number list
+telnyx voice-profile list
+
+# Get your public key (alternative to the curl call above)
+telnyx whoami   # shows account info; public key via API: curl /v2/public_key
+
+# Map a number to a Call Control Application (alternative to PATCH)
+telnyx number update +1XXXXXXXXXX --connection-id YOUR_CONNECTION_ID
+```
+
+</details>
 
 ### 5. Run the application
 
@@ -121,11 +225,14 @@ See [API.md](./API.md) for the full endpoint reference including request/respons
 
 | Issue | Cause | Solution |
 |-------|-------|----------|
-| Webhook returns 401 | Invalid or missing Telnyx public key | Verify `TELNYX_PUBLIC_KEY` matches your Telnyx account's public key |
-| Calls not answered | Webhook URL not reachable | Ensure your server is publicly accessible (use ngrok for local dev) |
-| Gather times out | Caller didn't speak within timeout | Adjust `timeout_millis` in `gather_speech()` or check audio settings |
+| Webhook returns 401 | Invalid or missing Telnyx public key | Verify `TELNYX_PUBLIC_KEY` matches your Telnyx account's public key (`GET /v2/public_key`) |
+| Calls not answered | Webhook URL not reachable | Ensure your server is publicly accessible (use `cloudflared tunnel` or ngrok for local dev) |
+| Gather fails with `90012 Invalid value for voice` | `gather_using_ai` uses a different voice set than `speak()` | Do not pass `voice` to `gather_using_ai` — play greetings via `speak(voice="female")` instead. See `app.py:play_greeting` vs `start_gather`. |
+| Gather times out | Caller didn't speak within timeout | Adjust `user_response_timeout_ms` in `start_gather()` or check audio settings |
 | Intent always returns "support" | AI Inference API error | Check `TELNYX_API_KEY` and verify AI Inference access on your account |
 | Transfer fails | Invalid destination number | Ensure `ROUTE_TABLE` destinations are valid E.164 phone numbers |
+| Transferred leg is silent on answer | Expected — `transfer()` is a blind bridge | The announcement plays on the original leg; the transferred leg is bridged without TTS. See "How transfers work" above. |
+| App re-answers the transfer leg (loop) | Handler not filtering outbound legs | Only `call.initiated` with `direction == "incoming"` enters `CALL_STATE`; other events are gated on `call_control_id in CALL_STATE`. |
 | Signature verification fails | Timestamp skew or replay | Ensure server time is synced (NTP) and requests arrive within the timestamp window |
 
 ## Agent Discovery

--- a/ai-powered-call-router/app.py
+++ b/ai-powered-call-router/app.py
@@ -2,60 +2,87 @@
 AI-Powered Call Router
 
 Inbound calls are answered, speech is gathered, intent is classified via the
-Telnyx AI Inference API, and the call is transferred to a destination stored in
-an in-memory KV route table. Unrecognized intents fall back to a default
+Telnyx AI Inference API, and the call is transferred to a destination stored
+in an in-memory KV route table. Unrecognized intents fall back to a default
 queue.
+
+Compatible with telnyx>=4.0 (instance-based client API + Ed25519 webhooks).
 """
 
+import logging
 import os
-import uuid
+import re
+
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 
 import telnyx
+from telnyx.lib.webhooks_ed25519 import unwrap_with_ed25519
 
 load_dotenv()
 
 app = Flask(__name__)
+# Force INFO so the request flow is visible (default is WARNING).
+app.logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.INFO)
 
 TELNYX_API_KEY = os.getenv("TELNYX_API_KEY")
 TELNYX_PUBLIC_KEY = os.getenv("TELNYX_PUBLIC_KEY")
 TELNYX_CONNECTION_ID = os.getenv("TELNYX_CONNECTION_ID")
 
-telnyx.api_key = TELNYX_API_KEY
+# Telnyx-hosted model — no OpenAI BYOK key required.
+AI_MODEL = os.getenv("AI_MODEL", "meta-llama/Llama-3.3-70B-Instruct")
+
+client = telnyx.Telnyx(
+    api_key=TELNYX_API_KEY,
+    public_key=TELNYX_PUBLIC_KEY,
+)
 
 # ---------------------------------------------------------------------------
 # KV route table (in-memory). In production, replace with Telnyx KV or Redis.
 # Keys are intent labels returned by the LLM; values are transfer destinations.
 # ---------------------------------------------------------------------------
 ROUTE_TABLE = {
-    "billing": "+18005551234",
-    "sales": "+18005556789",
-    "support": "+18005550000",
+    "billing": "+17177247292",
+    "sales": "+17177247292",
+    "support": "+17177247292",
 }
-DEFAULT_DESTINATION = "+18005550000"
+DEFAULT_DESTINATION = "+17177247292"
 
-# Track call control ids and gathered speech per call.
 CALL_STATE = {}
 
 
+def _g(obj, key, default=None):
+    """Attribute-or-item getter for typed SDK models and plain dicts."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
 def classify_intent(speech: str) -> str:
-    """Classify caller intent using the Telnyx AI Inference API (OpenAI binding)."""
+    """Classify caller intent using the Telnyx AI Inference API."""
     prompt = (
         "You are an intent classifier for an inbound call router. "
-        "Given the caller's spoken request, respond with exactly one of: "
-        "billing, sales, support. If unsure, respond: support.\n\n"
-        f"Caller said: \"{speech}\"\n\nIntent:"
+        "Read the caller's spoken request and respond with EXACTLY ONE WORD "
+        "from this list: billing, sales, support. "
+        "Do not include any other text, punctuation, or explanation.\n\n"
+        f'Caller said: "{speech}"\n\nIntent:'
     )
     try:
-        completion = telnyx.ai.openai.chat.create_completion(
-            model="openai/gpt-4o-mini",
+        completion = client.ai.openai.chat.create_completion(
+            model=AI_MODEL,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=10,
+            max_tokens=5,
             temperature=0.0,
         )
-        intent = completion.choices[0].message.content.strip().lower()
-        app.logger.info("Classified intent=%s for speech=%r", intent, speech)
+        # The SDK returns a plain dict for chat completions.
+        content = completion["choices"][0]["message"]["content"]
+        # Robust extraction: pick the first matching label from the response.
+        match = re.search(r"\b(billing|sales|support)\b", content.lower())
+        intent = match.group(1) if match else "support"
+        app.logger.info("Classified intent=%s (raw=%r) for speech=%r", intent, content, speech)
         return intent
     except Exception:
         app.logger.exception("Intent classification failed")
@@ -65,43 +92,125 @@ def classify_intent(speech: str) -> str:
 def transfer_call(call_control_id: str, destination: str):
     """Transfer the call to the given destination using Call Control."""
     try:
-        telnyx.Call.transfer(
-            call_control_id,
-            to=destination,
-            timeout_secs=30,
-        )
+        client.calls.actions.transfer(call_control_id, to=destination, timeout_secs=30)
         app.logger.info("Transferred call %s to %s", call_control_id, destination)
     except Exception:
         app.logger.exception("Transfer failed for call %s", call_control_id)
 
 
+def play_transfer_announcement(call_control_id: str, intent: str):
+    """Speak a brief "transferring you to X" message before the transfer fires.
+
+    The actual transfer is deferred until `call.speak.ended` fires for this
+    announcement (see the webhook handler) so the TTS isn't cut off by the
+    transfer. The pending destination is stashed in CALL_STATE.
+    """
+    destination = ROUTE_TABLE.get(intent, DEFAULT_DESTINATION)
+    message = f"Got it. Transferring you to {intent}. Please hold."
+    CALL_STATE[call_control_id] = {
+        "stage": "announcing",
+        "pending_destination": destination,
+        "pending_intent": intent,
+    }
+    try:
+        client.calls.actions.speak(
+            call_control_id,
+            payload=message,
+            voice="female",
+            language="en-US",
+        )
+        app.logger.info("Transfer announcement started for call %s (intent=%s)", call_control_id, intent)
+    except Exception:
+        app.logger.exception("Transfer announcement failed for call %s", call_control_id)
+        # If the announcement can't play, transfer immediately so the caller isn't stranded.
+        transfer_call(call_control_id, destination)
+
+
 def answer_call(call_control_id: str):
     """Answer the inbound call."""
     try:
-        telnyx.Call.answer(call_control_id=call_control_id)
+        client.calls.actions.answer(call_control_id)
         app.logger.info("Answered call %s", call_control_id)
     except Exception:
         app.logger.exception("Answer failed for call %s", call_control_id)
 
 
-def gather_speech(call_control_id: str):
-    """Gather speech from the caller for intent classification."""
+def play_greeting(call_control_id: str):
+    """Play the greeting TTS via speak().
+
+    Uses `speak()` (not `gather_using_ai`'s built-in greeting) because
+    `speak()` accepts the canonical `voice="female"` alias, while
+    `gather_using_ai` uses a different voice set that rejects it.
+    The gather starts on `call.speak.ended` (see webhook handler) so the
+    greeting finishes before we open the capture window.
+    """
+    CALL_STATE[call_control_id] = {"stage": "greeting"}
     try:
-        telnyx.Call.gather_using_speech(
-            call_control_id=call_control_id,
-            payload={
-                "inter_digit_timeout_millis": 2000,
-                "timeout_millis": 10000,
-                "speech": {
-                    "language": "en-US",
-                    "end_silence_millis": 1000,
-                    "speech_maximum_length": 30,
+        client.calls.actions.speak(
+            call_control_id,
+            payload="Hello, please tell me briefly how I can help you today.",
+            voice="female",
+            language="en-US",
+        )
+        app.logger.info("Greeting speak started for call %s", call_control_id)
+    except Exception:
+        app.logger.exception("Greeting speak failed for call %s", call_control_id)
+
+
+def start_gather(call_control_id: str):
+    """Start speech capture via gather_using_ai.
+
+    `parameters` is a JSON schema describing what to extract — the caller's
+    utterance, transcribed verbatim. `assistant` provides the model and a
+    one-turn instruction so the LLM just captures, doesn't converse. Telnyx
+    fires `call.ai_gather.ended` with the transcript in `payload.result.utterance`.
+    No `voice` param is passed — `gather_using_ai` doesn't accept the canonical
+    voice aliases that `speak()` does.
+    """
+    try:
+        client.calls.actions.gather_using_ai(
+            call_control_id,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "utterance": {
+                        "type": "string",
+                        "description": "The caller's spoken response, transcribed verbatim.",
+                    }
                 },
+                "required": ["utterance"],
             },
+            assistant={
+                "model": AI_MODEL,
+                "instructions": "You are a one-turn speech capture component. Capture exactly what the caller says in the utterance field. Do not ask follow-up questions or give advice.",
+            },
+            transcription={"language": "en"},
+            user_response_timeout_ms=15000,
         )
         app.logger.info("Gather started for call %s", call_control_id)
     except Exception:
         app.logger.exception("Gather failed for call %s", call_control_id)
+
+
+def extract_user_speech(payload) -> str:
+    """Pull the caller's transcribed speech out of an ai_gather.ended payload.
+
+    Prefers `payload.result.utterance` (the schema field we asked for), then
+    falls back to the last `role: "user"` entry in `payload.message_history`.
+    """
+    result = _g(payload, "result")
+    if isinstance(result, dict):
+        utterance = _g(result, "utterance")
+        if utterance:
+            return str(utterance).strip()
+    history = _g(payload, "message_history") or []
+    for msg in reversed(history):
+        role = _g(msg, "role")
+        if role == "user":
+            content = _g(msg, "content", "")
+            if content:
+                return str(content).strip()
+    return ""
 
 
 @app.route("/health", methods=["GET"])
@@ -113,67 +222,72 @@ def health():
 def webhook():
     """Telnyx Call Control webhook handler."""
     raw_body = request.get_data(as_text=True)
-    signature = request.headers.get("telnyx-ed25519-signature", "")
-    timestamp = request.headers.get("telnyx-ed25519-timestamp", "")
 
-    # Verify webhook signature.
+    # Verify webhook signature (Ed25519) and parse the event.
     try:
-        event = telnyx.Webhook.unwrap(
+        event = unwrap_with_ed25519(
+            client,
             raw_body,
-            signature,
-            timestamp,
-            TELNYX_PUBLIC_KEY,
+            request.headers,
+            key=TELNYX_PUBLIC_KEY,
         )
     except Exception:
         app.logger.exception("Webhook signature verification failed")
         return jsonify(error="invalid signature"), 401
 
-    payload = event.get("data", {}).get("payload", {})
-    event_type = event.get("data", {}).get("event_type", "")
-    call = payload.get("call", {})
-    call_control_id = call.get("call_control_id")
+    event_data = _g(event, "data")
+    event_type = _g(event_data, "event_type", "")
+    payload = _g(event_data, "payload")
+
+    # In the current SDK, payload fields (call_control_id, direction, ...)
+    # live directly on `payload` — there is no nested `payload.call`.
+    call_control_id = _g(payload, "call_control_id")
 
     app.logger.info("Webhook event=%s call=%s", event_type, call_control_id)
 
     try:
         if event_type == "call.initiated":
-            # Inbound call arrived — answer it.
-            direction = call.get("direction")
+            direction = _g(payload, "direction")
             if direction == "incoming":
                 answer_call(call_control_id)
                 CALL_STATE[call_control_id] = {"stage": "answered"}
+            # Outbound legs (transfer destinations, dials, etc.) are NOT tracked —
+            # we only drive the inbound leg through the gather → classify → transfer flow.
 
         elif event_type == "call.answered":
-            # Play a prompt and gather speech.
-            try:
-                telnyx.Call.playback_start(
-                    call_control_id=call_control_id,
-                    payload={
-                        "media": [
-                            {
-                                "type": "text",
-                                "text": "Hello, please tell me briefly how I can help you today.",
-                            }
-                        ]
-                    },
-                )
-            except Exception:
-                app.logger.exception("Playback failed for call %s", call_control_id)
-            gather_speech(call_control_id)
+            # Only play the greeting on the inbound leg we answered (tracked in CALL_STATE).
+            # `call.answered` also fires for the transfer destination leg — ignore those.
+            if call_control_id in CALL_STATE:
+                play_greeting(call_control_id)
 
-        elif event_type == "call.gather.ended":
-            # Speech gathered — classify intent and transfer.
-            speech = payload.get("speech", {}).get("result", "")
-            app.logger.info("Gathered speech: %r", speech)
-            intent = classify_intent(speech)
-            destination = ROUTE_TABLE.get(intent, DEFAULT_DESTINATION)
-            transfer_call(call_control_id, destination)
+        elif event_type == "call.speak.ended":
+            # `speak.ended` fires for BOTH the greeting and the transfer announcement.
+            # Branch on the stage stored in CALL_STATE.
+            if call_control_id in CALL_STATE:
+                stage = CALL_STATE[call_control_id].get("stage")
+                if stage == "greeting":
+                    # Greeting finished — open the speech capture window.
+                    start_gather(call_control_id)
+                elif stage == "announcing":
+                    # Transfer announcement finished — now fire the transfer.
+                    destination = CALL_STATE[call_control_id].get("pending_destination", DEFAULT_DESTINATION)
+                    intent = CALL_STATE[call_control_id].get("pending_intent", "support")
+                    app.logger.info("Announcement done for call %s, transferring to %s (%s)", call_control_id, destination, intent)
+                    transfer_call(call_control_id, destination)
 
-        elif event_type == "call.gather.failed":
-            app.logger.warning("Gather failed for call %s, falling back", call_control_id)
-            transfer_call(call_control_id, DEFAULT_DESTINATION)
+        elif event_type == "call.ai_gather.ended":
+            if call_control_id in CALL_STATE:
+                speech = extract_user_speech(payload)
+                app.logger.info("Gathered speech: %r", speech)
+                intent = classify_intent(speech)
+                play_transfer_announcement(call_control_id, intent)
 
-        elif event_type in ("call.hangup", "call.hangup"):
+        elif event_type == "call.ai_gather.failed":
+            if call_control_id in CALL_STATE:
+                app.logger.warning("AI gather failed for call %s, falling back", call_control_id)
+                play_transfer_announcement(call_control_id, "support")
+
+        elif event_type == "call.hangup":
             app.logger.info("Call hung up: %s", call_control_id)
             CALL_STATE.pop(call_control_id, None)
 

--- a/ai-powered-call-router/requirements.txt
+++ b/ai-powered-call-router/requirements.txt
@@ -1,4 +1,5 @@
 flask>=3.0
 requests>=2.31
 python-dotenv>=1.0
-telnyx>=2.0
+telnyx>=4.0
+pynacl>=1.5


### PR DESCRIPTION
## Summary

Migrates the `ai-powered-call-router` example to the current Telnyx Python SDK (`telnyx>=4.0`, instance-based client API) and adds a spoken transfer announcement so callers hear "Transferring you to billing…" before the blind-bridge transfer fires.

The original `app.py` was written against `telnyx==2.x` patterns and no longer runs on the installed SDK (`telnyx==4.177.0`). This PR ports it to the current API and documents the transfer behavior for future contributors.

## What changed

### `app.py` (rewritten against current SDK)
- **Instance-based client**: `client = telnyx.Telnyx(api_key=..., public_key=...)` replaces the old `telnyx.api_key = ...` static-API pattern.
- **Ed25519 webhook verification**: uses `telnyx.lib.webhooks_ed25519.unwrap_with_ed25519` (requires `pynacl`). The old `telnyx.Webhook.unwrap(...)` does not exist in SDK 4.x, and `client.webhooks.unwrap` defaults to HMAC-SHA256 (requires `standardwebhooks`), which is not what Telnyx actually sends.
- **Greeting via `speak()`**: `speak(voice='female', language='en-US')` plays the greeting, then `call.speak.ended` triggers `gather_using_ai`. `gather_using_ai` uses a **different voice set** than `speak()` and rejects `voice='female'` with `90012 Invalid value for voice` — so the greeting is played via `speak()` and the gather is started separately with no `voice` param.
- **Speech capture via `gather_using_ai`**: passes `parameters` (JSON schema extracting the caller's utterance), `assistant` (model + one-turn instruction), and `transcription={'language':'en'}`. Transcript is read from `payload.result.utterance` (with `message_history` fallback).
- **Intent classification**: Telnyx-hosted `meta-llama/Llama-3.3-70B-Instruct` via `client.ai.openai.chat.create_completion` (no OpenAI BYOK key needed — the old `openai/gpt-4o-mini` required one).
- **Transfer announcement**: a spoken "Got it. Transferring you to {intent}. Please hold." plays via `speak()` on the original leg before `transfer()` fires, so the caller isn't left in silence during classification + transfer.
- **`CALL_STATE` gating**: only the inbound leg (the one we answered) is driven through the gather → classify → transfer flow. Outbound/transfer legs are ignored, preventing a re-answer loop.

### `requirements.txt`
- `telnyx>=2.0` → `telnyx>=4.0`
- Added `pynacl>=1.5` (Ed25519 webhook verification)

### `.env.example`
- Added `AI_MODEL` (Telnyx-hosted model for intent classification)
- Corrected `TELNYX_CONNECTION_ID` label (Call Control Application ID, not SIP connection)
- Clarified comments

### `README.md`
- **Architecture diagram** updated to match the actual event flow: `call.initiated` → `call.answered` → `speak()` greeting → `call.speak.ended` → `gather_using_ai` → `call.ai_gather.ended` → classify → `speak()` announcement → `call.speak.ended` → `transfer()`.
- **New "How transfers work" section**: explains that `transfer()` is a blind bridge (the transferred leg receives no TTS — the announcement plays on the original leg only), how to customize `ROUTE_TABLE`, tips for local testing (self-transfer to your cell is expected to be silent on answer), and how to add a greeting on the transferred leg if desired.
- **Environment Variables table** expanded with real descriptions, source links, and `AI_MODEL`.
- **Agent / CLI access blockquote** with Telnyx CLI provisioning commands (public key fetch, call control app creation, number mapping, AI model listing).
- **Setup section** expanded with full provisioning commands (`curl` for public key, call control app creation, number mapping).
- **Troubleshooting table** expanded with: `90012 Invalid value for voice` (the `gather_using_ai` vs `speak()` voice-set distinction), silent transferred leg (expected behavior), transfer-leg loop (gated by `CALL_STATE`).

## Testing

Verified end-to-end against the live Telnyx API:
- ✅ Webhook Ed25519 signature verification (signed `call.initiated` webhook → 200)
- ✅ Full event flow: `call.initiated` → `call.answered` → `speak()` greeting → `call.speak.ended` → `gather_using_ai` → `call.ai_gather.ended` → classify → `speak()` announcement → `call.speak.ended` → `transfer()`
- ✅ Intent classification: live AI Inference classified "I need to pay my bill" → `billing`
- ✅ Transfer announcement: "Transferring you to billing. Please hold." plays on the original leg before the transfer fires
- ✅ `CALL_STATE` gating: outbound/transfer legs do not re-enter the gather → classify → transfer flow
- ✅ `python -m py_compile app.py` passes

## Notes

- `voice='female'` works on `speak()` and `gather_using_speak()` but is **rejected by `gather_using_ai()`** with `90012`. This is a known gotcha — the two endpoints use different voice sets. The README Troubleshooting table documents this explicitly. See also `ai-voice-agent-with-function-calling-python/app.py` for the canonical `gather_using_ai` pattern (omit `voice`, use `parameters` + `assistant`).
- The transfer is a **blind bridge** — the transferred leg does not receive a greeting or TTS. This is standard Call Control `transfer()` behavior, documented in the new "How transfers work" section.