### PR TITLE
fix: honor ?session= URL param for per-session actor isolation (DEV-828)

### DIFF
--- a/langchain-streaming-agent/src/demo-html.ts
+++ b/langchain-streaming-agent/src/demo-html.ts
@@ -93,6 +93,9 @@ const els = {
   meta: document.getElementById("meta"),
 };
 
+const urlSession = new URLSearchParams(location.search).get("session");
+if (urlSession) els.session.value = urlSession;
+
 let client = null;
 let lastEventSeq = 0;
 let liveTurn = 0;


### PR DESCRIPTION
## Summary

`langchain-streaming-agent`: the demo UI ignored the `?session=` query param and always attached to the session typed in the input field (default `demo`). Every page load on any URL therefore attached to the same shared actor — conversations from different users (or different browser tabs) bled into one durable log.

## Fix

Seed the session input from the URL on load, so each session id gets its own durable agent — the behavior the README already documents.

## Source / Tracking

| Field | Value |
|---|---|
| Linear issue | [DEV-828](https://linear.app/telnyx/issue/DEV-828/sprint-2-langchain-streaming-agent) |
| Sample path | `langchain-streaming-agent/` |
| Follow-up to | #183 |

## Validation

- `tsc --noEmit`: clean
- vitest: 11 passed / 2 skipped
- Live: two different `?session=` URLs now show independent conversations (verified against the deployed function, which runs the same UI).
