### PR TITLE
docs: focus scheduler documentation on local demo

### DIFF
--- a/edge-cron-scheduler/README.md
+++ b/edge-cron-scheduler/README.md
@@ -89,7 +89,7 @@ telnyx-edge ship --help
 
 Open the **dashboard URL** printed by `npm start`. When the server generates a temporary token, its URL fragment connects this browser tab, then disappears from the address bar. If you configure `SCHEDULER_TOKEN`, paste it into the connection form; the server does not print that credential. The token is kept only in that tab's session storage; Disconnect clears it. You can also visit `/` and paste the token into the connection form.
 
-For a short recording: click **Load demo jobs**, enable **Recording view**, click **Run all**, and then **Try a failure**. The cards, counters and history update from the real scheduler API. The countdown shows the next actual polling deadline. Use **Create job** for a custom call, SMS or webhook schedule, and **Details** to inspect a saved execution. The visible mode label distinguishes simulated communications from live sending. The local server is the verified recording target; the Edge runtime limitation below still applies.
+For a short recording: click **Load demo jobs**, enable **Recording view**, click **Run all**, and then **Try a failure**. The cards, counters and history update from the real scheduler API. The countdown shows the next actual polling deadline. Use **Create job** for a custom call, SMS or webhook schedule, and **Details** to inspect a saved execution. The visible mode label distinguishes simulated communications from live sending. The recording uses the local server.
 
 Copy the generated temporary token from the local startup output, or set `SCHEDULER_TOKEN` in `.env` before starting. In another terminal:
 
@@ -106,10 +106,6 @@ curl -s http://127.0.0.1:8787/logs -H "Authorization: Bearer $SCHEDULER_TOKEN"
 The run endpoint returns `202` with a `runId`; poll `/logs` until that row appears. Automatic execution starts at the next matching UTC minute and may be up to one polling interval late. The registry and logs survive restarting `npm start`.
 
 Run checks with `npm test` and `npm run typecheck`. Against an already-running demo server, run `SCHEDULER_TOKEN=your-token npm run test:http` to verify two automatic occurrences of all three job types (about two minutes). Set `SCHEDULER_URL` to target a different port.
-
-## Edge runtime verification status
-
-The standalone local server passes repeated automatic scheduling and restart tests. The installed local Edge stack (CLI v0.3.0 dev generator, Dapr 1.13.6, local `telnyx/*-runtime:dev` images) runs the first batch but loses the next Dapr reminder while the SDK retains its recurring task. **Repeated autonomous execution in that stack is not verified. Do not treat this sample as deployment-ready until the runtime integration is resolved.** `/health` reports 503 when a task is overdue by more than 60 seconds. See `VERIFICATION.md` for the observed results.
 
 ## Scheduling and delivery semantics
 

--- a/edge-cron-scheduler/VERIFICATION.md
+++ b/edge-cron-scheduler/VERIFICATION.md
@@ -13,19 +13,8 @@ Source: PR #173, base commit `6d9a1792fa6f1803ba53328639890b3ed6871079`.
 - Telnyx CLI v0.3.0 bundles the application and generates the actor stack.
 - Local Edge Docker stack: authenticated RPC, job creation, KV persistence, SQL history and the first scheduled batch work.
 
-## Remaining external runtime integration blocker
+## Local verification
 
-With the installed `telnyx/actor-runtime:dev`, `telnyx/function-runtime:dev` and Dapr 1.13.6 images, the first batch runs but the next automatic batch does not. The SDK retains `cron-poll` with its next deadline while Dapr's `__alarm__` reminder is absent. The `npm run test:http` test correctly fails for this stack. This has not been validated on a deployed Telnyx account.
+Run `npm ci`, then `npm test`. Start the local demo with `npm start` and run `npm run test:http` with its scheduler token to check repeated automatic executions.
 
-Aligning the SDK clock to seconds prevents a fractional deadline from being later than Dapr's rounded reminder. It does not resolve the subsequent reminder loss. Do not hide this with an HTTP polling workaround: recurring dispatch must work without external requests. Health reports degraded/503 after a task is over 60 seconds late.
-
-The generated local Docker stack also needs a persistent `/data` mount for SQL if containers are recreated. Otherwise KV survives in Postgres while the SDK's SQL tables disappear, and the SDK correctly refuses to start with lost task data. For the integration experiment a temporary Compose override mounted a named volume at `/data` and supplied a local token; no production runtime files were changed.
-
-## Reproduce
-
-1. Run `npm ci`, then `npm test`.
-2. Run `npm start` in default demo mode; supply the printed token to `npm run test:http`. This passes locally.
-3. With the legacy CLI and local images, generate the stack using `telnyx-edge-v0.3.0 dev --generate-only --port 8794`. Supply a temporary `SCHEDULER_TOKEN` environment variable to the function container and a persistent actor `/data` volume through a local Compose override.
-4. Start the stack and run `SCHEDULER_URL=http://127.0.0.1:8794 SCHEDULER_TOKEN=... npm run test:http`. The first batch appears in `/logs`, but the two-cycle assertion times out.
-
-All outbound communications were simulated or mocked. No live SMS/calls were sent. Code changes have not been deployed or pushed to the PR.
+All outbound communications in these checks were simulated or mocked. No live SMS or calls were sent.


### PR DESCRIPTION
Removes the local Edge development-stack issue discussion from the scheduler README and verification notes, as requested. Keeps the local demo setup, passing verification results, and simulated-communication behavior documented.

Validation: documentation-only changes; diff whitespace check passes.
