### PR TITLE
Add email-inbox-demo (TRUST-286): focused inbound-email demo for Telnyx Email API

### DIFF
--- a/email-inbox-demo/.env.example
+++ b/email-inbox-demo/.env.example
@@ -1,0 +1,19 @@
+# Local server defaults to DEMO_MODE. No credentials needed until you connect a real inbox.
+DEMO_MODE=true
+PORT=8788
+HOST=127.0.0.1
+
+# Leave empty to generate a temporary token on startup.
+EMAIL_INBOX_TOKEN=
+
+# Local SQLite file. Created automatically on first run.
+EMAIL_INBOX_DB=.data/inbox.sqlite
+
+# How often the DEMO_MODE seeder injects a realistic inbound email (ms).
+DEMO_SEED_INTERVAL_MS=15000
+
+# Only required when DEMO_MODE=false (connecting to real Telnyx Email API).
+# TELNYX_API_KEY=KEY0123456789ABCDEF
+# TELNYX_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----...-----END PUBLIC KEY-----
+# TELNYX_EMAIL_DOMAIN_ID=
+# TELNYX_PUBLIC_BASE_URL=https://your-tunnel.ngrok.app

--- a/email-inbox-demo/.gitignore
+++ b/email-inbox-demo/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.data/
+*.log

--- a/email-inbox-demo/API.md
+++ b/email-inbox-demo/API.md
@@ -1,0 +1,128 @@
+# API Reference — Email Inbox Demo
+
+Base URL for local development: `http://127.0.0.1:8788`. All routes are JSON unless stated otherwise. The webhook route accepts JSON without authentication — it verifies Telnyx's Ed25519 signature instead.
+
+| Method | Path | Auth | Response |
+|---|---|---|---|
+| `GET` | `/` | none | `text/html; charset=utf-8` dashboard shell |
+| `GET` | `/health` | none | `{ok, demoMode, hasTelnyxCreds, inboxes}` |
+| `GET` | `/api/inboxes` | none | `InboxRow[]` — newest first |
+| `POST` | `/api/inboxes` | none | `InboxRow` (creates in DEMO_MODE locally, or via Telnyx in live mode) |
+| `DELETE` | `/api/inboxes/:id` | none | `204 No Content` — cascades to messages |
+| `GET` | `/api/inboxes/:id/messages` | none | `MessageRow[]` — newest first; optional `?status=received\|read\|archived\|deleted` |
+| `GET` | `/api/messages/:id` | none | `MessageRow` — includes `body_html`, `body_text`, `headers_json`, `attachments_json` |
+| `POST` | `/api/messages/:id/read` | none | `{ok: true}` — flips status, sets `read_at`, broadcasts SSE |
+| `POST` | `/api/messages/:id/archive` | none | `{ok: true}` — flips status, broadcasts SSE |
+| `POST` | `/api/messages/:id/delete` | none | `{ok: true}` — soft-delete, broadcasts SSE |
+| `GET` | `/api/events` | none | `text/event-stream` — SSE bus (see below) |
+| `POST` | `/webhooks/email` | Ed25519 | `202 {ok, id}` — accepts Telnyx `email.received` |
+| `POST` | `/api/demo/trigger` | none | `{ok, id}` — DEMO_MODE only; inject one synthetic inbound |
+
+## SSE Events
+
+```
+event: hello
+data: {"id":"<client-id>","demoMode":true}
+
+event: inbox_created
+data: {"inbox": {...InboxRow}}
+
+event: message_received
+data: {"id":"msg_...","inbox_id":"inbox_...","from_address":"...","from_name":"...","subject":"..."}
+
+event: message_status
+data: {"id":"msg_...","status":"read|archived|deleted"}
+```
+
+## Webhook payload (Telnyx → app)
+
+Telnyx posts `email.received` to `/webhooks/email`. The handler reads:
+
+```jsonc
+{
+  "data": {
+    "event_type": "email.received",
+    "id": "evt_...",
+    "occurred_at": "2026-09-10T...",
+    "payload": {
+      "message_id": "msg_...",
+      "inbox_id": "inb_...",
+      "from":     { "email": "alice@example.com", "name": "Alice" },
+      "to":       [{ "email": "bob@example.com",  "name": null }],
+      "cc":       [],
+      "subject":  "...",
+      "text":     "...",
+      "html":     "<p>...</p>",
+      "headers":  { "from": "...", "subject": "...", ... },
+      "attachments": [{ "id": "...", "filename": "...", "content_type": "...", "size": 1234 }],
+      "thread_id": "t_..."
+    }
+  }
+}
+```
+
+Headers required by the webhook route:
+
+| Header | Description |
+|---|---|
+| `telnyx-signature-ed25519` | Hex-encoded Ed25519 signature of `<timestamp>.<rawBody>` |
+| `telnyx-timestamp` | Unix seconds; rejected if outside ±300s tolerance |
+
+In `DEMO_MODE=true`, signature verification is bypassed so the `POST /api/demo/trigger` and unsigned local tests work.
+
+## Row types
+
+```ts
+type InboxRow = {
+  id: string;
+  email_address: string;
+  display_name: string | null;
+  domain_id: string;
+  inbound_enabled: 0 | 1;
+  status: string;
+  source: "demo" | "telnyx";
+  created_at: number;
+  updated_at: number;
+};
+
+type MessageRow = {
+  id: string;
+  inbox_id: string;
+  telnyx_id: string | null;
+  thread_id: string | null;
+  from_address: string;
+  from_name: string | null;
+  to_addresses: string;
+  cc_addresses: string | null;
+  subject: string | null;
+  preview: string | null;
+  body_html: string | null;
+  body_text: string | null;
+  headers_json: string | null;
+  attachments_json: string | null;
+  status: "received" | "read" | "archived" | "deleted";
+  received_at: number;
+  read_at: number | null;
+};
+```
+
+## Error responses
+
+```jsonc
+// 400
+{ "error": "username and domain are required" }
+{ "error": "missing inbox_id in payload" }
+
+// 401 (live mode only)
+{ "error": "invalid signature", "reason": "stale_timestamp" | "bad_signature" | "missing_header" | "no_public_key" }
+
+// 403 (live mode only)
+{ "error": "demo mode disabled" }
+
+// 404
+{ "error": "not found" }
+{ "error": "unknown inbox" }
+
+// 502 (live mode only)
+{ "error": "<Telnyx API error message>" }
+```

--- a/email-inbox-demo/DEMO.md
+++ b/email-inbox-demo/DEMO.md
@@ -1,0 +1,103 @@
+# Demo Script: Email Inbox Demo
+
+The narrated run-through for the TRUST-286 YouTube recording. Target: ~4 minutes. Click-by-click + what the audience sees at each step.
+
+## Before recording
+
+1. `npm install && npm start` (DEMO_MODE — no credentials needed)
+2. Open `http://localhost:8788` in a fresh tab at full width (1280×800 or larger)
+3. Confirm the seeded demo inbox shows: `support@telnyx-demo.msgtelnyx.com`
+4. Confirm the message list is empty or has one or two seeded messages from the auto-injector
+5. Optional: open `/health` in a second tab to show `demoMode: true` and `inboxes: 1`
+
+## Act 1 — Show the empty (or near-empty) inbox (15 sec)
+
+**Screen:** Dashboard at `/`, full width.
+
+**Say:** *"This is a focused look at the inbound side of the Telnyx Email API. No outbound, no AI replies — just receive, list, and read. And it runs in DEMO_MODE without any Telnyx credentials or ngrok."*
+
+> Talking point: *"The seeder is firing in the background, but I'm starting from a clean slate so you can see one message arrive on cue."*
+
+## Act 2 — Recording view (10 sec)
+
+**Click:** **Recording view** in the top right.
+
+**Audience sees:** Type enlarges, the "Trigger inbound" debug button hides, a demo banner appears.
+
+**Say:** *"For the recording I switch to a presentation-friendly layout."*
+
+## Act 3 — Trigger an inbound (60 sec)
+
+**Click:** **Trigger inbound** — but **before** you click, the button is hidden in recording view.
+
+**Screen direction:** Switch back to normal view briefly to click the button, or click the **+ Add inbox** first to demonstrate that, then come back. *Decision: keep recording view off until Act 4 to keep this realistic.*
+
+**Click:** Trigger inbound.
+
+**Audience sees:** A toast flashes ("Injected simulated inbound"), a new message appears in the list, the reader pane opens automatically with the full HTML body, the message is marked as read.
+
+**Say:** *"A Stripe receipt just landed. The message list updated live over Server-Sent Events — no refresh. The reader opened automatically, rendered the HTML body safely in a sandboxed iframe, and marked the message as read."*
+
+> Talking point: *"The seeder synthesizes the exact payload shape Telnyx would send for `email.received`. The rendering path is identical to live mode — only the input source differs."*
+
+**Click:** Trigger inbound twice more. Show variety: a GitHub two-factor code email, then a meeting notes email.
+
+**Say:** *"Three different senders, three different formats — receipts, security alerts, internal updates. The dashboard handles each the same way."*
+
+## Act 4 — Add a second inbox (30 sec)
+
+**Click:** **Recording view** again to hide debug controls before showing the create flow.
+
+**Click:** **+ Add inbox** at the bottom of the left pane. Type `sales` as the username and `acme-robotics` as the subdomain. Hit Enter.
+
+**Audience sees:** A new inbox appears in the sidebar (`sales@acme-robotics.msgtelnyx.com`) with 0 unread. The header count updates from "1 total" to "2 total". The message list clears because the new inbox has no messages yet.
+
+**Say:** *"Creating an inbox is one API call — `POST /v2/email_inboxes` with `inbound_enabled: true`. In DEMO_MODE this creates a synthetic one locally; in live mode it calls the real Telnyx API and registers the inbox on the shared_inbound subdomain. No DNS, no MX records, no SMTP plumbing."*
+
+## Act 5 — Independent message streams (30 sec)
+
+**Click:** into the new `sales@acme-robotics` inbox.
+
+**Click:** Trigger inbound twice. The new inbox gets its own randomized emails.
+
+**Audience sees:** The sidebar unread badge for `sales@acme-robotics` ticks from 0 to 2. The message list shows two new emails.
+
+**Click:** back into the original `support@telnyx-demo` inbox. The previous messages are still there.
+
+**Say:** *"Each inbox is independent — its own message stream, its own unread badge. Messages update live over SSE the moment a webhook fires."*
+
+## Act 6 — Archive and delete (20 sec)
+
+**Click:** into a message in any inbox.
+
+**Click:** **Archive**. The message disappears from the default list.
+
+**Click:** the **All** filter dropdown and switch to **Archived**. The archived message reappears.
+
+**Say:** *"Archive is a soft delete — the row stays, but it's filtered out of the default view. Switch to the Archived filter and it comes back. Delete is the same pattern, but more final."*
+
+## Act 7 — Plain-text toggle (10 sec)
+
+**Click:** into any HTML message with a longer body.
+
+**Click:** **Plain text** (the disclosure under the iframe).
+
+**Audience sees:** A monospaced text rendering of the same message body, in case the HTML is broken or suspicious.
+
+**Say:** *"And the plain-text body is always available — useful when the HTML is broken, or when you want to copy a snippet without the markup."*
+
+## Act 8 — Outro (10 sec)
+
+**Click:** Recording view off, switch back to clean dashboard state.
+
+**Say:** *"Inbound email on the Telnyx Email API: one platform, one API key, one signed webhook. Clone the repo, run `npm start` in DEMO_MODE, and you have a working demo on your machine in under a minute."*
+
+---
+
+## Total runtime: ~3 minutes 5 seconds
+
+If you have more time, add:
+- **Live mode walkthrough** (2 min): set `DEMO_MODE=false`, add real credentials, point ngrok at the webhook, send a real email to the inbox. Audience sees the message arrive in the dashboard.
+- **Ed25519 verification demo** (1 min): show the verification code path, generate a tampered payload in DevTools, watch the 401 response. Good for the security-focused audience.
+
+If you have less time, cut Act 6 (archive/delete) and Act 7 (plain-text toggle).

--- a/email-inbox-demo/GUIDE.md
+++ b/email-inbox-demo/GUIDE.md
@@ -1,0 +1,163 @@
+# Implementation Guide — Email Inbox Demo
+
+A walkthrough of every file in the project, the design decisions behind it, and the gotchas worth knowing about. For the auto-generated agent-discovery summary, see `README.md`.
+
+## Stack
+
+| Layer | Choice | Why |
+|---|---|---|
+| Runtime | Node.js 22.13+ | Matches the rest of the `telnyx-code-examples` repo |
+| Web server | Express 4 | Minimal, no Edge Compute complexity — pure HTTP dashboard |
+| Persistence | better-sqlite3 11 | Synchronous, embedded, no migrations framework needed |
+| Telnyx SDK | `telnyx` Node v7.20+ | Official SDK; covers Email API |
+| Webhook crypto | `tweetnacl` 1.0.3 | Ed25519 verify; smaller surface than libsodium |
+| Frontend | Vanilla HTML/CSS/JS in a TypeScript template string | Zero build step, self-contained, matches the `omni-channel-lab-inbox-agent` admin UI pattern |
+
+## File map
+
+```
+email-inbox-demo/
+├── package.json              # type: module, scripts, deps
+├── tsconfig.json             # ES2022, NodeNext, strict
+├── .env.example              # all config knobs with defaults
+├── .gitignore
+├── README.md                 # user-facing entry point
+├── PRD.md                    # product spec (TRUST-286)
+├── DEMO.md                   # narration script for the YouTube recording
+├── API.md                    # endpoint reference
+├── GUIDE.md                  # this file — implementation walkthrough
+├── src/
+│   ├── types.ts              # row types + Telnyx payload shape
+│   ├── db.ts                 # better-sqlite3 cache + migrations
+│   ├── telnyxClient.ts       # `telnyx` SDK wrappers + payload mapper
+│   ├── webhookVerify.ts      # Ed25519 verification (tweetnacl)
+│   ├── demoSeeder.ts         # background fake-inbound generator
+│   ├── dashboard.ts          # 3-pane HTML export (single self-contained file)
+│   └── server.ts             # Express wiring + SSE bus
+└── tests/
+    └── smoke.test.ts         # 5 smoke tests
+```
+
+## Design decisions
+
+### 1. DEMO_MODE is the default — and the first-run experience
+
+The README's quickstart is `npm install && npm start`. No `.env` editing, no Telnyx account, no ngrok. On first launch the server creates a demo inbox (`support@telnyx-demo.msgtelnyx.com`) and the seeder starts firing realistic inbound every 15s.
+
+This means the YouTube demo works out-of-the-box and any developer cloning the repo has a working demo in under a minute. The "trigger inbound" button gives them deterministic control when they want it.
+
+The seeder synthesizes the exact `email.received` payload shape Telnyx would send, then routes it through the same storage + SSE pipeline as a real webhook. Switching to live mode is just a config flip.
+
+### 2. The dashboard is one self-contained HTML file
+
+`src/dashboard.ts` exports a single function `dashboard(opts)` that returns a complete HTML document as a string. The server serves it from `GET /`. The page uses inline CSS and inline JS — no separate asset files, no build step, no framework.
+
+This is the same pattern as `omni-channel-lab-inbox-agent/src/adminHtml.ts` and keeps the project portable: anyone can open the dashboard in a browser and inspect it.
+
+### 3. SSE for live updates, not WebSocket
+
+A monitoring feed is one-way push — server to browser. SSE runs over plain HTTP, works through every proxy without configuration, and the browser's `EventSource` reconnects automatically. No need for WebSocket's bidirectional complexity.
+
+Three event types on the bus:
+- `inbox_created` — a new inbox appeared
+- `message_received` — new email arrived (triggered dashboard refresh + unread badge update)
+- `message_status` — read/archive/delete flipped (triggered dashboard refresh)
+
+### 4. `body.recording` CSS class for the YouTube-friendly view
+
+A single class flip on `<body>` makes the demo presentable on screen:
+- Type enlarges (15px → 16px body, 13px → 15px inbox rows)
+- Debug controls hide (`#trigger-btn`, the "+ Add inbox" form)
+- A neutral banner appears explaining the recording view
+
+Toggle button is the top-right "Recording view" / "Exit recording view" link.
+
+### 5. Ed25519 verification uses `tweetnacl`
+
+The Telnyx CLI returns the public key in raw base64 form. We accept three forms:
+- Raw base64 (32 bytes) — the Telnyx CLI default
+- Raw hex (64 chars) — common in some tools
+- PEM-encoded `-----BEGIN PUBLIC KEY-----` — for users who converted it
+
+We use `nacl.sign.detached.verify(message, signature, publicKey)` over the message bytes `<timestamp>.<rawBody>`. The timestamp tolerance is ±300s (5 min) by default.
+
+In `DEMO_MODE=true`, signature verification is bypassed so the manual trigger and unsigned local tests work. In `DEMO_MODE=false`, an unsigned or tampered webhook returns 401.
+
+### 6. Raw body capture on the webhook route
+
+Express's body-parsing middleware consumes the request body — but Ed25519 verification requires the **exact bytes** Telnyx sent, not a re-serialized JSON object. So:
+
+- We do NOT register `app.use(express.json())` globally
+- The webhook route uses `express.raw({ type: "*/*", limit: "2mb" })` to capture bytes
+- Other routes that need a parsed JSON body register `express.json()` locally
+
+This is the only non-obvious middleware ordering in the project. The PRD's troubleshooting section calls it out.
+
+### 7. SQLite for the local cache
+
+`better-sqlite3` is synchronous, embedded, and has zero migrations framework overhead. The schema is three tables (`inboxes`, `messages`, `events`) created idempotently on first run via `CREATE TABLE IF NOT EXISTS`. No drizzle, no prisma, no knex.
+
+The `events` table is a per-message timeline (queued → received → read → archived) that's currently just appended to but ready for the v2 follow-on that renders delivery chips in the UI.
+
+### 8. The dashboard SSE client reconnects on error
+
+`EventSource.onerror` triggers a `setTimeout(connectSSE, 2000)` reconnect. This handles transient network blips, server restarts, and SSE connection drops without crashing the dashboard. There's no exponential backoff — for a local demo the simplicity is worth more than the resilience.
+
+## Gotchas
+
+### Express body parsing order
+
+If `app.use(express.json())` runs before the webhook route, the raw body is already consumed and `req.body` is a parsed object, not a Buffer. `Buffer.isBuffer(req.body)` will be `false` and verification will silently always pass — but `payload.data.payload.inbox_id` will be undefined because the JSON wasn't reparsed.
+
+**Fix**: don't register global JSON parsing. Use per-route `express.json()` where needed.
+
+### The dashboard's SSE consumer can race with creation
+
+When the user creates an inbox via `POST /api/inboxes`, the server broadcasts `inbox_created` AND returns the new row in the HTTP response. The dashboard's submit handler reloads the inbox list from the API — but it also has an `inbox_created` listener. If the SSE message arrives first, the dashboard re-renders; if the HTTP response arrives first, the same thing happens. Either order works.
+
+### `tweetnacl`'s public key vs Node's crypto
+
+`tweetnacl` takes raw 32-byte keys, not the PEM-wrapped X.509 SubjectPublicKeyInfo format. PEM blocks must be stripped to the base64 body, decoded to raw bytes, and verified as 32 bytes exactly. The Telnyx CLI returns the raw base64 form which is what `nacl.sign.keyPair.fromSecretKey` and friends accept.
+
+### The `received_at` field is set in three places
+
+The `messages.received_at` column needs a Unix-ms timestamp. The seeder and the webhook handler both set it explicitly because `payloadToMessageFields` doesn't return it (it's not in the Telnyx payload — we use `Date.now()` at insertion time instead).
+
+### DEMO seeder's `queueMicrotask`
+
+The seeder calls `queueMicrotask(() => this.tick())` once on `start()` so the dashboard isn't empty on first load even if the interval hasn't fired. The interval is `unref()`'d so it doesn't keep the process alive if the server stops cleanly.
+
+## Why not Edge Compute?
+
+`omni-channel-lab-inbox-agent` runs on Telnyx Edge Compute (Agent SDK + Stateful Actor). This demo doesn't, because:
+
+1. The scope is narrower — no per-customer actor state, no cross-channel inbox, no AI assistant
+2. A local Express server is faster to run, easier to inspect, and doesn't require `telnyx-edge ship` to redeploy during dev
+3. The dashboard uses Server-Sent Events, which is simpler to set up against a long-running HTTP server than against Edge Compute's request/response model
+
+For a single-channel focused inbox demo, local Express is the right tool.
+
+## What goes where in a v2 follow-on
+
+| v2 | Where |
+|---|---|
+| Attachments download | `GET /api/messages/:id/attachments/:attachmentId` → proxy to Telnyx Storage with a fresh signed URL |
+| Reply | `POST /api/messages/:id/reply` → calls `POST /v2/email_messages` with `In-Reply-To` / `References` |
+| Threading | Group `messages` by `thread_id` in the dashboard's left pane |
+| Delivery events | Extend the webhook registration + `events` table to track `email.delivered`, `email.opened`, `email.clicked` |
+| Operator auth | Replace the unauthenticated API surface with bearer-token middleware (or pass the dashboard through the local Edge Compute runner's existing pattern) |
+
+## How to extend
+
+To add a new endpoint:
+
+1. Add a handler to `src/server.ts` with explicit `express.json()` or `express.raw()` middleware where needed
+2. If it changes UI state, call `broadcast(eventName, data)` so connected dashboards update live
+3. If it changes persistent state, use the `InboxDb` methods — never call the DB directly
+
+To add a new dashboard panel:
+
+1. Edit `src/dashboard.ts` — add a `<section class="pane">` in `.layout`
+2. Add a route in `src/server.ts` that returns the data
+3. Add a `fetchJson` call in the inline JS that renders the panel
+4. Test in DEMO_MODE first (no credentials), then live mode

--- a/email-inbox-demo/PRD.md
+++ b/email-inbox-demo/PRD.md
@@ -1,0 +1,190 @@
+# PRD: Email Inbox Demo — TRUST-286
+
+## Document Control
+
+- Owner: Telnyx DevRel
+- Linear: [TRUST-286 — Email Inbox Demo](https://linear.app/telnyx/issue/TRUST-286/email-inbox-demo)
+- Reviewer: Stephen Malito
+- Status: Built — pending review
+- Created: 2026-09-10
+- Target build: TypeScript on local Node.js (Express + better-sqlite3 + vanilla HTML)
+
+## 1. Summary
+
+A focused web demo of the **inbound** side of the Telnyx Email API. Create inboxes on verified domains with `inbound_enabled`, receive `email.received` webhooks (Ed25519-signed), list and read messages in a three-pane inbox UI. Live updates over Server-Sent Events. The recording target for the TRUST team's YouTube demo (TRUST-286).
+
+This is a sub-feature of the broader Email API release (August 28 2026 GA) and a focused, standalone companion to the `omni-channel-lab-inbox-agent` demo, which mixes email with fax / voice / SMS / appointments.
+
+## 2. Personas
+
+| Persona | Role |
+|---|---|
+| **Demo viewer** (YouTube audience) | Watches the presenter click around — adds an inbox, sees inbound arrive live, opens a message, archives it |
+| **Presenter (Harpreet)** | Records the demo against the running app; flips to "recording view" for a clean screen capture |
+| **Real user** (post-demo) | Clones the repo, runs `npm start` in DEMO_MODE in under a minute, explores the UI without needing a Telnyx account |
+
+## 3. User-visible flow
+
+1. Open `http://localhost:8788` — dashboard renders with a seeded demo inbox
+2. Toggle **Recording view** (top right) — type enlarges, debug controls hide, demo banner shows
+3. Click **Trigger inbound** — a realistic email arrives: Stripe receipt, GitHub 2FA code, meeting notes — randomized; the message list updates live, the reader opens automatically
+4. Click another message — reader renders the HTML body in a sandboxed iframe with a plain-text toggle; Archive / Delete buttons appear; the message is marked as read
+5. Click **+ Add inbox** — create a new inbox (DEMO_MODE creates a synthetic one locally; live mode calls `POST /v2/email_inboxes`)
+6. Click into the new inbox — independent message list; the sidebar shows unread badges updating live
+
+## 4. Architecture
+
+```
+  External sender                    Telnyx Email API                  Dashboard (Express)
+        │                                  │                                  │
+        │ SMTP → MX                        │                                  │
+        ▼                                  │                                  │
+   ┌──────────────────┐                    │                                  │
+   │ Telnyx inbound   │                    │                                  │
+   │ (verified domain)│                    │                                  │
+   └────────┬─────────┘                    │                                  │
+            │ email.received webhook       │                                  │
+            ▼                              │                                  │
+   ┌──────────────────────────────┐ POST /webhooks/email                  │
+   │ Local Express server         │ ─────────────────────▶ ┌────────────┐ │
+   │ • verify Ed25519 signature  │                          │ SQLite     │ │
+   │ • extract message_id        │                          │ cache      │ │
+   │ • store in local SQLite     │ ◀─── SSE events ────── │ + events   │ │
+   │ • append to event timeline  │                          └─────┬──────┘ │
+   └──────────────────────────────┘                                │       │
+                                                                   ▼       │
+                                                            ┌──────────────┐
+                                                            │ 3-pane HTML  │
+                                                            │ dashboard    │
+                                                            │ + recording  │
+                                                            │ view         │
+                                                            └──────────────┘
+```
+
+### Components
+
+| Component | Technology | Role |
+|---|---|---|
+| Web server | Express on Node 22+ | Routes, SSE bus, webhook receiver |
+| Cache | better-sqlite3 | Local store of inboxes, messages, events |
+| Telnyx SDK | `telnyx` Node v7.20+ | `POST /v2/email_inboxes` (live mode) |
+| Webhook verify | `tweetnacl` | Ed25519 over `telnyx-signature-ed25519` + `telnyx-timestamp` |
+| Dashboard | Self-contained HTML/CSS/JS | 3-pane inbox UI; SSE for live updates |
+| Demo seeder | Background interval | Synthesizes realistic inbound for DEMO_MODE |
+
+## 5. Data Model
+
+```sql
+CREATE TABLE inboxes (
+  id              TEXT PRIMARY KEY,
+  email_address   TEXT NOT NULL UNIQUE,
+  display_name    TEXT,
+  domain_id       TEXT NOT NULL,
+  inbound_enabled INTEGER NOT NULL DEFAULT 1,
+  status          TEXT NOT NULL DEFAULT 'active',
+  source          TEXT NOT NULL DEFAULT 'demo',  -- 'demo' | 'telnyx'
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL
+);
+
+CREATE TABLE messages (
+  id               TEXT PRIMARY KEY,
+  inbox_id         TEXT NOT NULL REFERENCES inboxes(id) ON DELETE CASCADE,
+  telnyx_id        TEXT,
+  thread_id        TEXT,
+  from_address     TEXT NOT NULL,
+  from_name        TEXT,
+  to_addresses     TEXT NOT NULL,
+  cc_addresses     TEXT,
+  subject          TEXT,
+  preview          TEXT,
+  body_html        TEXT,
+  body_text        TEXT,
+  headers_json     TEXT,
+  attachments_json TEXT,
+  status           TEXT NOT NULL DEFAULT 'received',  -- 'received' | 'read' | 'archived' | 'deleted'
+  received_at      INTEGER NOT NULL,
+  read_at          INTEGER
+);
+
+CREATE TABLE events (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  inbox_id   TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  kind       TEXT NOT NULL,
+  detail     TEXT,
+  ts         INTEGER NOT NULL
+);
+```
+
+## 6. Functional Requirements
+
+| ID | Requirement | Priority | Acceptance Criteria |
+|---|---|---|---|
+| FR-1 | List inboxes | Must | `GET /api/inboxes` returns the inbox list with unread counts |
+| FR-2 | Create inbox (live) | Must | `POST /api/inboxes` with credentials calls `POST /v2/email_inboxes` with `inbound_enabled: true`; returns the new row |
+| FR-3 | Create inbox (demo) | Must | `POST /api/inboxes` without credentials creates a synthetic inbox locally |
+| FR-4 | List messages | Must | `GET /api/inboxes/:id/messages?status=received` returns message list, newest first |
+| FR-5 | Retrieve message | Must | `GET /api/messages/:id` returns full row including HTML + text bodies and headers |
+| FR-6 | Mark read | Must | `POST /api/messages/:id/read` flips status and sets `read_at`; SSE broadcast |
+| FR-7 | Archive | Should | `POST /api/messages/:id/archive` flips status; SSE broadcast |
+| FR-8 | Delete (soft) | Should | `POST /api/messages/:id/delete` flips status; SSE broadcast |
+| FR-9 | Live webhook receiver | Must | `POST /webhooks/email` verifies Ed25519 signature, extracts payload, stores message, broadcasts SSE |
+| FR-10 | DEMO_MODE seeder | Must | Background timer injects one realistic inbound every `DEMO_SEED_INTERVAL_MS` (default 15s) into one of the demo inboxes |
+| FR-11 | Manual trigger | Should | `POST /api/demo/trigger` with `{inbox_id}` injects one inbound on demand (debug button) |
+| FR-12 | SSE event bus | Must | `GET /api/events` streams `inbox_created`, `message_received`, `message_status` events to connected dashboards |
+| FR-13 | Recording view | Should | `body.recording` class enlarges type, hides debug controls, shows demo banner; toggled by top-bar button |
+| FR-14 | Ed25519 verify | Must | All `email.received` webhooks in live mode verify against `TELNYX_PUBLIC_KEY`; bypass only in DEMO_MODE for the manual trigger |
+
+## 7. Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/` | Dashboard HTML |
+| `GET` | `/health` | Liveness |
+| `GET` | `/api/inboxes` | List inboxes |
+| `POST` | `/api/inboxes` | Create inbox (live or demo) |
+| `DELETE` | `/api/inboxes/:id` | Delete inbox + cascade messages |
+| `GET` | `/api/inboxes/:id/messages?status=...` | List messages |
+| `GET` | `/api/messages/:id` | Single message |
+| `POST` | `/api/messages/:id/read` | Mark read |
+| `POST` | `/api/messages/:id/archive` | Archive |
+| `POST` | `/api/messages/:id/delete` | Soft-delete |
+| `GET` | `/api/events` | SSE stream |
+| `POST` | `/webhooks/email` | Telnyx `email.received` receiver (Ed25519) |
+| `POST` | `/api/demo/trigger` | DEMO_MODE only — inject one synthetic inbound |
+
+## 8. Environment Variables
+
+See README.md "Environment Variables" section.
+
+## 9. Acceptance Criteria
+
+- [x] DEMO_MODE runs end-to-end with no Telnyx credentials
+- [x] Dashboard renders at `http://localhost:8788`
+- [x] DEMO seeder injects realistic inbound on a timer
+- [x] Trigger button injects one inbound on demand
+- [x] Creating a new inbox adds it to the sidebar live (SSE)
+- [x] Clicking a message opens the reader, marks it read, renders HTML + text bodies
+- [x] Ed25519 signature verification accepts valid signatures, rejects tampered bodies and stale timestamps
+- [x] 5 smoke tests pass (`npm test`)
+- [x] `npm run typecheck` and `npm run build` pass clean
+- [x] Recording view enlarges type and hides debug controls
+
+## 10. Out of Scope
+
+- Sending outbound email (covered by `ai-email-agent-python`, `POST /v2/email_messages`)
+- AI-drafted replies (covered by `ai-email-agent-python`)
+- Cross-channel inbox (covered by `omni-channel-lab-inbox-agent`)
+- Production operator authentication
+- Threading / conversation grouping beyond simple `thread_id` column
+- Attachments download (UI shows attachments list; download is a v2 follow-on)
+- Templates / Liquid rendering (send-side only)
+
+## 11. References
+
+- Linear TRUST-286: https://linear.app/telnyx/issue/TRUST-286/email-inbox-demo
+- Email API GA release notes: https://telnyx.com/release-notes/email-api-now-generally-available
+- Email API quickstart: https://developers.telnyx.com/docs/messaging/email/quickstart
+- Email API API reference: https://developers.telnyx.com/api-reference/email-messages/create-or-send-an-email-message
+- omni-channel-lab-inbox-agent: https://github.com/team-telnyx/telnyx-code-examples/tree/main/omni-channel-lab-inbox-agent

--- a/email-inbox-demo/README.md
+++ b/email-inbox-demo/README.md
@@ -1,0 +1,201 @@
+---
+name: email-inbox-demo
+title: "Email Inbox Demo with Telnyx Email API"
+description: "A focused inbound-email demo for the Telnyx Email API. Create inboxes on verified domains, receive messages through email.received webhooks, list and read them, and watch the UI update live. DEMO_MODE injects realistic inbound so the UI feels alive without a real account or ngrok."
+language: nodejs
+framework: express
+telnyx_products: [Email API]
+---
+
+# Email Inbox Demo
+
+A self-contained inbound-email dashboard for the **Telnyx Email API**. Create inboxes on verified domains with `inbound_enabled`, receive messages through `email.received` webhooks (Ed25519-signed), and read them in a clean three-pane UI — folders, message list, reader — with live Server-Sent Events so new mail appears without a refresh.
+
+Built for the TRUST-286 demo. **DEMO_MODE** runs the full pipeline without Telnyx credentials: a background seeder injects realistic inbound (Stripe receipts, GitHub notifications, customer follow-ups, two-factor codes, meeting notes) on a timer so the UI feels alive on first open.
+
+## Why Telnyx
+
+Telnyx is **AI Communications Infrastructure** — voice, messaging, fax, email, and AI inference on one private global network. The Email API adds inbound as a first-class channel: create inboxes on verified domains, receive `email.received` webhooks with Ed25519 signatures, list and read messages via REST. No SMTP plumbing, no DNS MX records to maintain, no separate SDK — one platform, one API key.
+
+## Telnyx API Endpoints Used
+
+- `POST /v2/email_inboxes` — create inbox with `inbound_enabled: true` on a verified domain
+- `GET /v2/email_inboxes` — list inboxes
+- `GET /v2/email_inboxes/{id}/messages` — list messages in an inbox
+- `GET /v2/emails/{id}` — retrieve a single message (HTML + text body, headers, attachments)
+- `POST /v2/email_domains/{domain_id}/webhooks` — register webhook URL for `email.received` and delivery events
+- `email.received` webhook (Ed25519-signed) — fires when a new message arrives
+
+> **Three domain paths** (see the [Email API quickstart](https://developers.telnyx.com/docs/messaging/email/quickstart) for the full list):
+> 1. `shared_inbound` (RECOMMENDED for the demo — no DNS needed): pass `"domain": "shared_inbound"` (or any string name) to `POST /v2/email_inboxes` and Telnyx auto-provisions the inbox on a managed subdomain.
+> 2. **Shared sandbox** (`mail.telnyx.com`, `msgtelnyx.com`): from-address must be `onboarding@<domain>`; recipients must be on your Telnyx account.
+> 3. **Custom verified domain**: bring your own domain, publish DNS records (MX/SPF/DKIM/DMARC), verify, then create inboxes.
+
+## Telnyx Webhook Events
+
+The dashboard listens for `email.received` (Ed25519-signed via the `telnyx-signature-ed25519` and `telnyx-timestamp` headers) and emits a live `message_received` Server-Sent Event so the UI updates without polling. Additional events (`email.delivered`, `email.opened`, `email.clicked`, `email.bounced`, `email.failed`) can be subscribed to by extending the webhook registration.
+
+## Architecture
+
+```
+  External sender                    Telnyx Email API                  Dashboard (Express)
+        │                                  │                                  │
+        │ SMTP → MX                        │                                  │
+        ▼                                  │                                  │
+   ┌──────────────────┐                    │                                  │
+   │ Telnyx inbound   │                    │                                  │
+   │ (verified domain)│                    │                                  │
+   └────────┬─────────┘                    │                                  │
+            │ email.received webhook       │                                  │
+            ▼                              │                                  │
+   ┌──────────────────────────────┐ POST /webhooks/email                  │
+   │ Local Express server         │ ─────────────────────▶ ┌────────────┐ │
+   │ • verify Ed25519 signature  │                          │ SQLite     │ │
+   │ • extract message_id        │                          │ cache      │ │
+   │ • store in local SQLite     │ ◀─── SSE events ────── │ + events   │ │
+   │ • append to event timeline  │                          └─────┬──────┘ │
+   └──────────────────────────────┘                                │       │
+                                                                   ▼       │
+                                                            ┌──────────────┐
+                                                            │ 3-pane HTML  │
+                                                            │ dashboard    │
+                                                            │ + recording  │
+                                                            │ view         │
+                                                            └──────────────┘
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DEMO_MODE` | no (default `true`) | If `true`, runs without Telnyx credentials and seeds fake inbound on a timer |
+| `PORT` | no (default `8788`) | Local server port |
+| `HOST` | no (default `127.0.0.1`) | Bind host |
+| `EMAIL_INBOX_DB` | no (default `.data/inbox.sqlite`) | Local SQLite cache path |
+| `DEMO_SEED_INTERVAL_MS` | no (default `15000`) | How often the seeder injects a fake inbound |
+| `TELNYX_API_KEY` | yes (live mode) | Telnyx v2 API key — `Portal → API Keys` |
+| `TELNYX_PUBLIC_KEY` | yes (live mode) | Ed25519 webhook verification key — base64 or PEM |
+| `TELNYX_PUBLIC_BASE_URL` | yes (live mode) | Public HTTPS URL of this server (ngrok / cloudflared) |
+
+## Setup
+
+```bash
+# Clone
+git clone https://github.com/team-telnyx/telnyx-code-examples.git
+cd telnyx-code-examples/email-inbox-demo
+
+# Install
+npm install
+
+# Run in DEMO_MODE — no credentials needed
+npm start
+# → http://localhost:8788
+# → Dashboard shows a seeded inbox "support@telnyx-demo.msgtelnyx.com"
+# → Every 15s a realistic inbound arrives via the background seeder
+```
+
+### Live mode (real Telnyx Email API)
+
+```bash
+# 1. Create an inbox on the shared_inbound domain (no DNS needed)
+export TELNYX_API_KEY="KEY..."
+curl -s -X POST "https://api.telnyx.com/v2/email_inboxes" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Email Inbox Demo", "domain": "shared_inbound"}'
+# → {"data": {"id": "...", "email_address": "inbox-xxxx@yoursubdomain.msgtelnyx.com", ...}}
+
+# 2. Get your webhook signing public key
+export TELNYX_PUBLIC_KEY=$(curl -s -H "Authorization: Bearer $TELNYX_API_KEY" \
+  https://api.telnyx.com/v2/public_key | jq -r '.data.public')
+
+# 3. Expose the local server
+ngrok http 8788
+export TELNYX_PUBLIC_BASE_URL="https://your-tunnel.ngrok.app"
+
+# 4. Wire the webhook on the inbox's domain
+curl -s -X POST "https://api.telnyx.com/v2/email_domains/<domain_id>/webhooks" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"url\": \"$TELNYX_PUBLIC_BASE_URL/webhooks/email\", \"events\": [\"email.received\", \"email.delivered\", \"email.opened\", \"email.clicked\", \"email.bounced\", \"email.failed\"]}"
+
+# 5. Configure the app
+cat > .env <<EOF
+DEMO_MODE=false
+TELNYX_API_KEY=$TELNYX_API_KEY
+TELNYX_PUBLIC_KEY=$TELNYX_PUBLIC_KEY
+TELNYX_PUBLIC_BASE_URL=$TELNYX_PUBLIC_BASE_URL
+EOF
+
+# 6. Run
+npm start
+# → Visit http://localhost:8788, click "+ Add inbox", send any email to your inbox address.
+```
+
+## Demo flow (for the YouTube recording)
+
+1. **Show the empty state (15s)** — open `http://localhost:8788`. The dashboard renders with one seeded demo inbox. The message list is empty. Narration: *"This is a focused look at the inbound side of the Telnyx Email API. No outbound, no AI — just receive, list, and read."*
+2. **Click "Recording view" (10s)** — top right. Type enlarges, debug controls hide. *"For the recording I switch to a presentation-friendly layout."*
+3. **Click "Trigger inbound" (60s)** — top right. A realistic email arrives: Stripe receipt, GitHub two-factor code, meeting notes — randomized each click. The toast flashes, the message appears in the list, the reader opens automatically. *"The seeder injects realistic inbound so the demo works without a real inbox or ngrok. The rendering path is the same code that handles real `email.received` webhooks — only the source differs."*
+4. **Click another message (15s)** — the reader renders the full HTML body in a sandboxed iframe, with a toggle to plain text. Archive / Delete buttons appear. *"Reading the message opens it, marks it as read, and renders the HTML body safely."*
+5. **Click "+ Add inbox" (30s)** — type a username + subdomain, hit submit. A second inbox appears in the sidebar with its own message stream. *"Creating an inbox is one API call — `POST /v2/email_inboxes` with `inbound_enabled: true`. In live mode this creates a real inbox on the shared_inbound subdomain."*
+6. **Click into the new inbox, trigger more (30s)** — show independent message lists per inbox, the unread badges in the sidebar updating live. *"Each inbox is independent. Messages stream in via Server-Sent Events so the UI updates the moment a webhook fires."*
+7. **Outro (15s)** — *"Inbound email on the Telnyx Email API: one platform, one API key, one signed webhook. Clone it and run it in DEMO_MODE in under a minute."*
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/server.ts` | Express server, SSE bus, route wiring, webhook receiver |
+| `src/db.ts` | `better-sqlite3` cache for inboxes + messages + events |
+| `src/dashboard.ts` | Self-contained 3-pane HTML dashboard export |
+| `src/telnyxClient.ts` | `telnyx` Node SDK wrappers + payload mapper |
+| `src/webhookVerify.ts` | Ed25519 signature verification (`tweetnacl`) |
+| `src/demoSeeder.ts` | Background fake-inbound generator for DEMO_MODE |
+| `src/types.ts` | Row types + Telnyx payload shapes |
+| `tests/smoke.test.ts` | 5 smoke tests — DB CRUD, seeder, payload mapping, Ed25519 verify |
+| `.env.example` | All configuration knobs with defaults |
+
+## Notes
+
+- **The dashboard runs without any npm frontend tooling** — vanilla HTML/CSS/JS, single self-contained file. Same pattern as the `omni-channel-lab-inbox-agent` admin UI.
+- **Ed25519 verification** uses `tweetnacl`. The public key can be either a PEM block or a raw base64/hex 32-byte string. Telnyx's `GET /v2/public_key` returns the raw base64 form.
+- **The DEMO_MODE seeder** synthesizes the exact `email.received` payload shape Telnyx would send, then routes it through the same storage + SSE pipeline. Switching to live mode (by setting `DEMO_MODE=false` and the three Telnyx env vars) flips the input source without changing the rendering path.
+- **Recording view** is a `body.recording` CSS class — type enlarges, debug controls hide, demo banner appears. Toggle with the top-right button.
+- **Trigger inbound** is hidden in recording view — it's a debug surface only.
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `npm install` fails on `@types/tweetnacl` | That package doesn't exist | Removed — `tweetnacl` ships its own types |
+| Dashboard loads but no messages appear | DEMO_MODE seeder hasn't fired yet | Wait 15s, or click "Trigger inbound" in the top bar |
+| `401 invalid signature` on webhook | `TELNYX_PUBLIC_KEY` doesn't match the webhook signing key | Re-fetch via `GET /v2/public_key` and update `.env` |
+| `502 Bad Gateway` on inbox creation | Telnyx API rejected the request | Check `TELNYX_API_KEY`, `EMAIL_SENDING_DOMAIN`, or domain verification status |
+| Webhook never fires | Public URL not reachable from Telnyx | Confirm `ngrok`/`cloudflared` is running and `TELNYX_PUBLIC_BASE_URL` matches |
+| Messages show but reader is blank | HTML body is empty | Toggle the "Plain text" disclosure under the iframe |
+
+## Related Examples
+
+- [omni-channel-lab-inbox-agent (TypeScript, Edge Compute)](https://github.com/team-telnyx/telnyx-code-examples/tree/main/omni-channel-lab-inbox-agent) — full lab-result workflow across fax, voice, SMS, email
+- [ai-email-agent-python (Python, Flask)](https://github.com/team-telnyx/telnyx-code-examples/tree/main/ai-email-agent-python) — AI-drafted email reply bot
+- [ai-voice-memo-to-email-python (Python, Flask)](https://github.com/team-telnyx/telnyx-code-examples/tree/main/ai-voice-memo-to-email-python) — phone call → formatted email
+- [Edge Cron Scheduler (TypeScript, Agent SDK)](https://github.com/team-telnyx/telnyx-code-examples/tree/main/edge-cron-scheduler) — durable job runner with auth-gated dashboard (the pattern this dashboard mirrors)
+
+## References
+
+- [Email API quickstart](https://developers.telnyx.com/docs/messaging/email/quickstart)
+- [Email API API reference](https://developers.telnyx.com/api-reference/email-messages/create-or-send-an-email-message)
+- [Email API GA release notes](https://telnyx.com/release-notes/email-api-now-generally-available)
+- [Telnyx Node SDK](https://github.com/team-telnyx/telnyx-node)
+- [Telnyx Developer Docs](https://developers.telnyx.com)
+
+## Agent Discovery
+
+- **Sign up**: [telnyx.com/sign-up](https://telnyx.com/sign-up)
+- **Agent CLI**: [github.com/team-telnyx/ai/tree/main/cli](https://github.com/team-telnyx/ai/tree/main/cli)
+- **Agent skills**: [github.com/team-telnyx/ai/tree/main/skills](https://github.com/team-telnyx/ai/tree/main/skills)
+- **LLM-friendly docs**: [developers.telnyx.com/llms-full.txt](https://developers.telnyx.com/llms-full.txt) · [llms.txt](https://raw.githubusercontent.com/team-telnyx/telnyx-code-examples/main/llms.txt)
+- **Telnyx CLI** (human + agent): [developers.telnyx.com/docs/development/cli](https://developers.telnyx.com/docs/development/cli)

--- a/email-inbox-demo/package-lock.json
+++ b/email-inbox-demo/package-lock.json
@@ -1,0 +1,1899 @@
+{
+  "name": "email-inbox-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "email-inbox-demo",
+      "version": "1.0.0",
+      "dependencies": {
+        "@telnyx/edge-runtime": "0.15.2",
+        "better-sqlite3": "11.7.0",
+        "dotenv": "16.4.7",
+        "express": "4.21.2",
+        "telnyx": "7.20.0",
+        "tweetnacl": "1.0.3"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "7.6.12",
+        "@types/express": "4.17.21",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1001.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1001.0.tgz",
+      "integrity": "sha512-6uTniZc87q+B5eXouGTl+7Tmc482rEeCcvxpsvREP8EfF0gvloRZ41UOA9sbSJlyy8TbqIBXb3kKfKarEArUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1129.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1129.0.tgz",
+      "integrity": "sha512-TwbRTrAGwtFFUQ/jozsj9Jyjy+UjIsfSKaNs/tQfggIWFbk1Mim+IWjZ//IOz97Wc5Q/z/6G4cb5znYUXHKxHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1001.0",
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/credential-provider-node": "^3.972.83",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.76",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.978.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
+      "integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
+      "integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
+      "integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
+      "integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-login": "^3.972.78",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
+      "integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.83",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
+      "integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-ini": "^3.973.16",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
+      "integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
+      "integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/token-providers": "3.1129.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
+      "integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.76.tgz",
+      "integrity": "sha512-NfnTkVUTBKTBuBgqaapFK9r3YdkKt1b2oRvgLzZq91bwNKh6ZS0S7sEcheguttREaL4iyfs/xQnqD7Z7AsWSsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
+      "integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1129.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
+      "integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@telnyx/edge-runtime": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@telnyx/edge-runtime/-/edge-runtime-0.15.2.tgz",
+      "integrity": "sha512-Boufv1GoS/5qbqN443UzSrmyP4usNf2yeRyDmVgUM3PEkZEkMM++6TeamwW7JZP+rvTHVaeyoHgS3owg2ifvng==",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1083.0",
+        "@types/ws": "^8.18.0",
+        "superjson": "^2.2.6",
+        "telnyx": "*",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.12",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.12.tgz",
+      "integrity": "sha512-fnQmj8lELIj7BSrZQAdBMHEHX8OZLYIHXqAKT1O7tDfLxaINzf00PMjw22r3N/xXh0w/sGHlO6SVaCQ2mj78lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.0.tgz",
+      "integrity": "sha512-mXpa5jnIKKHeoGzBrUJrc65cXFKcILGZpU3FXR0pradUEm9MA7UZz02qfEejaMcm9iXrSOCenwwYMJ/tZ1y5Ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.1.0.tgz",
+      "integrity": "sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/telnyx": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/telnyx/-/telnyx-7.20.0.tgz",
+      "integrity": "sha512-Y+M9h8I9cvd/Zv/RzgrWnQX22VJx8+oClwGtsxvwr3lfkA+Gl0XutwuDmKhuIzTcyrpkf/qCdC2kjPYARqXrqw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "^8.18.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/email-inbox-demo/package.json
+++ b/email-inbox-demo/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "email-inbox-demo",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "A focused inbound-email demo for the Telnyx Email API. Create inboxes on verified domains, receive messages through email.received webhooks, list and read them, and watch the UI update live. Includes a DEMO_MODE that simulates realistic inbound so the UI feels alive without a real inbox or ngrok.",
+  "engines": {
+    "node": ">=22.13"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "dev": "npm run build && node --env-file-if-exists=.env dist/src/server.js",
+    "start": "npm run dev",
+    "test": "npm run build && node --test dist/tests/*.test.js"
+  },
+  "dependencies": {
+    "@telnyx/edge-runtime": "0.15.2",
+    "better-sqlite3": "11.7.0",
+    "dotenv": "16.4.7",
+    "express": "4.21.2",
+    "telnyx": "7.20.0",
+    "tweetnacl": "1.0.3"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "7.6.12",
+    "@types/express": "4.17.21",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/email-inbox-demo/src/dashboard.ts
+++ b/email-inbox-demo/src/dashboard.ts
@@ -1,0 +1,639 @@
+/**
+ * Email Inbox Demo — dashboard HTML.
+ *
+ * 3-pane layout, vanilla HTML/JS, SSE for live inbound updates.
+ *
+ *   ┌──────────────┬──────────────────────────┬──────────────────────────┐
+ *   │ Inboxes       │ Message list              │ Reader                   │
+ *   │ ─────────     │ ─────────────             │ ─────────                │
+ *   │ • Acme        │ ● Priya — Re: Order …     │ From: priya@…            │
+ *   │   3 unread    │   2 min ago               │ Subject: Re: Order…      │
+ *   │ • Cloud       │ ○ Stripe — Invoice INV…   │                          │
+ *   │   12 unread   │   1 hour ago              │ [HTML body renders here] │
+ *   │               │ ○ GitHub — Two-factor…    │                          │
+ *   │ + New inbox   │   yesterday              │ Reply (v2)               │
+ *   └──────────────┴──────────────────────────┴──────────────────────────┘
+ *
+ * Recording view: a `.recording` class on the body enlarges type, hides the
+ * "Trigger inbound" debug button, and shows a Telnyx-style demo banner.
+ */
+export function dashboard(opts: {
+  demoMode: boolean;
+  hasTelnyxCreds: boolean;
+  apiBase: string;
+}): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Email Inbox · Telnyx</title>
+<style>
+  :root {
+    --ink: #0b1414;
+    --ink-muted: #5b6663;
+    --line: #e2e8e4;
+    --paper: #f7f8f6;
+    --green: #00E3AA;
+    --green-deep: #00B98B;
+    --tan: #e7e8e0;
+    --red: #cf3a3a;
+    --blue: #3434EF;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  button, input, select, textarea { font: inherit; color: inherit; }
+  button {
+    cursor: pointer;
+    background: var(--ink);
+    color: var(--paper);
+    border: none;
+    border-radius: 8px;
+    padding: 8px 14px;
+    font-weight: 600;
+  }
+  button:hover { background: #2a3434; }
+  button.secondary {
+    background: transparent;
+    color: var(--ink);
+    border: 1px solid var(--line);
+  }
+  button.secondary:hover { background: #eef0ec; }
+  button:disabled { opacity: 0.4; cursor: wait; }
+  input, select {
+    border: 1px solid var(--line);
+    background: #fff;
+    border-radius: 8px;
+    padding: 8px 10px;
+    outline: none;
+  }
+  input:focus, select:focus { border-color: var(--green-deep); box-shadow: 0 0 0 3px rgba(0,185,139,.18); }
+  a { color: var(--green-deep); }
+  a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible {
+    outline: 3px solid var(--green-deep);
+    outline-offset: 2px;
+  }
+
+  .topbar {
+    background: var(--green);
+    color: var(--ink);
+    padding: 14px 22px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid rgba(0,0,0,.1);
+  }
+  .brand { display: flex; align-items: center; gap: 14px; }
+  .brand-mark {
+    width: 32px; height: 32px;
+    background: var(--ink);
+    color: var(--green);
+    border-radius: 8px;
+    display: grid; place-items: center;
+    font-weight: 800; font-size: 13px;
+    letter-spacing: -0.02em;
+  }
+  .brand-title {
+    font-weight: 800;
+    font-size: 16px;
+    letter-spacing: -0.01em;
+  }
+  .brand-sub {
+    font-size: 11px;
+    color: var(--ink-muted);
+    margin-top: -2px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+  .demo-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--ink);
+    color: var(--green);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .demo-pill::before {
+    content: "";
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--green);
+    box-shadow: 0 0 0 3px rgba(0,227,170,.3);
+  }
+  .demo-pill.live { background: var(--green-deep); color: white; }
+  .topbar-right { display: flex; gap: 10px; align-items: center; }
+
+  .layout {
+    display: grid;
+    grid-template-columns: 260px 360px 1fr;
+    height: calc(100vh - 64px);
+    max-width: 1600px;
+    margin: 0 auto;
+    background: #fff;
+    border: 1px solid var(--line);
+    border-top: none;
+  }
+  .pane { overflow-y: auto; border-right: 1px solid var(--line); }
+  .pane:last-child { border-right: none; }
+
+  .pane-header {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fbfcfb;
+  }
+  .pane-header h2 {
+    margin: 0;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-muted);
+  }
+
+  /* ── Inboxes pane ──────────────────────────────────────── */
+  .inbox-list { list-style: none; margin: 0; padding: 8px; }
+  .inbox-row {
+    padding: 12px 14px;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: background .12s;
+    border: 1px solid transparent;
+  }
+  .inbox-row:hover { background: var(--paper); }
+  .inbox-row.selected {
+    background: var(--paper);
+    border-color: var(--line);
+  }
+  .inbox-row .addr {
+    font-weight: 700;
+    font-size: 13px;
+    word-break: break-all;
+  }
+  .inbox-row .meta {
+    font-size: 11px;
+    color: var(--ink-muted);
+    margin-top: 2px;
+    display: flex; justify-content: space-between;
+  }
+  .inbox-row .badge {
+    background: var(--green);
+    color: var(--ink);
+    padding: 1px 6px;
+    border-radius: 6px;
+    font-size: 10px;
+    font-weight: 700;
+  }
+  .new-inbox-form {
+    padding: 12px;
+    border-top: 1px solid var(--line);
+    display: grid;
+    gap: 8px;
+  }
+
+  /* ── Message list pane ─────────────────────────────────── */
+  .msg-list { list-style: none; margin: 0; padding: 0; }
+  .msg-row {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+    transition: background .1s;
+    position: relative;
+  }
+  .msg-row:hover { background: #f6f8f6; }
+  .msg-row.selected { background: var(--paper); border-left: 3px solid var(--green); padding-left: 15px; }
+  .msg-row.unread { background: #fff; }
+  .msg-row.unread::before {
+    content: "";
+    position: absolute;
+    top: 22px; left: 6px;
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--green-deep);
+  }
+  .msg-row .from {
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--ink);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .msg-row .subject {
+    font-size: 13px;
+    color: var(--ink);
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .msg-row.unread .from,
+  .msg-row.unread .subject { font-weight: 700; }
+  .msg-row .preview {
+    font-size: 12px;
+    color: var(--ink-muted);
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .msg-row .time {
+    font-size: 11px;
+    color: var(--ink-muted);
+    position: absolute;
+    top: 14px; right: 18px;
+  }
+  .empty-state {
+    padding: 40px 24px;
+    text-align: center;
+    color: var(--ink-muted);
+    font-size: 13px;
+  }
+  .empty-state strong { color: var(--ink); display: block; font-size: 14px; margin-bottom: 4px; }
+
+  /* ── Reader pane ───────────────────────────────────────── */
+  .reader { padding: 22px 28px; }
+  .reader-empty { padding: 60px 28px; text-align: center; color: var(--ink-muted); }
+  .reader-header { border-bottom: 1px solid var(--line); padding-bottom: 16px; margin-bottom: 18px; }
+  .reader-subject { font-size: 22px; font-weight: 700; line-height: 1.3; margin: 0 0 8px 0; }
+  .reader-meta {
+    display: grid; grid-template-columns: auto 1fr; gap: 4px 12px;
+    font-size: 13px;
+  }
+  .reader-meta dt { color: var(--ink-muted); font-weight: 600; }
+  .reader-meta dd { margin: 0; word-break: break-word; }
+  .reader-actions { margin-top: 14px; display: flex; gap: 8px; flex-wrap: wrap; }
+  .reader-body { padding-top: 16px; line-height: 1.6; }
+  .reader-body iframe {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    min-height: 360px;
+    background: #fff;
+  }
+  .reader-body pre {
+    background: var(--paper);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px;
+    white-space: pre-wrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+
+  /* ── Toast ─────────────────────────────────────────────── */
+  .toast {
+    position: fixed;
+    bottom: 24px; right: 24px;
+    background: var(--ink);
+    color: var(--green);
+    padding: 12px 18px;
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 600;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity .2s, transform .2s;
+    pointer-events: none;
+    z-index: 100;
+  }
+  .toast.show { opacity: 1; transform: translateY(0); }
+  .toast.error { background: var(--red); color: white; }
+
+  /* ── Recording view: enlarge, simplify ─────────────────── */
+  body.recording { background: #fdfdf9; }
+  body.recording .topbar { background: var(--green); }
+  body.recording .layout {
+    height: calc(100vh - 70px);
+    box-shadow: 0 6px 32px rgba(0,0,0,.08);
+    border-radius: 14px;
+    margin: 8px auto;
+    overflow: hidden;
+  }
+  body.recording { font-size: 16px; }
+  body.recording .reader-subject { font-size: 26px; }
+  body.recording .pane-header h2 { font-size: 13px; }
+  body.recording .inbox-row .addr { font-size: 15px; }
+  body.recording .msg-row { padding: 18px 22px; }
+  body.recording .msg-row .from,
+  body.recording .msg-row .subject { font-size: 15px; }
+  body.recording .msg-row .preview { font-size: 14px; }
+  body.recording .new-inbox-form,
+  body.recording .debug-btn { display: none; }
+  body.recording .recording-hint { display: block; }
+  .recording-hint { display: none; padding: 14px 22px; background: var(--tan); color: var(--ink); font-size: 13px; border-bottom: 1px solid var(--line); }
+
+  .debug-btn {
+    background: transparent;
+    border: 1px dashed var(--line);
+    color: var(--ink-muted);
+    padding: 6px 10px;
+    font-size: 11px;
+    font-weight: 600;
+  }
+  .debug-btn:hover { background: var(--paper); color: var(--ink); }
+</style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <div class="brand-mark">Tx</div>
+      <div>
+        <div class="brand-title">Email Inbox</div>
+        <div class="brand-sub">Telnyx Email API · Inbound</div>
+      </div>
+    </div>
+    <div class="topbar-right">
+      ${opts.demoMode
+        ? '<span class="demo-pill">Demo mode</span>'
+        : opts.hasTelnyxCreds
+          ? '<span class="demo-pill live">Live</span>'
+          : '<span class="demo-pill">No credentials</span>'}
+      <button class="secondary" id="recording-toggle" aria-pressed="false">Recording view</button>
+      ${opts.demoMode
+        ? '<button class="debug-btn" id="trigger-btn" title="Inject one simulated inbound now">Trigger inbound</button>'
+        : ""}
+    </div>
+  </header>
+
+  <div class="recording-hint">Recording view: type enlarged, debug controls hidden, demo banner on.</div>
+
+  <main class="layout">
+    <aside class="pane" id="inboxes-pane">
+      <div class="pane-header"><h2>Inboxes</h2><span id="inbox-count" style="font-size:11px;color:var(--ink-muted);"></span></div>
+      <ul class="inbox-list" id="inbox-list"></ul>
+      ${opts.demoMode
+        ? `<form class="new-inbox-form" id="new-inbox-form">
+             <input type="text" id="new-inbox-username" placeholder="username" value="support" />
+             <input type="text" id="new-inbox-domain" placeholder="subdomain" value="telnyx-demo" />
+             <button type="submit">+ Add inbox</button>
+           </form>`
+        : ""}
+    </aside>
+
+    <section class="pane" id="messages-pane">
+      <div class="pane-header">
+        <h2 id="messages-pane-title">Inbox</h2>
+        <select id="status-filter" style="font-size:11px;padding:4px 6px;">
+          <option value="all">All</option>
+          <option value="received">Unread</option>
+          <option value="read">Read</option>
+          <option value="archived">Archived</option>
+        </select>
+      </div>
+      <ul class="msg-list" id="msg-list"></ul>
+    </section>
+
+    <section class="pane" id="reader-pane">
+      <div class="pane-header"><h2>Reader</h2><span id="reader-meta-summary"></span></div>
+      <div id="reader"></div>
+    </section>
+  </main>
+
+  <div class="toast" id="toast"></div>
+
+  <script>
+    const API = ${JSON.stringify(opts.apiBase)};
+    const DEMO_MODE = ${JSON.stringify(opts.demoMode)};
+
+    const state = {
+      inboxes: [],
+      selectedInboxId: null,
+      messages: [],
+      selectedMessageId: null,
+      statusFilter: "all",
+      recording: false,
+    };
+
+    const $ = (id) => document.getElementById(id);
+    const inboxListEl = $("inbox-list");
+    const msgListEl = $("msg-list");
+    const readerEl = $("reader");
+    const inboxCountEl = $("inbox-count");
+    const messagesTitleEl = $("messages-pane-title");
+    const readerSummaryEl = $("reader-meta-summary");
+
+    function toast(text, kind) {
+      const el = $("toast");
+      el.textContent = text;
+      el.className = "toast show" + (kind === "error" ? " error" : "");
+      clearTimeout(toast._t);
+      toast._t = setTimeout(() => { el.className = "toast"; }, 2400);
+    }
+
+    function fmtTime(ts) {
+      const d = new Date(ts);
+      const now = new Date();
+      const diff = (now - d) / 1000;
+      if (diff < 60) return "just now";
+      if (diff < 3600) return Math.floor(diff / 60) + "m ago";
+      if (diff < 86400) return Math.floor(diff / 3600) + "h ago";
+      return d.toLocaleDateString();
+    }
+
+    async function fetchJson(url, opts) {
+      const res = await fetch(url, opts);
+      const ct = res.headers.get("content-type") || "";
+      const body = ct.includes("application/json") ? await res.json() : await res.text();
+      if (!res.ok) throw new Error(typeof body === "string" ? body : (body.error || res.statusText));
+      return body;
+    }
+
+    async function loadInboxes() {
+      state.inboxes = await fetchJson(API + "/api/inboxes");
+      inboxCountEl.textContent = state.inboxes.length + " total";
+      inboxListEl.innerHTML = state.inboxes.length
+        ? state.inboxes.map((ib) => \`
+            <li class="inbox-row \${ib.id === state.selectedInboxId ? "selected" : ""}"
+                data-id="\${ib.id}">
+              <div class="addr">\${ib.email_address}</div>
+              <div class="meta">
+                <span>\${ib.source === "demo" ? "Demo" : "Live"} · \${ib.status}</span>
+                <span class="badge" data-inbox-id="\${ib.id}" data-unread></span>
+              </div>
+            </li>
+          \`).join("")
+        : '<li class="empty-state"><strong>No inboxes yet</strong>Add one to start receiving.</li>';
+      inboxListEl.querySelectorAll(".inbox-row").forEach((row) => {
+        row.addEventListener("click", () => selectInbox(row.dataset.id));
+      });
+      updateUnreadBadges();
+      if (!state.selectedInboxId && state.inboxes.length) selectInbox(state.inboxes[0].id);
+    }
+
+    function updateUnreadBadges() {
+      const counts = {};
+      state.messages.forEach((m) => { if (m.status === "received") counts[m.inbox_id] = (counts[m.inbox_id] || 0) + 1; });
+      document.querySelectorAll("[data-unread]").forEach((el) => {
+        const c = counts[el.dataset.inboxId] || 0;
+        el.textContent = c > 0 ? c + " unread" : "0";
+      });
+    }
+
+    async function selectInbox(id) {
+      state.selectedInboxId = id;
+      const ib = state.inboxes.find((i) => i.id === id);
+      messagesTitleEl.textContent = ib ? ib.email_address : "Inbox";
+      inboxListEl.querySelectorAll(".inbox-row").forEach((row) => {
+        row.classList.toggle("selected", row.dataset.id === id);
+      });
+      await loadMessages();
+    }
+
+    async function loadMessages() {
+      if (!state.selectedInboxId) { state.messages = []; renderMessages(); return; }
+      const statusParam = state.statusFilter === "all" ? "" : "?status=" + state.statusFilter;
+      state.messages = await fetchJson(API + "/api/inboxes/" + state.selectedInboxId + "/messages" + statusParam);
+      renderMessages();
+      updateUnreadBadges();
+    }
+
+    function renderMessages() {
+      const list = state.messages;
+      msgListEl.innerHTML = list.length
+        ? list.map((m) => \`
+            <li class="msg-row \${m.status === "received" ? "unread" : ""} \${m.id === state.selectedMessageId ? "selected" : ""}"
+                data-id="\${m.id}">
+              <div class="from">\${escapeHtml(m.from_name || m.from_address)}</div>
+              <div class="subject">\${escapeHtml(m.subject || "(no subject)")}</div>
+              <div class="preview">\${escapeHtml(m.preview || "")}</div>
+              <div class="time">\${fmtTime(m.received_at)}</div>
+            </li>
+          \`).join("")
+        : '<li class="empty-state"><strong>Inbox empty</strong>' + (DEMO_MODE ? "Trigger an inbound from the top bar." : "Send a message to your inbox address.") + '</li>';
+      msgListEl.querySelectorAll(".msg-row").forEach((row) => {
+        row.addEventListener("click", () => selectMessage(row.dataset.id));
+      });
+    }
+
+    async function selectMessage(id) {
+      state.selectedMessageId = id;
+      msgListEl.querySelectorAll(".msg-row").forEach((row) => {
+        row.classList.toggle("selected", row.dataset.id === id);
+      });
+      const msg = await fetchJson(API + "/api/messages/" + id);
+      renderReader(msg);
+      // Mark read
+      if (msg.status === "received") {
+        await fetchJson(API + "/api/messages/" + id + "/read", { method: "POST" });
+        msg.status = "read";
+        loadMessages();
+      }
+    }
+
+    function renderReader(msg) {
+      readerSummaryEl.textContent = msg.status;
+      readerEl.innerHTML = msg.body_html
+        ? \`<div class="reader">
+             <div class="reader-header">
+               <h1 class="reader-subject">\${escapeHtml(msg.subject || "(no subject)")}</h1>
+               <dl class="reader-meta">
+                 <dt>From</dt><dd>\${escapeHtml(msg.from_name || "")} &lt;\${escapeHtml(msg.from_address)}&gt;</dd>
+                 <dt>To</dt><dd>\${escapeHtml(msg.to_addresses)}</dd>
+                 \${msg.cc_addresses ? '<dt>Cc</dt><dd>' + escapeHtml(msg.cc_addresses) + '</dd>' : ''}
+                 <dt>Received</dt><dd>\${new Date(msg.received_at).toLocaleString()}</dd>
+               </dl>
+               <div class="reader-actions">
+                 <button class="secondary" id="archive-btn">Archive</button>
+                 <button class="secondary" id="delete-btn">Delete</button>
+               </div>
+             </div>
+             <div class="reader-body">
+               <iframe sandbox srcdoc="\${escapeAttr(msg.body_html)}"></iframe>
+               \${msg.body_text ? '<details style="margin-top:10px;"><summary style="cursor:pointer;color:var(--ink-muted);font-size:12px;">Plain text</summary><pre>' + escapeHtml(msg.body_text) + '</pre></details>' : ''}
+             </div>
+           </div>\`
+        : \`<div class="reader">
+             <div class="reader-header">
+               <h1 class="reader-subject">\${escapeHtml(msg.subject || "(no subject)")}</h1>
+               <dl class="reader-meta">
+                 <dt>From</dt><dd>\${escapeHtml(msg.from_address)}</dd>
+                 <dt>To</dt><dd>\${escapeHtml(msg.to_addresses)}</dd>
+                 <dt>Received</dt><dd>\${new Date(msg.received_at).toLocaleString()}</dd>
+               </dl>
+             </div>
+             <div class="reader-body"><pre>\${escapeHtml(msg.body_text || "(empty body)")}</pre></div>
+           </div>\`;
+      const arc = $("archive-btn");
+      const del = $("delete-btn");
+      if (arc) arc.onclick = async () => { await fetchJson(API + "/api/messages/" + msg.id + "/archive", { method: "POST" }); toast("Archived"); await loadMessages(); };
+      if (del) del.onclick = async () => { await fetchJson(API + "/api/messages/" + msg.id + "/delete", { method: "POST" }); toast("Deleted"); state.selectedMessageId = null; readerEl.innerHTML = '<div class="reader-empty">Select a message to read it.</div>'; await loadMessages(); };
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+    }
+    function escapeAttr(s) { return escapeHtml(s).replace(/"/g, "&quot;"); }
+
+    // ── SSE ─────────────────────────────────────────────
+    let evtSrc;
+    function connectSSE() {
+      if (evtSrc) evtSrc.close();
+      evtSrc = new EventSource(API + "/api/events");
+      evtSrc.addEventListener("inbox_created", () => loadInboxes());
+      evtSrc.addEventListener("message_received", (ev) => {
+        const data = JSON.parse(ev.data);
+        toast("New email from " + (data.from_name || data.from_address));
+        if (data.inbox_id === state.selectedInboxId) loadMessages();
+        else updateUnreadBadges();
+      });
+      evtSrc.addEventListener("message_status", () => { if (state.selectedInboxId) loadMessages(); });
+      evtSrc.onerror = () => setTimeout(connectSSE, 2000);
+    }
+
+    // ── Wiring ──────────────────────────────────────────
+    $("status-filter").addEventListener("change", (e) => {
+      state.statusFilter = e.target.value;
+      loadMessages();
+    });
+
+    $("recording-toggle").addEventListener("click", () => {
+      state.recording = !state.recording;
+      document.body.classList.toggle("recording", state.recording);
+      $("recording-toggle").setAttribute("aria-pressed", String(state.recording));
+      $("recording-toggle").textContent = state.recording ? "Exit recording view" : "Recording view";
+    });
+
+    if (DEMO_MODE) {
+      const trigger = $("trigger-btn");
+      if (trigger) trigger.addEventListener("click", async () => {
+        if (!state.selectedInboxId) return;
+        await fetchJson(API + "/api/demo/trigger", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ inbox_id: state.selectedInboxId }) });
+        toast("Injected simulated inbound");
+      });
+
+      $("new-inbox-form").addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const username = $("new-inbox-username").value.trim();
+        const domain = $("new-inbox-domain").value.trim();
+        if (!username || !domain) return;
+        try {
+          await fetchJson(API + "/api/inboxes", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ username, domain }) });
+          toast("Inbox created");
+          $("new-inbox-username").value = "";
+          await loadInboxes();
+        } catch (err) { toast("Failed: " + err.message, "error"); }
+      });
+    }
+
+    (async () => {
+      await loadInboxes();
+      connectSSE();
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/email-inbox-demo/src/db.ts
+++ b/email-inbox-demo/src/db.ts
@@ -1,0 +1,200 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { EventRow, InboxRow, MessageRow } from "./types.js";
+
+/**
+ * Local SQLite cache for the email-inbox-demo.
+ *
+ * We persist:
+ *   - inboxes: every inbox the user has created (real or demo)
+ *   - messages: every email.received event (real or demo-seeded)
+ *   - events: per-message timeline (queued → received → read → archived)
+ *
+ * The dashboard reads from this cache; the real Telnyx API is only consulted
+ * for inbox creation + initial sync.
+ */
+export class InboxDb {
+  private db: Database.Database;
+
+  constructor(path: string) {
+    mkdirSync(dirname(path), { recursive: true });
+    this.db = new Database(path);
+    this.db.pragma("journal_mode = WAL");
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS inboxes (
+        id              TEXT PRIMARY KEY,
+        email_address   TEXT NOT NULL UNIQUE,
+        display_name    TEXT,
+        domain_id       TEXT NOT NULL,
+        inbound_enabled INTEGER NOT NULL DEFAULT 1,
+        status          TEXT NOT NULL DEFAULT 'active',
+        source          TEXT NOT NULL DEFAULT 'demo',
+        created_at      INTEGER NOT NULL,
+        updated_at      INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS inboxes_by_address ON inboxes(email_address);
+
+      CREATE TABLE IF NOT EXISTS messages (
+        id               TEXT PRIMARY KEY,
+        inbox_id         TEXT NOT NULL REFERENCES inboxes(id) ON DELETE CASCADE,
+        telnyx_id        TEXT,
+        thread_id        TEXT,
+        from_address     TEXT NOT NULL,
+        from_name        TEXT,
+        to_addresses     TEXT NOT NULL,
+        cc_addresses     TEXT,
+        subject          TEXT,
+        preview          TEXT,
+        body_html        TEXT,
+        body_text        TEXT,
+        headers_json     TEXT,
+        attachments_json TEXT,
+        status           TEXT NOT NULL DEFAULT 'received',
+        received_at      INTEGER NOT NULL,
+        read_at          INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS messages_by_inbox ON messages(inbox_id, received_at DESC);
+      CREATE INDEX IF NOT EXISTS messages_by_status ON messages(status);
+
+      CREATE TABLE IF NOT EXISTS events (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        inbox_id   TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        kind       TEXT NOT NULL,
+        detail     TEXT,
+        ts         INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS events_by_message ON events(message_id, ts);
+    `);
+  }
+
+  // ── Inboxes ───────────────────────────────────────────────────────────
+
+  createInbox(input: {
+    id: string;
+    email_address: string;
+    display_name?: string | null;
+    domain_id: string;
+    source: "demo" | "telnyx";
+  }): InboxRow {
+    const now = Date.now();
+    this.db
+      .prepare(
+        `INSERT INTO inboxes (id, email_address, display_name, domain_id, inbound_enabled, status, source, created_at, updated_at)
+         VALUES (@id, @email_address, @display_name, @domain_id, 1, 'active', @source, @created_at, @updated_at);`,
+      )
+      .run({
+        id: input.id,
+        email_address: input.email_address,
+        display_name: input.display_name ?? null,
+        domain_id: input.domain_id,
+        source: input.source,
+        created_at: now,
+        updated_at: now,
+      });
+    return this.getInbox(input.id)!;
+  }
+
+  getInbox(id: string): InboxRow | null {
+    return (this.db.prepare(`SELECT * FROM inboxes WHERE id = ?;`).get(id) as
+      | InboxRow
+      | undefined) ?? null;
+  }
+
+  getInboxByAddress(email: string): InboxRow | null {
+    return (this.db
+      .prepare(`SELECT * FROM inboxes WHERE email_address = ?;`)
+      .get(email) as InboxRow | undefined) ?? null;
+  }
+
+  listInboxes(): InboxRow[] {
+    return this.db
+      .prepare(`SELECT * FROM inboxes ORDER BY created_at DESC;`)
+      .all() as InboxRow[];
+  }
+
+  deleteInbox(id: string): void {
+    this.db.prepare(`DELETE FROM inboxes WHERE id = ?;`).run(id);
+  }
+
+  // ── Messages ──────────────────────────────────────────────────────────
+
+  insertMessage(m: Omit<MessageRow, "read_at"> & { read_at?: number | null }): MessageRow {
+    this.db
+      .prepare(
+        `INSERT INTO messages (id, inbox_id, telnyx_id, thread_id, from_address, from_name, to_addresses, cc_addresses, subject, preview, body_html, body_text, headers_json, attachments_json, status, received_at, read_at)
+         VALUES (@id, @inbox_id, @telnyx_id, @thread_id, @from_address, @from_name, @to_addresses, @cc_addresses, @subject, @preview, @body_html, @body_text, @headers_json, @attachments_json, @status, @received_at, @read_at);`,
+      )
+      .run({
+        ...m,
+        read_at: m.read_at ?? null,
+      });
+    return this.getMessage(m.id)!;
+  }
+
+  getMessage(id: string): MessageRow | null {
+    return (this.db.prepare(`SELECT * FROM messages WHERE id = ?;`).get(id) as
+      | MessageRow
+      | undefined) ?? null;
+  }
+
+  listMessages(inboxId: string, opts: { status?: string; limit?: number } = {}): MessageRow[] {
+    const limit = opts.limit ?? 200;
+    if (opts.status) {
+      return this.db
+        .prepare(
+          `SELECT * FROM messages WHERE inbox_id = ? AND status = ? ORDER BY received_at DESC LIMIT ?;`,
+        )
+        .all(inboxId, opts.status, limit) as MessageRow[];
+    }
+    return this.db
+      .prepare(
+        `SELECT * FROM messages WHERE inbox_id = ? ORDER BY received_at DESC LIMIT ?;`,
+      )
+      .all(inboxId, limit) as MessageRow[];
+  }
+
+  setMessageStatus(id: string, status: MessageRow["status"]): void {
+    const now = Date.now();
+    if (status === "read") {
+      this.db
+        .prepare(`UPDATE messages SET status = ?, read_at = ? WHERE id = ?;`)
+        .run(status, now, id);
+    } else {
+      this.db.prepare(`UPDATE messages SET status = ? WHERE id = ?;`).run(status, id);
+    }
+  }
+
+  // ── Events ────────────────────────────────────────────────────────────
+
+  appendEvent(ev: Omit<EventRow, "id">): EventRow {
+    const result = this.db
+      .prepare(
+        `INSERT INTO events (inbox_id, message_id, kind, detail, ts) VALUES (?, ?, ?, ?, ?);`,
+      )
+      .run(ev.inbox_id, ev.message_id, ev.kind, ev.detail ?? null, ev.ts);
+    const row = this.db
+      .prepare(`SELECT * FROM events WHERE id = ?;`)
+      .get(result.lastInsertRowid) as EventRow | undefined;
+    return row!;
+  }
+
+  listEvents(messageId: string): EventRow[] {
+    return this.db
+      .prepare(`SELECT * FROM events WHERE message_id = ? ORDER BY ts ASC;`)
+      .all(messageId) as EventRow[];
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+export function defaultDbPath(): string {
+  return resolve(process.env.EMAIL_INBOX_DB ?? ".data/inbox.sqlite");
+}

--- a/email-inbox-demo/src/demoSeeder.ts
+++ b/email-inbox-demo/src/demoSeeder.ts
@@ -1,0 +1,172 @@
+import { randomBytes } from "node:crypto";
+import type { InboxDb } from "./db.js";
+import { payloadToMessageFields } from "./telnyxClient.js";
+import type { EmailReceivedPayload } from "./types.js";
+
+/**
+ * Fake inbound seeder for DEMO_MODE.
+ *
+ * Periodically injects a realistic-looking inbound email into the local DB so
+ * the dashboard feels alive without a verified domain, ngrok, or actual
+ * inbound mail traffic. The injected payload has the same shape as a real
+ * `email.received` Telnyx webhook so the rendering path is identical.
+ */
+export class DemoSeeder {
+  private timer: NodeJS.Timeout | null = null;
+  private senders = [
+    { email: "priya.sharma@acme-robotics.com", name: "Priya Sharma" },
+    { email: "ops-alerts@cloudstatus.io", name: "Cloud Status" },
+    { email: "lena.bauer@munichfinanz.de", name: "Lena Bauer" },
+    { email: "stripe-receipts@stripe.com", name: "Stripe" },
+    { email: "no-reply@github.com", name: "GitHub" },
+    { email: "samira.k@globextraders.ae", name: "Samira K." },
+    { email: "kevin.tan@singpost.sg", name: "Kevin Tan" },
+    { email: "ana.fonseca@saudeclinicas.br", name: "Ana Fonseca" },
+  ];
+
+  private subjectTemplates = [
+    "Re: Order #{n} — shipping confirmation",
+    "Action required: verify your account by Friday",
+    "Your weekly report is ready",
+    "New invoice INV-{n} from Acme Robotics",
+    "Two-factor authentication code: {code}",
+    "Re: Q3 contract — final version attached",
+    "Heads up: maintenance window Saturday 02:00 UTC",
+    "Welcome to Cloud Status — confirm your subscription",
+    "Customer support ticket #{n} escalated to engineering",
+    "Meeting notes from Tuesday — please review",
+  ];
+
+  private bodySnippets = [
+    "Hi team,\n\nQuick update on the attached — let me know if anything looks off and I'll jump on a call this afternoon.\n\nThanks,\n{name}",
+    "We've detected an unusual sign-in from a new device. If this was you, no action is required. If not, please reset your password immediately and reply to this email so we can lock the account.\n\n— The Security Team",
+    "Your invoice for this month is attached. The total of ${amount} will be charged to your card on file in 3 business days. Reply to this thread if you have any questions about the line items.\n\nBest,\nBilling",
+    "Here's a summary of the meeting. Three action items:\n  1. {item}\n  2. {item}\n  3. {item}\n\nPlease reply with anything we missed.\n\nThanks,\n{name}",
+  ];
+
+  constructor(
+    private db: InboxDb,
+    private intervalMs: number,
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    // Fire one immediately so the dashboard isn't empty on first load.
+    queueMicrotask(() => this.tick());
+    this.timer = setInterval(() => this.tick(), this.intervalMs);
+    // Don't keep the event loop alive just for the seeder.
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private tick(): void {
+    const inboxes = this.db.listInboxes().filter((ib) => ib.source === "demo");
+    if (inboxes.length === 0) return;
+    const inbox = inboxes[Math.floor(Math.random() * inboxes.length)];
+    const message = this.synthesize(inbox.id, inbox.email_address);
+    this.db.insertMessage({ ...message, status: "received", read_at: null });
+    this.db.appendEvent({
+      inbox_id: inbox.id,
+      message_id: message.id,
+      kind: "email.received",
+      detail: "Simulated inbound via DEMO_MODE seeder",
+      ts: Date.now(),
+    });
+  }
+
+  /** Public — exposed via the API for the demo "Trigger inbound" button. */
+  triggerNow(inboxId: string): string | null {
+    const inbox = this.db.getInbox(inboxId);
+    if (!inbox) return null;
+    const message = this.synthesize(inboxId, inbox.email_address);
+    this.db.insertMessage({ ...message, status: "received", read_at: null });
+    this.db.appendEvent({
+      inbox_id: inboxId,
+      message_id: message.id,
+      kind: "email.received",
+      detail: "Manually triggered via UI",
+      ts: Date.now(),
+    });
+    return message.id;
+  }
+
+  private synthesize(inboxId: string, toAddress: string) {
+    const sender = this.senders[Math.floor(Math.random() * this.senders.length)];
+    const subjectTpl = this.subjectTemplates[Math.floor(Math.random() * this.subjectTemplates.length)];
+    const bodyTpl = this.bodySnippets[Math.floor(Math.random() * this.bodySnippets.length)];
+    const name = sender.name.split(" ")[0];
+    const n = Math.floor(Math.random() * 9000) + 1000;
+    const code = String(Math.floor(Math.random() * 900000) + 100000);
+    const amount = (Math.random() * 800 + 50).toFixed(2);
+    const items = [
+      "draft the proposal and circulate by Wednesday",
+      "schedule a follow-up call with the customer",
+      "file the support ticket with engineering",
+    ];
+    const fill = (s: string) =>
+      s
+        .replaceAll("{n}", String(n))
+        .replaceAll("{code}", code)
+        .replaceAll("{amount}", amount)
+        .replaceAll("{name}", name)
+        .replaceAll("{item}", items[Math.floor(Math.random() * items.length)]);
+
+    const subject = fill(subjectTpl);
+    const bodyText = fill(bodyTpl);
+    const bodyHtml =
+      `<div style="font-family:-apple-system,Segoe UI,sans-serif;font-size:14px;line-height:1.55;color:#1f2328;">` +
+      bodyText
+        .split(/\n\n+/)
+        .map((para) => `<p style="margin:0 0 12px 0;">${escapeHtml(para).replace(/\n/g, "<br>")}</p>`)
+        .join("") +
+      `</div>`;
+
+    const payload: EmailReceivedPayload = {
+      data: {
+        event_type: "email.received",
+        id: `demo_${Date.now()}_${randomBytes(3).toString("hex")}`,
+        occurred_at: new Date().toISOString(),
+        payload: {
+          message_id: `demo_msg_${Date.now()}_${randomBytes(4).toString("hex")}`,
+          inbox_id: inboxId,
+          from: { email: sender.email, name: sender.name },
+          to: [{ email: toAddress, name: null }],
+          subject,
+          text: bodyText,
+          html: bodyHtml,
+          headers: {
+            "message-id": `<${randomBytes(8).toString("hex")}@${sender.email.split("@")[1]}>`,
+            "from": `${sender.name} <${sender.email}>`,
+            "to": toAddress,
+            "subject": subject,
+            "date": new Date().toUTCString(),
+            "mime-version": "1.0",
+            "content-type": "text/html; charset=UTF-8",
+          },
+          attachments: [],
+        },
+      },
+    };
+    const fields = payloadToMessageFields(payload, inboxId);
+    return {
+      id: `msg_demo_${Date.now()}_${randomBytes(4).toString("hex")}`,
+      ...fields,
+      received_at: Date.now(),
+    } as const;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/email-inbox-demo/src/server.ts
+++ b/email-inbox-demo/src/server.ts
@@ -1,0 +1,293 @@
+import express from "express";
+import { randomBytes } from "node:crypto";
+import { InboxDb, defaultDbPath } from "./db.js";
+import { dashboard } from "./dashboard.js";
+import { DemoSeeder } from "./demoSeeder.js";
+import { TelnyxEmailClient, payloadToMessageFields } from "./telnyxClient.js";
+import { verifyTelnyxSignature } from "./webhookVerify.js";
+import type { EmailReceivedPayload } from "./types.js";
+
+/**
+ * Email Inbox Demo — Express server.
+ *
+ * Routes:
+ *   GET  /                              -> dashboard HTML
+ *   GET  /api/inboxes                   -> list inboxes
+ *   POST /api/inboxes                   -> create inbox (demo or telnyx)
+ *   DELETE /api/inboxes/:id             -> delete inbox
+ *   GET  /api/inboxes/:id/messages      -> list messages (filter by status)
+ *   GET  /api/messages/:id              -> single message (body + headers)
+ *   POST /api/messages/:id/read         -> mark as read
+ *   POST /api/messages/:id/archive      -> archive
+ *   POST /api/messages/:id/delete       -> delete (soft)
+ *   GET  /api/events                    -> SSE: inbound + status changes
+ *   POST /webhooks/email                -> email.received (Ed25519-verified)
+ *   POST /api/demo/trigger              -> inject one simulated inbound (DEMO_MODE only)
+ *   GET  /health                        -> liveness
+ */
+export async function main(): Promise<void> {
+  const demoMode = (process.env.DEMO_MODE ?? "true") !== "false";
+  const port = Number(process.env.PORT ?? 8788);
+  const host = process.env.HOST ?? "127.0.0.1";
+  const apiKey = process.env.TELNYX_API_KEY;
+  const publicKey = process.env.TELNYX_PUBLIC_KEY;
+  const publicBaseUrl = process.env.TELNYX_PUBLIC_BASE_URL;
+
+  const db = new InboxDb(defaultDbPath());
+  const seeder = new DemoSeeder(db, Number(process.env.DEMO_SEED_INTERVAL_MS ?? 15000));
+  const telnyx = apiKey ? new TelnyxEmailClient(apiKey) : null;
+
+  // Seed a demo inbox on first run so the UI isn't empty.
+  if (demoMode && db.listInboxes().length === 0) {
+    db.createInbox({
+      id: "inbox_demo_support",
+      email_address: "support@telnyx-demo.msgtelnyx.com",
+      display_name: "Support",
+      domain_id: "shared_inbound",
+      source: "demo",
+    });
+  }
+  if (demoMode) seeder.start();
+
+  const app = express();
+
+  // SSE bus
+  type SseClient = { id: string; res: express.Response };
+  const sseClients = new Set<SseClient>();
+  function broadcast(event: string, data: unknown): void {
+    const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const client of sseClients) {
+      try {
+        client.res.write(payload);
+      } catch {
+        sseClients.delete(client);
+      }
+    }
+  }
+
+  // ── Dashboard ─────────────────────────────────────────────────────
+  app.get("/", (_req, res) => {
+    const hasCreds = Boolean(apiKey);
+    res
+      .type("text/html; charset=utf-8")
+      .send(
+        dashboard({
+          demoMode,
+          hasTelnyxCreds: hasCreds,
+          apiBase: publicBaseUrl || `http://${host}:${port}`,
+        }),
+      );
+  });
+
+  // ── Inboxes ──────────────────────────────────────────────────────
+  app.get("/api/inboxes", (_req, res) => {
+    res.json(db.listInboxes());
+  });
+
+  app.post(
+    "/api/inboxes",
+    express.json({ limit: "256kb" }),
+    async (req, res) => {
+      const { username, domain, displayName } = req.body ?? {};
+      if (!username || !domain) {
+        return res.status(400).json({ error: "username and domain are required" });
+      }
+      if (telnyx && !demoMode) {
+        try {
+          const created = await telnyx.createInbox({ domain, username, displayName });
+          const row = db.createInbox({
+            id: `inbox_${created.id}`,
+            email_address: created.email_address,
+            display_name: displayName ?? null,
+            domain_id: created.domain_id,
+            source: "telnyx",
+          });
+          broadcast("inbox_created", { inbox: row });
+          return res.json(row);
+        } catch (err) {
+          return res.status(502).json({ error: String((err as Error).message ?? err) });
+        }
+      }
+      const id = `inbox_demo_${randomBytes(4).toString("hex")}`;
+      const email = `${username}@${domain}.msgtelnyx.com`;
+      const row = db.createInbox({
+        id,
+        email_address: email,
+        display_name: displayName ?? null,
+        domain_id: domain,
+        source: "demo",
+      });
+      broadcast("inbox_created", { inbox: row });
+      res.json(row);
+    },
+  );
+
+  app.delete("/api/inboxes/:id", (req, res) => {
+    db.deleteInbox(req.params.id);
+    res.status(204).end();
+  });
+
+  // ── Messages ──────────────────────────────────────────────────────
+  app.get("/api/inboxes/:id/messages", (req, res) => {
+    const status = req.query.status && req.query.status !== "all" ? String(req.query.status) : undefined;
+    res.json(db.listMessages(req.params.id, { status }));
+  });
+
+  app.get("/api/messages/:id", (req, res) => {
+    const msg = db.getMessage(req.params.id);
+    if (!msg) return res.status(404).json({ error: "not found" });
+    res.json(msg);
+  });
+
+  app.post("/api/messages/:id/read", (req, res) => {
+    db.setMessageStatus(req.params.id, "read");
+    broadcast("message_status", { id: req.params.id, status: "read" });
+    res.json({ ok: true });
+  });
+
+  app.post("/api/messages/:id/archive", (req, res) => {
+    db.setMessageStatus(req.params.id, "archived");
+    broadcast("message_status", { id: req.params.id, status: "archived" });
+    res.json({ ok: true });
+  });
+
+  app.post("/api/messages/:id/delete", (req, res) => {
+    db.setMessageStatus(req.params.id, "deleted");
+    broadcast("message_status", { id: req.params.id, status: "deleted" });
+    res.json({ ok: true });
+  });
+
+  // ── SSE ───────────────────────────────────────────────────────────
+  app.get("/api/events", (_req, res) => {
+    res.set({
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    res.flushHeaders?.();
+    const client: SseClient = { id: randomBytes(8).toString("hex"), res };
+    sseClients.add(client);
+    res.write(`event: hello\ndata: ${JSON.stringify({ id: client.id, demoMode })}\n\n`);
+    const heartbeat = setInterval(() => {
+      try {
+        res.write(`: ping\n\n`);
+      } catch {
+        clearInterval(heartbeat);
+        sseClients.delete(client);
+      }
+    }, 15000);
+    heartbeat.unref?.();
+    _req.on("close", () => {
+      clearInterval(heartbeat);
+      sseClients.delete(client);
+    });
+  });
+
+  // ── Telnyx webhook receiver (raw body for Ed25519 verify) ─────────
+  app.post(
+    "/webhooks/email",
+    express.raw({ type: "*/*", limit: "2mb" }),
+    (req, res) => {
+      const sig = req.header("telnyx-signature-ed25519");
+      const ts = req.header("telnyx-timestamp");
+      const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from("");
+      const verification = verifyTelnyxSignature({
+        rawBody,
+        signature: sig,
+        timestamp: ts,
+        publicKeyPem: publicKey,
+      });
+      if (!verification.ok && !demoMode) {
+        return res.status(401).json({ error: "invalid signature", reason: verification.reason });
+      }
+      let payload: EmailReceivedPayload;
+      try {
+        payload = JSON.parse(rawBody.toString("utf8") || "{}");
+      } catch {
+        return res.status(400).json({ error: "invalid json" });
+      }
+      const p = payload.data?.payload ?? {};
+      const inboxId = p.inbox_id;
+      if (!inboxId) return res.status(400).json({ error: "missing inbox_id in payload" });
+      const inbox = db.getInbox(inboxId);
+      if (!inbox) return res.status(404).json({ error: "unknown inbox" });
+
+      const fields = payloadToMessageFields(payload, inboxId);
+      const id = `msg_${randomBytes(6).toString("hex")}`;
+      const message = db.insertMessage({
+        id,
+        ...fields,
+        status: "received",
+        read_at: null,
+        received_at: Date.now(),
+      });
+      db.appendEvent({
+        inbox_id: inboxId,
+        message_id: id,
+        kind: "email.received",
+        detail: "Verified Telnyx webhook",
+        ts: Date.now(),
+      });
+      broadcast("message_received", {
+        id,
+        inbox_id: inboxId,
+        from_address: message.from_address,
+        from_name: message.from_name,
+        subject: message.subject,
+      });
+      res.status(202).json({ ok: true, id });
+    },
+  );
+
+  // ── Demo trigger ──────────────────────────────────────────────────
+  app.post(
+    "/api/demo/trigger",
+    express.json({ limit: "256kb" }),
+    (req, res) => {
+      if (!demoMode) return res.status(403).json({ error: "demo mode disabled" });
+      const inboxId = req.body?.inbox_id;
+      if (!inboxId) return res.status(400).json({ error: "inbox_id required" });
+      const id = seeder.triggerNow(inboxId);
+      if (!id) return res.status(404).json({ error: "inbox not found" });
+      const message = db.getMessage(id)!;
+      broadcast("message_received", {
+        id,
+        inbox_id: inboxId,
+        from_address: message.from_address,
+        from_name: message.from_name,
+        subject: message.subject,
+      });
+      res.json({ ok: true, id });
+    },
+  );
+
+  // ── Health ────────────────────────────────────────────────────────
+  app.get("/health", (_req, res) => {
+    res.json({
+      ok: true,
+      demoMode,
+      hasTelnyxCreds: Boolean(apiKey),
+      inboxes: db.listInboxes().length,
+    });
+  });
+
+  // Start
+  const server = app.listen(port, host, () => {
+    const mode = demoMode ? "DEMO" : "LIVE";
+    console.log(`Email Inbox: http://${host}:${port} (${mode} mode)`);
+    if (!demoMode && publicBaseUrl) {
+      console.log(`Webhook URL: ${publicBaseUrl}/webhooks/email`);
+    }
+  });
+  server.on("error", (err) => {
+    console.error("Server error:", err);
+    process.exit(1);
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/email-inbox-demo/src/telnyxClient.ts
+++ b/email-inbox-demo/src/telnyxClient.ts
@@ -1,0 +1,112 @@
+import Telnyx from "telnyx";
+import type { EmailReceivedPayload } from "./types.js";
+
+/**
+ * Thin wrapper around the Telnyx Email API.
+ *
+ * Used by the live-mode fetch handler. In DEMO_MODE this module is never
+ * reached — the demo seeder writes directly to the local SQLite cache so the
+ * UI feels alive without an account, ngrok, or a verified domain.
+ */
+export type CreateInboxArgs = {
+  /** Telnyx-managed subdomain (e.g. "shared_inbound") or a custom domain_id. */
+  domain: string;
+  /** Required for shared_inbound; optional for verified custom domains. */
+  username?: string;
+  /** Friendly name shown in the inbox UI. */
+  displayName?: string;
+};
+
+export type CreatedInbox = {
+  id: string;
+  email_address: string;
+  domain_id: string;
+  status: string;
+};
+
+export class TelnyxEmailClient {
+  private telnyx: Telnyx;
+
+  constructor(apiKey: string) {
+    this.telnyx = new Telnyx({ apiKey, maxRetries: 0, timeout: 10000 });
+  }
+
+  async createInbox(args: CreateInboxArgs): Promise<CreatedInbox> {
+    const body: Record<string, unknown> = {
+      domain: args.domain,
+      inbound_enabled: true,
+    };
+    if (args.username) body.username = args.username;
+    if (args.displayName) body.name = args.displayName;
+
+    const res = (await this.telnyx.emailInboxes.create({ ...body })) as any;
+    return {
+      id: res.id,
+      email_address: res.email_address,
+      domain_id: res.domain_id,
+      status: res.status ?? "active",
+    };
+  }
+
+  async listInboxes(): Promise<Array<{ id: string; email_address: string; domain_id: string }>> {
+    const list = (await this.telnyx.emailInboxes.list()) as any;
+    return (list.data ?? []).map((ib: any) => ({
+      id: ib.id,
+      email_address: ib.email_address,
+      domain_id: ib.domain_id,
+    }));
+  }
+
+  /** Configure a domain's webhook so email.received events hit our endpoint. */
+  async registerWebhook(args: {
+    domainId: string;
+    url: string;
+    events?: string[];
+  }): Promise<{ id: string }> {
+    const events = args.events ?? [
+      "email.received",
+      "email.delivered",
+      "email.opened",
+      "email.clicked",
+      "email.bounced",
+      "email.failed",
+    ];
+    const res = (await (this.telnyx.emailDomains as any).webhooks.create(args.domainId, {
+      url: args.url,
+      events,
+    })) as any;
+    return { id: res.id };
+  }
+}
+
+/**
+ * Convert a Telnyx email.received payload into the row fields we store.
+ * Pure function — no I/O — so the same code path serves live webhooks and
+ * the demo seeder.
+ */
+export function payloadToMessageFields(payload: EmailReceivedPayload, inboxId: string) {
+  const d = payload.data ?? {};
+  const p = d.payload ?? {};
+  const from = p.from ?? {};
+  const toList = (p.to ?? []).map((t) => t.email).filter(Boolean) as string[];
+  const ccList = (p.cc ?? []).map((t) => t.email).filter(Boolean) as string[];
+  const subject = p.subject ?? "(no subject)";
+  const text = p.text ?? "";
+  const html = p.html ?? "";
+  const preview = text.slice(0, 160).replace(/\s+/g, " ").trim();
+  return {
+    inbox_id: inboxId,
+    telnyx_id: (p.message_id ?? d.id ?? null) as string | null,
+    thread_id: (p.thread_id ?? null) as string | null,
+    from_address: (from.email ?? "unknown@example.com") as string,
+    from_name: (from.name ?? null) as string | null,
+    to_addresses: toList.join(", "),
+    cc_addresses: ccList.length ? ccList.join(", ") : null,
+    subject,
+    preview: preview || null,
+    body_html: html || null,
+    body_text: text || null,
+    headers_json: p.headers ? JSON.stringify(p.headers) : null,
+    attachments_json: p.attachments ? JSON.stringify(p.attachments) : null,
+  };
+}

--- a/email-inbox-demo/src/types.ts
+++ b/email-inbox-demo/src/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared types for the email-inbox-demo.
+ *
+ * Every persisted entity has a row type. Every Telnyx payload maps to one of
+ * the InboundEmail or InboxEvent shapes below. Webhook payloads from Telnyx
+ * are deliberately loose (the API adds fields over time), so the JSON
+ * envelopes here are `Record<string, unknown>` plus the fields we read.
+ */
+
+export type InboxRow = {
+  id: string;
+  email_address: string;
+  display_name: string | null;
+  domain_id: string;
+  inbound_enabled: 0 | 1;
+  status: string;
+  created_at: number;
+  updated_at: number;
+  /** "demo" for simulated inboxes, "telnyx" for real ones. */
+  source: "demo" | "telnyx";
+};
+
+export type MessageRow = {
+  id: string;
+  inbox_id: string;
+  /** Telnyx message id, or a demo-prefixed synthetic id. */
+  telnyx_id: string | null;
+  thread_id: string | null;
+  from_address: string;
+  from_name: string | null;
+  to_addresses: string;
+  cc_addresses: string | null;
+  subject: string | null;
+  preview: string | null;
+  body_html: string | null;
+  body_text: string | null;
+  headers_json: string | null;
+  attachments_json: string | null;
+  status: "received" | "read" | "archived" | "deleted";
+  received_at: number;
+  read_at: number | null;
+};
+
+export type EventRow = {
+  id: number;
+  inbox_id: string;
+  message_id: string;
+  kind: string;
+  detail: string | null;
+  ts: number;
+};
+
+/** Telnyx `email.received` webhook payload (the fields we read). */
+export type EmailReceivedPayload = {
+  data?: {
+    event_type?: string;
+    id?: string;
+    occurred_at?: string;
+    payload?: {
+      message_id?: string;
+      inbox_id?: string;
+      from?: { email?: string; name?: string | null };
+      to?: Array<{ email?: string; name?: string | null }>;
+      cc?: Array<{ email?: string; name?: string | null }>;
+      subject?: string;
+      text?: string;
+      html?: string;
+      headers?: Record<string, string>;
+      attachments?: Array<{
+        id?: string;
+        filename?: string;
+        content_type?: string;
+        size?: number;
+      }>;
+      thread_id?: string;
+    };
+  };
+  meta?: Record<string, unknown>;
+};

--- a/email-inbox-demo/src/webhookVerify.ts
+++ b/email-inbox-demo/src/webhookVerify.ts
@@ -1,0 +1,102 @@
+import nacl from "tweetnacl";
+import { createHash } from "node:crypto";
+
+/**
+ * Ed25519 signature verification for Telnyx webhooks.
+ *
+ * Telnyx sends:
+ *   telnyx-signature-ed25519: <hex signature>
+ *   telnyx-timestamp: <unix seconds>
+ *
+ * The signed payload is `<timestamp>.<rawBody>` (the exact bytes Telnyx
+ * received — no JSON re-serialization). We hash the concatenation and
+ * verify against the configured public key.
+ *
+ * The public key is provided via the `TELNYX_PUBLIC_KEY` env var. The Telnyx
+ * CLI exposes it via:
+ *   curl -s -H "Authorization: Bearer $TELNYX_API_KEY" https://api.telnyx.com/v2/public_key | jq -r '.data.public'
+ */
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: "missing_header" | "stale_timestamp" | "bad_signature" | "no_public_key" };
+
+export function verifyTelnyxSignature(args: {
+  rawBody: Buffer;
+  signature: string | null | undefined;
+  timestamp: string | null | undefined;
+  publicKeyPem: string | null | undefined;
+  toleranceSeconds?: number;
+}): VerifyResult {
+  const { rawBody, signature, timestamp, publicKeyPem } = args;
+  const tolerance = args.toleranceSeconds ?? 300;
+
+  if (!signature || !timestamp) return { ok: false, reason: "missing_header" };
+  if (!publicKeyPem) return { ok: false, reason: "no_public_key" };
+
+  const tsNum = Number(timestamp);
+  if (!Number.isFinite(tsNum)) return { ok: false, reason: "stale_timestamp" };
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSec - tsNum) > tolerance) {
+    return { ok: false, reason: "stale_timestamp" };
+  }
+
+  const sigBytes = safeHexToBytes(signature);
+  if (!sigBytes) return { ok: false, reason: "bad_signature" };
+
+  const pubBytes = pemToRawEd25519(publicKeyPem);
+  if (!pubBytes) return { ok: false, reason: "bad_signature" };
+
+  const message = Buffer.concat([Buffer.from(`${timestamp}.`), rawBody]);
+  const ok = nacl.sign.detached.verify(message, sigBytes, pubBytes);
+  return ok ? { ok: true } : { ok: false, reason: "bad_signature" };
+}
+
+function safeHexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0) return null;
+  try {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Accept either a raw 32-byte Ed25519 public key (hex or base64) or a
+ * PEM-encoded PUBLIC KEY block. The Telnyx CLI returns the raw key as a
+ * single base64 string, so we handle that as the common case.
+ */
+function pemToRawEd25519(pem: string): Uint8Array | null {
+  const trimmed = pem.trim();
+  // PEM: take the base64 between BEGIN and END markers
+  if (trimmed.includes("BEGIN")) {
+    const lines = trimmed.split(/\r?\n/).filter(
+      (l) => !l.startsWith("-----") && l.trim().length > 0,
+    );
+    const b64 = lines.join("");
+    return base64ToBytes(b64);
+  }
+  // Raw key — try base64 first, fall back to hex
+  const asBase64 = base64ToBytes(trimmed);
+  if (asBase64 && asBase64.length === 32) return asBase64;
+  const asHex = safeHexToBytes(trimmed);
+  if (asHex && asHex.length === 32) return asHex;
+  return null;
+}
+
+function base64ToBytes(b64: string): Uint8Array | null {
+  try {
+    const buf = Buffer.from(b64, "base64");
+    return new Uint8Array(buf);
+  } catch {
+    return null;
+  }
+}
+
+/** Stable id for a Telnyx message (sha256 of `inbox_id|message_id`). */
+export function messageFingerprint(inboxId: string, telnyxId: string): string {
+  return createHash("sha256").update(`${inboxId}|${telnyxId}`).digest("hex").slice(0, 24);
+}

--- a/email-inbox-demo/tests/smoke.test.ts
+++ b/email-inbox-demo/tests/smoke.test.ts
@@ -1,0 +1,163 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import nacl from "tweetnacl";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InboxDb } from "../src/db.js";
+import { DemoSeeder } from "../src/demoSeeder.js";
+import { payloadToMessageFields } from "../src/telnyxClient.js";
+import { verifyTelnyxSignature } from "../src/webhookVerify.js";
+
+function tmpDb(): InboxDb {
+  const dir = mkdtempSync(join(tmpdir(), "inbox-test-"));
+  const path = join(dir, "test.sqlite");
+  const db = new InboxDb(path);
+  return db;
+}
+
+test("db creates inbox and message, updates status", () => {
+  const db = tmpDb();
+  const inbox = db.createInbox({
+    id: "inbox_test",
+    email_address: "test@example.com",
+    domain_id: "shared_inbound",
+    source: "demo",
+  });
+  assert.equal(inbox.email_address, "test@example.com");
+  assert.equal(inbox.source, "demo");
+
+  const msg = db.insertMessage({
+    id: "msg_1",
+    inbox_id: inbox.id,
+    telnyx_id: null,
+    thread_id: null,
+    from_address: "sender@example.com",
+    from_name: "Sender",
+    to_addresses: "test@example.com",
+    cc_addresses: null,
+    subject: "Hello",
+    preview: "Hi there",
+    body_html: "<p>Hi there</p>",
+    body_text: "Hi there",
+    headers_json: null,
+    attachments_json: null,
+    status: "received",
+    received_at: Date.now(),
+  });
+  assert.equal(msg.status, "received");
+  db.setMessageStatus("msg_1", "read");
+  const after = db.getMessage("msg_1");
+  assert.equal(after?.status, "read");
+  assert.ok(after?.read_at, "read_at should be set");
+  db.close();
+});
+
+test("demo seeder synthesizes a realistic inbound message", async () => {
+  const db = tmpDb();
+  db.createInbox({
+    id: "inbox_demo",
+    email_address: "demo@example.com",
+    domain_id: "shared_inbound",
+    source: "demo",
+  });
+  const seeder = new DemoSeeder(db, 60_000); // don't fire on interval
+  const id = seeder.triggerNow("inbox_demo");
+  assert.ok(id, "seeder should return a message id");
+  const msg = db.getMessage(id!);
+  assert.ok(msg);
+  assert.ok(msg!.from_address.includes("@"));
+  assert.ok(msg!.subject && msg!.subject.length > 0);
+  assert.ok(msg!.body_text && msg!.body_text.length > 0);
+  assert.equal(msg!.status, "received");
+  // Body HTML should be present and include the subject
+  assert.ok(msg!.body_html && msg!.body_html.includes("<p"));
+  db.close();
+});
+
+test("payloadToMessageFields maps Telnyx webhook to row fields", () => {
+  const payload = {
+    data: {
+      event_type: "email.received",
+      payload: {
+        message_id: "abc-123",
+        inbox_id: "inbox_test",
+        from: { email: "alice@example.com", name: "Alice" },
+        to: [{ email: "bob@example.com" }],
+        subject: "Test",
+        text: "Hello bob",
+        html: "<p>Hello bob</p>",
+        thread_id: "t-1",
+      },
+    },
+  };
+  const fields = payloadToMessageFields(payload as any, "inbox_test");
+  assert.equal(fields.from_address, "alice@example.com");
+  assert.equal(fields.from_name, "Alice");
+  assert.equal(fields.subject, "Test");
+  assert.equal(fields.body_text, "Hello bob");
+  assert.equal(fields.thread_id, "t-1");
+  assert.equal(fields.telnyx_id, "abc-123");
+});
+
+test("Ed25519 signature verification accepts valid signature, rejects tampered body", () => {
+  const { publicKey, secretKey } = nacl.sign.keyPair();
+  const ts = String(Math.floor(Date.now() / 1000));
+  const body = Buffer.from(JSON.stringify({ data: { event_type: "email.received" } }));
+  const message = Buffer.concat([Buffer.from(`${ts}.`), body]);
+  const sig = nacl.sign.detached(message, secretKey);
+  const hex = Buffer.from(sig).toString("hex");
+  const pem = Buffer.from(publicKey).toString("base64");
+
+  const ok = verifyTelnyxSignature({
+    rawBody: body,
+    signature: hex,
+    timestamp: ts,
+    publicKeyPem: pem,
+  });
+  assert.deepEqual(ok, { ok: true });
+
+  // Tamper the body — signature should fail
+  const tampered = verifyTelnyxSignature({
+    rawBody: Buffer.from("tampered"),
+    signature: hex,
+    timestamp: ts,
+    publicKeyPem: pem,
+  });
+  assert.equal(tampered.ok, false);
+
+  // Stale timestamp — reject
+  const stale = String(Math.floor(Date.now() / 1000) - 600);
+  const staleMsg = Buffer.concat([Buffer.from(`${stale}.`), body]);
+  const staleSig = Buffer.from(nacl.sign.detached(staleMsg, secretKey)).toString("hex");
+  const staleResult = verifyTelnyxSignature({
+    rawBody: body,
+    signature: staleSig,
+    timestamp: stale,
+    publicKeyPem: pem,
+    toleranceSeconds: 60,
+  });
+  assert.equal(staleResult.ok, false);
+});
+
+test("Ed25519 verification with PEM-encoded public key", () => {
+  const { publicKey, secretKey } = nacl.sign.keyPair();
+  const ts = String(Math.floor(Date.now() / 1000));
+  const body = Buffer.from('{"hello":"world"}');
+  const message = Buffer.concat([Buffer.from(`${ts}.`), body]);
+  const sig = Buffer.from(nacl.sign.detached(message, secretKey)).toString("hex");
+
+  // Build a fake PEM block
+  const b64 = Buffer.from(publicKey).toString("base64");
+  const lines = b64.match(/.{1,64}/g) ?? [];
+  const pem = `-----BEGIN PUBLIC KEY-----\n${lines.join("\n")}\n-----END PUBLIC KEY-----\n`;
+
+  const ok = verifyTelnyxSignature({
+    rawBody: body,
+    signature: sig,
+    timestamp: ts,
+    publicKeyPem: pem,
+  });
+  assert.deepEqual(ok, { ok: true });
+});

--- a/email-inbox-demo/tsconfig.json
+++ b/email-inbox-demo/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Standalone inbound-email sample for the Telnyx Email API. Create inboxes on verified domains with `inbound_enabled`, receive `email.received` webhooks (Ed25519-signed), list and read messages in a 3-pane HTML dashboard, live updates over Server-Sent Events.

Targets the YouTube recording for TRUST-286. Sub-feature of the broader Email API GA (release notes) and a focused, standalone companion to `omni-channel-lab-inbox-agent`.

## What's in the demo

- **DEMO_MODE** runs end-to-end without Telnyx credentials — a background seeder injects realistic inbound (Stripe receipts, GitHub notifications, 2FA codes, meeting notes) on a 15s timer so the dashboard feels alive.
- **Live mode** by setting `DEMO_MODE=false` + `TELNYX_API_KEY` + `TELNYX_PUBLIC_KEY` + `TELNYX_PUBLIC_BASE_URL`. The dashboard then talks to the real Telnyx Email API.
- **3-pane UI** — folders / message list / reader — with live SSE updates, recording-view toggle (larger type, hidden debug controls), per-inbox unread badges, plain-text toggle under the HTML reader iframe.
- **Ed25519 webhook verification** using `tweetnacl`, accepting raw base64, hex, or PEM public keys.

## Stack

- TypeScript, Node 22.13+
- Express 4, better-sqlite3
- `telnyx` Node SDK v7.20+
- Vanilla HTML dashboard (no React/Vue/build step) — self-contained pattern matching `omni-channel-lab-inbox-agent/src/adminHtml.ts`

## Linear

[TRUST-286 — Email Inbox Demo](https://linear.app/telnyx/issue/TRUST-286/email-inbox-demo)

## Tests

5 smoke tests pass (`npm test`):
- DB CRUD: inbox + message lifecycle, status transitions
- Demo seeder: synthesizes a realistic inbound
- Payload mapper: `payloadToMessageFields` correctly maps Telnyx webhook
- Ed25519 verify: accepts valid signature, rejects tampered body and stale timestamp
- Ed25519 verify: PEM-encoded public key works

## Checklist

- [x] `npm install` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` — 5/5 pass
- [x] Dashboard renders at `/` (verified at 22KB HTML, content-type `text/html; charset=utf-8`)
- [x] Webhook receiver stores messages from a real `email.received` payload shape
- [x] DEMO seeder injects realistic inbound on a timer
- [x] Ed25519 signature verification accepts valid signatures
- [x] README.md, PRD.md, DEMO.md, API.md, GUIDE.md all included
- [ ] **DO NOT MERGE** — needs reviewer sign-off before this lands on `main`

## File map

```
email-inbox-demo/
├── package.json
├── tsconfig.json
├── .env.example
├── README.md          # user-facing entry point
├── PRD.md             # product spec
├── DEMO.md            # YouTube narration script (~3m 5s)
├── API.md             # endpoint reference
├── GUIDE.md           # implementation walkthrough
├── src/
│   ├── server.ts      # Express + SSE bus + webhook receiver
│   ├── db.ts          # better-sqlite3 cache
│   ├── dashboard.ts   # 3-pane HTML export
│   ├── telnyxClient.ts
│   ├── webhookVerify.ts
│   ├── demoSeeder.ts
│   └── types.ts
└── tests/smoke.test.ts
```